### PR TITLE
Fix Visual Studio 2019 compilation errors

### DIFF
--- a/tests/add.cpp
+++ b/tests/add.cpp
@@ -23,15 +23,15 @@ namespace {
     using scalar_t = double;
     using vector_t = basic_mdspan<scalar_t, extents<dynamic_extent>>;
 
-    constexpr size_t vectorSize(5);
-    constexpr size_t storageSize = size_t(3) * vectorSize;
+    constexpr ptrdiff_t vectorSize(5);
+    constexpr ptrdiff_t storageSize = ptrdiff_t(3) * vectorSize;
     std::vector<scalar_t> storage(storageSize);
 
     vector_t x(storage.data(), vectorSize);
     vector_t y(storage.data() + vectorSize, vectorSize);
     vector_t z(storage.data() + 2*vectorSize, vectorSize);
 
-    for (size_t k = 0; k < vectorSize; ++k) {
+    for (ptrdiff_t k = 0; k < vectorSize; ++k) {
       const scalar_t x_k = scalar_t (k) + 1.0;
       const scalar_t y_k = scalar_t (k) + 2.0;
       x(k) = x_k;
@@ -40,7 +40,7 @@ namespace {
     }
 
     linalg_add(x, y, z);
-    for (size_t k = 0; k < vectorSize; ++k) {
+    for (ptrdiff_t k = 0; k < vectorSize; ++k) {
       const scalar_t x_k = scalar_t (k) + 1.0;
       const scalar_t y_k = scalar_t (k) + 2.0;
       // Make sure the function didn't modify the input.
@@ -56,15 +56,15 @@ namespace {
     using scalar_t = std::complex<real_t>;
     using vector_t = basic_mdspan<scalar_t, extents<dynamic_extent>>;
 
-    constexpr size_t vectorSize(5);
-    constexpr size_t storageSize = size_t(3) * vectorSize;
+    constexpr ptrdiff_t vectorSize(5);
+    constexpr ptrdiff_t storageSize = ptrdiff_t(3) * vectorSize;
     std::vector<scalar_t> storage(storageSize);
 
     vector_t x(storage.data(), vectorSize);
     vector_t y(storage.data() + vectorSize, vectorSize);
     vector_t z(storage.data() + 2*vectorSize, vectorSize);
 
-    for (size_t k = 0; k < vectorSize; ++k) {
+    for (ptrdiff_t k = 0; k < vectorSize; ++k) {
       const scalar_t x_k(real_t(k) + 4.0, -real_t(k) - 1.0);
       const scalar_t y_k(real_t(k) + 5.0, -real_t(k) - 2.0);
       x(k) = x_k;
@@ -73,7 +73,7 @@ namespace {
     }
 
     linalg_add(x, y, z);
-    for (size_t k = 0; k < vectorSize; ++k) {
+    for (ptrdiff_t k = 0; k < vectorSize; ++k) {
       const scalar_t x_k(real_t(k) + 4.0, -real_t(k) - 1.0);
       const scalar_t y_k(real_t(k) + 5.0, -real_t(k) - 2.0);
       // Make sure the function didn't modify the input.

--- a/tests/conjugate_transpose_view.cpp
+++ b/tests/conjugate_transpose_view.cpp
@@ -21,7 +21,7 @@ namespace {
     using matrix_static_t =
       basic_mdspan<scalar_t, extents<dim, dim>>;
 
-    constexpr size_t storageSize = size_t(dim*dim);
+    constexpr ptrdiff_t storageSize = ptrdiff_t(dim*dim);
     std::vector<scalar_t> A_storage (storageSize);
     std::vector<scalar_t> B_storage (storageSize);
 

--- a/tests/conjugate_view.cpp
+++ b/tests/conjugate_view.cpp
@@ -15,14 +15,14 @@ namespace {
     using scalar_t = std::complex<real_t>;
     using vector_t = basic_mdspan<scalar_t, extents<dynamic_extent>>;
 
-    constexpr size_t vectorSize (5);
-    constexpr size_t storageSize = size_t (2) * vectorSize;
+    constexpr ptrdiff_t vectorSize (5);
+    constexpr ptrdiff_t storageSize = ptrdiff_t (2) * vectorSize;
     std::vector<scalar_t> storage (storageSize);
 
     vector_t x (storage.data (), vectorSize);
     vector_t y (storage.data () + vectorSize, vectorSize);
 
-    for (size_t k = 0; k < vectorSize; ++k) {
+    for (ptrdiff_t k = 0; k < vectorSize; ++k) {
       const scalar_t x_k(real_t(k) + 1.0, real_t(k) + 1.0);
       const scalar_t y_k(real_t(k) + 2.0, real_t(k) + 2.0);
       x(k) = x_k;
@@ -41,7 +41,7 @@ namespace {
     }
 
     auto y_conj = conjugate_view (y);
-    for (size_t k = 0; k < vectorSize; ++k) {
+    for (ptrdiff_t k = 0; k < vectorSize; ++k) {
       const scalar_t x_k(real_t(k) + 1.0, real_t(k) + 1.0);
       EXPECT_EQ( x(k), x_k );
 

--- a/tests/copy.cpp
+++ b/tests/copy.cpp
@@ -21,7 +21,7 @@ namespace {
 
   template<class Real>
   struct MakeVectorValues {
-    static std::pair<Real, Real> make(const size_t k) {
+    static std::pair<Real, Real> make(const ptrdiff_t k) {
       const Real x_k = Real(k) + Real(1.0);
       const Real y_k = Real(k) + Real(2.0);
       return {x_k, y_k};
@@ -31,7 +31,7 @@ namespace {
   template<class Real>
   struct MakeVectorValues<std::complex<Real>> {
     static std::pair<std::complex<Real>, std::complex<Real>>
-    make (const size_t k) {
+    make (const ptrdiff_t k) {
       const std::complex<Real> x_k(Real(k) + 4.0, -Real(k) - 1.0);
       const std::complex<Real> y_k(Real(k) + 5.0, -Real(k) - 2.0);
       return {x_k, y_k};
@@ -39,7 +39,7 @@ namespace {
   };
 
   template<class Scalar>
-  std::pair<Scalar, Scalar> makeVectorValues(const size_t k) {
+  std::pair<Scalar, Scalar> makeVectorValues(const ptrdiff_t k) {
     return MakeVectorValues<Scalar>::make(k);
   }
 
@@ -48,21 +48,21 @@ namespace {
     using scalar_t = double;
     using vector_t = basic_mdspan<scalar_t, extents<dynamic_extent>>;
 
-    constexpr size_t vectorSize(5);
-    constexpr size_t storageSize = size_t(2) * vectorSize;
+    constexpr ptrdiff_t vectorSize(5);
+    constexpr ptrdiff_t storageSize = ptrdiff_t(2) * vectorSize;
     std::vector<scalar_t> storage(storageSize);
 
     vector_t x(storage.data(), vectorSize);
     vector_t y(storage.data() + vectorSize, vectorSize);
 
-    for (size_t k = 0; k < vectorSize; ++k) {
+    for (ptrdiff_t k = 0; k < vectorSize; ++k) {
       const auto vals = makeVectorValues<scalar_t>(k);
       x(k) = vals.first;
       y(k) = vals.second;
     }
 
     linalg_copy(x, y);
-    for (size_t k = 0; k < vectorSize; ++k) {
+    for (ptrdiff_t k = 0; k < vectorSize; ++k) {
       const auto vals = makeVectorValues<scalar_t>(k);
       // Make sure the function didn't modify the input.
       EXPECT_EQ( x(k), vals.first );
@@ -76,21 +76,21 @@ namespace {
     using scalar_t = std::complex<real_t>;
     using vector_t = basic_mdspan<scalar_t, extents<dynamic_extent>>;
 
-    constexpr size_t vectorSize(5);
-    constexpr size_t storageSize = size_t(2) * vectorSize;
+    constexpr ptrdiff_t vectorSize(5);
+    constexpr ptrdiff_t storageSize = ptrdiff_t(2) * vectorSize;
     std::vector<scalar_t> storage(storageSize);
 
     vector_t x(storage.data(), vectorSize);
     vector_t y(storage.data() + vectorSize, vectorSize);
 
-    for (size_t k = 0; k < vectorSize; ++k) {
+    for (ptrdiff_t k = 0; k < vectorSize; ++k) {
       const auto vals = makeVectorValues<scalar_t>(k);
       x(k) = vals.first;
       y(k) = vals.second;
     }
 
     linalg_copy(x, y);
-    for (size_t k = 0; k < vectorSize; ++k) {
+    for (ptrdiff_t k = 0; k < vectorSize; ++k) {
       const auto vals = makeVectorValues<scalar_t>(k);
       // Make sure the function didn't modify the input.
       EXPECT_EQ( x(k), vals.first );
@@ -140,7 +140,7 @@ TEST(BLAS1_copy_matrix, mdspan_double)
 
   constexpr ptrdiff_t numRows(5);
   constexpr ptrdiff_t numCols(4);
-  constexpr size_t storageSize = size_t(2) * size_t(numRows*numCols);
+  constexpr ptrdiff_t storageSize = ptrdiff_t(2) * ptrdiff_t(numRows*numCols);
   std::vector<scalar_t> storage(storageSize);
 
   matrix_t A(storage.data(), numRows, numCols);
@@ -173,7 +173,7 @@ TEST(BLAS1_copy_matrix, mdspan_complex_double)
 
   constexpr ptrdiff_t numRows(5);
   constexpr ptrdiff_t numCols(4);
-  constexpr size_t storageSize = size_t(2) * size_t(numRows*numCols);
+  constexpr ptrdiff_t storageSize = ptrdiff_t(2) * ptrdiff_t(numRows*numCols);
   std::vector<scalar_t> storage(storageSize);
 
   matrix_t A(storage.data(), numRows, numCols);

--- a/tests/dot.cpp
+++ b/tests/dot.cpp
@@ -37,15 +37,15 @@ namespace {
     using scalar_t = double;
     using vector_t = basic_mdspan<scalar_t, extents<dynamic_extent>>;
 
-    constexpr size_t vectorSize (5);
-    constexpr size_t storageSize = size_t (2) * vectorSize;
+    constexpr ptrdiff_t vectorSize (5);
+    constexpr ptrdiff_t storageSize = ptrdiff_t (2) * vectorSize;
     std::vector<scalar_t> storage (storageSize);
 
     vector_t x (storage.data (), vectorSize);
     vector_t y (storage.data () + vectorSize, vectorSize);
 
     scalar_t expectedDotResult {};
-    for (size_t k = 0; k < vectorSize; ++k) {
+    for (ptrdiff_t k = 0; k < vectorSize; ++k) {
       const scalar_t x_k = scalar_t (k) + 1.0;
       const scalar_t y_k = scalar_t (k) + 2.0;
       x(k) = x_k;
@@ -83,8 +83,8 @@ namespace {
     using scalar_t = std::complex<real_t>;
     using vector_t = basic_mdspan<scalar_t, extents<dynamic_extent>>;
 
-    constexpr size_t vectorSize (5);
-    constexpr size_t storageSize = size_t (2) * vectorSize;
+    constexpr ptrdiff_t vectorSize (5);
+    constexpr ptrdiff_t storageSize = ptrdiff_t (2) * vectorSize;
     std::vector<scalar_t> storage (storageSize);
 
     vector_t x (storage.data (), vectorSize);
@@ -92,7 +92,7 @@ namespace {
 
     scalar_t expectedDotResult {};
     scalar_t expectedConjDotResult {};
-    for (size_t k = 0; k < vectorSize; ++k) {
+    for (ptrdiff_t k = 0; k < vectorSize; ++k) {
       const scalar_t x_k(real_t(k) + 1.0, real_t(k) + 1.0);
       const scalar_t y_k(real_t(k) + 2.0, real_t(k) + 2.0);
       x(k) = x_k;

--- a/tests/gemm.cpp
+++ b/tests/gemm.cpp
@@ -80,8 +80,8 @@ namespace {
     using extents_t = extents<dynamic_extent, dynamic_extent>;
     using matrix_t = basic_mdspan<scalar_t, extents_t, layout_left>;
 
-    constexpr size_t maxDim = 7;
-    constexpr size_t storageSize(7*maxDim*maxDim);
+    constexpr ptrdiff_t maxDim = 7;
+    constexpr ptrdiff_t storageSize(7*maxDim*maxDim);
     std::vector<scalar_t> storage(storageSize);
 
     for (ptrdiff_t C_numRows : {1, 4, 7}) {

--- a/tests/givens.cpp
+++ b/tests/givens.cpp
@@ -156,14 +156,14 @@ namespace {
     using scalar_t = real_t;
     using vector_t = basic_mdspan<scalar_t, extents<dynamic_extent>>;
 
-    constexpr size_t vectorSize(5);
-    constexpr size_t storageSize = size_t(2) * vectorSize;
+    constexpr ptrdiff_t vectorSize(5);
+    constexpr ptrdiff_t storageSize = ptrdiff_t(2) * vectorSize;
     std::vector<scalar_t> storage(storageSize);
 
     vector_t x(storage.data(), vectorSize);
     vector_t y(storage.data() + vectorSize, vectorSize);
 
-    for (size_t k = 0; k < vectorSize; ++k) {
+    for (ptrdiff_t k = 0; k < vectorSize; ++k) {
       const scalar_t x_k(real_t(k) + 4.0);
       const scalar_t y_k(real_t(k) + 5.0);
       x(k) = x_k;
@@ -175,7 +175,7 @@ namespace {
       const scalar_t s(0.0);
 
       givens_rotation_apply(x, y, c, s);
-      for (size_t k = 0; k < vectorSize; ++k) {
+      for (ptrdiff_t k = 0; k < vectorSize; ++k) {
         scalar_t x_k(real_t(k) + 4.0);
         scalar_t y_k(real_t(k) + 5.0);
 
@@ -192,7 +192,7 @@ namespace {
       const scalar_t s(1.0);
 
       givens_rotation_apply(x, y, c, s);
-      for (size_t k = 0; k < vectorSize; ++k) {
+      for (ptrdiff_t k = 0; k < vectorSize; ++k) {
         scalar_t x_k(real_t(k) + 4.0);
         scalar_t y_k(real_t(k) + 5.0);
 
@@ -212,14 +212,14 @@ namespace {
     using scalar_t = std::complex<real_t>;
     using vector_t = basic_mdspan<scalar_t, extents<dynamic_extent>>;
 
-    constexpr size_t vectorSize(5);
-    constexpr size_t storageSize = size_t(2) * vectorSize;
+    constexpr ptrdiff_t vectorSize(5);
+    constexpr ptrdiff_t storageSize = ptrdiff_t(2) * vectorSize;
     std::vector<scalar_t> storage(storageSize);
 
     vector_t x(storage.data(), vectorSize);
     vector_t y(storage.data() + vectorSize, vectorSize);
 
-    for (size_t k = 0; k < vectorSize; ++k) {
+    for (ptrdiff_t k = 0; k < vectorSize; ++k) {
       const scalar_t x_k(real_t(k) + 4.0, -real_t(k) - 1.0);
       const scalar_t y_k(real_t(k) + 5.0, -real_t(k) - 2.0);
       x(k) = x_k;
@@ -233,7 +233,7 @@ namespace {
       const scalar_t s(0.0, 0.0);
 
       givens_rotation_apply(x, y, c, s);
-      for (size_t k = 0; k < vectorSize; ++k) {
+      for (ptrdiff_t k = 0; k < vectorSize; ++k) {
         scalar_t x_k(real_t(k) + 4.0, -real_t(k) - 1.0);
         scalar_t y_k(real_t(k) + 5.0, -real_t(k) - 2.0);
 
@@ -250,7 +250,7 @@ namespace {
       const scalar_t s(1.0, 0.0);
 
       givens_rotation_apply(x, y, c, s);
-      for (size_t k = 0; k < vectorSize; ++k) {
+      for (ptrdiff_t k = 0; k < vectorSize; ++k) {
         scalar_t x_k(real_t(k) + 4.0, -real_t(k) - 1.0);
         scalar_t y_k(real_t(k) + 5.0, -real_t(k) - 2.0);
 

--- a/tests/iterator.cpp
+++ b/tests/iterator.cpp
@@ -185,7 +185,7 @@ namespace {
     static_assert(mdspan_type::rank() == 1);
     using pointer = typename mdspan_type::pointer;
 
-    mdspan_type x(nullptr, 0);
+    mdspan_type x; // (nullptr, extents_type(0)); // FIXME (mfh 2020/06/18) doesn't build with VS 2019
     using iterator = decltype(begin(x));
     static_assert(std::is_same_v<iterator, decltype(end(x))>);
 
@@ -273,8 +273,8 @@ namespace {
     using extents_t = extents<dynamic_extent, dynamic_extent>;
     using matrix_t = basic_mdspan<scalar_t, extents_t, layout_t>;
 
-    constexpr size_t dim(5);
-    constexpr size_t storageSize(dim * dim);
+    constexpr ptrdiff_t dim(5);
+    constexpr ptrdiff_t storageSize(dim * dim);
 
     std::vector<scalar_t> storage(storageSize);
     matrix_t A(storage.data(), dim, dim);
@@ -432,8 +432,8 @@ namespace {
   //   using extents_t = extents<dynamic_extent>;
   //   using vector_t = basic_mdspan<scalar_t, extents_t, layout_t>;
 
-  //   constexpr size_t vectorSize(10);
-  //   constexpr size_t storageSize(10);
+  //   constexpr ptrdiff_t vectorSize(10);
+  //   constexpr ptrdiff_t storageSize(10);
   //   std::vector<scalar_t> storage(storageSize);
   //   vector_t x(storage.data(), vectorSize);
   // }

--- a/tests/norm2.cpp
+++ b/tests/norm2.cpp
@@ -37,17 +37,17 @@ namespace {
     using scalar_t = double;
     using vector_t = basic_mdspan<scalar_t, extents<dynamic_extent>>;
 
-    constexpr size_t vectorSize(5);
+    constexpr ptrdiff_t vectorSize(5);
     constexpr mag_t tol =
       mag_t(vectorSize) * std::numeric_limits<mag_t>::epsilon();
 
-    constexpr size_t storageSize = vectorSize;
+    constexpr ptrdiff_t storageSize = vectorSize;
     std::vector<scalar_t> storage(storageSize);
 
     vector_t x(storage.data(), vectorSize);
 
     mag_t expectedNormResultSquared {};
-    for (size_t k = 0; k < vectorSize; ++k) {
+    for (ptrdiff_t k = 0; k < vectorSize; ++k) {
       const scalar_t x_k = scalar_t(k) + scalar_t(1.0);
       x(k) = x_k;
       expectedNormResultSquared += x_k * x_k;
@@ -74,18 +74,18 @@ namespace {
     using scalar_t = std::complex<real_t>;
     using vector_t = basic_mdspan<scalar_t, extents<dynamic_extent>>;
 
-    constexpr size_t vectorSize(5);
+    constexpr ptrdiff_t vectorSize(5);
     // Complex numbers use more arithmetic than their real analogs.
     constexpr mag_t tol = 4.0 * mag_t(vectorSize) *
       std::numeric_limits<mag_t>::epsilon();
 
-    constexpr size_t storageSize = vectorSize;
+    constexpr ptrdiff_t storageSize = vectorSize;
     std::vector<scalar_t> storage(storageSize);
 
     vector_t x(storage.data(), vectorSize);
 
     mag_t expectedNormResultSquared {};
-    for (size_t k = 0; k < vectorSize; ++k) {
+    for (ptrdiff_t k = 0; k < vectorSize; ++k) {
       const scalar_t x_k(real_t(k) + 3.0, -real_t(k) - 1.0);
       x(k) = x_k;
       expectedNormResultSquared += abs(x_k) * abs(x_k);

--- a/tests/scale.cpp
+++ b/tests/scale.cpp
@@ -23,33 +23,33 @@ namespace {
     using scalar_t = double;
     using vector_t = basic_mdspan<scalar_t, extents<dynamic_extent>>;
 
-    constexpr size_t vectorSize(5);
-    constexpr size_t storageSize = vectorSize;
+    constexpr ptrdiff_t vectorSize(5);
+    constexpr ptrdiff_t storageSize = vectorSize;
     std::vector<scalar_t> storage(storageSize);
 
     const scalar_t scaleFactor = 5.0;
     vector_t x(storage.data(), vectorSize);
 
     {
-      for (size_t k = 0; k < vectorSize; ++k) {
+      for (ptrdiff_t k = 0; k < vectorSize; ++k) {
         const scalar_t x_k = scalar_t (k) + 1.0;
         x(k) = x_k;
       }
       const scalar_t scaleFactor = 5.0;
       scale(scaleFactor, x);
-      for (size_t k = 0; k < vectorSize; ++k) {
+      for (ptrdiff_t k = 0; k < vectorSize; ++k) {
         const scalar_t x_k = scalar_t (k) + 1.0;
         EXPECT_EQ( x(k), scaleFactor * x_k );
       }
     }
     {
-      for (size_t k = 0; k < vectorSize; ++k) {
+      for (ptrdiff_t k = 0; k < vectorSize; ++k) {
         const scalar_t x_k = scalar_t (k) + 1.0;
         x(k) = x_k;
       }
       const float scaleFactor = 5.0;
       scale(scaleFactor, x);
-      for (size_t k = 0; k < vectorSize; ++k) {
+      for (ptrdiff_t k = 0; k < vectorSize; ++k) {
         const scalar_t x_k = scalar_t (k) + 1.0;
         EXPECT_EQ( x(k), scaleFactor * x_k );
       }
@@ -62,32 +62,32 @@ namespace {
     using scalar_t = std::complex<real_t>;
     using vector_t = basic_mdspan<scalar_t, extents<dynamic_extent>>;
 
-    constexpr size_t vectorSize(5);
-    constexpr size_t storageSize = vectorSize;
+    constexpr ptrdiff_t vectorSize(5);
+    constexpr ptrdiff_t storageSize = vectorSize;
     std::vector<scalar_t> storage(storageSize);
 
     vector_t x(storage.data(), vectorSize);
 
     {
-      for (size_t k = 0; k < vectorSize; ++k) {
+      for (ptrdiff_t k = 0; k < vectorSize; ++k) {
         const scalar_t x_k(real_t(k) + 4.0, -real_t(k) - 1.0);
         x(k) = x_k;
       }
       const real_t scaleFactor = 5.0;
       scale(scaleFactor, x);
-      for (size_t k = 0; k < vectorSize; ++k) {
+      for (ptrdiff_t k = 0; k < vectorSize; ++k) {
         const scalar_t x_k(real_t(k) + 4.0, -real_t(k) - 1.0);
         EXPECT_EQ( x(k), scaleFactor * x_k );
       }
     }
     {
-      for (size_t k = 0; k < vectorSize; ++k) {
+      for (ptrdiff_t k = 0; k < vectorSize; ++k) {
         const scalar_t x_k(real_t(k) + 4.0, -real_t(k) - 1.0);
         x(k) = x_k;
       }
       const scalar_t scaleFactor (5.0, -1.0);
       scale(scaleFactor, x);
-      for (size_t k = 0; k < vectorSize; ++k) {
+      for (ptrdiff_t k = 0; k < vectorSize; ++k) {
         const scalar_t x_k(real_t(k) + 4.0, -real_t(k) - 1.0);
         EXPECT_EQ( x(k), scaleFactor * x_k );
       }

--- a/tests/scaled_view.cpp
+++ b/tests/scaled_view.cpp
@@ -17,14 +17,14 @@ namespace {
     using vector_t =
       basic_mdspan<vector_element_type, extents<dynamic_extent>>;
 
-    constexpr size_t vectorSize (5);
-    constexpr size_t storageSize = size_t (2) * vectorSize;
+    constexpr ptrdiff_t vectorSize (5);
+    constexpr ptrdiff_t storageSize = ptrdiff_t (2) * vectorSize;
     std::vector<vector_element_type> storage (storageSize);
 
     vector_t x (storage.data (), vectorSize);
     vector_t y (storage.data () + vectorSize, vectorSize);
 
-    for (size_t k = 0; k < vectorSize; ++k) {
+    for (ptrdiff_t k = 0; k < vectorSize; ++k) {
       const vector_element_type x_k = vector_element_type(k) + 1.0;
       const vector_element_type y_k = vector_element_type(k) + 2.0;
       x(k) = x_k;
@@ -44,7 +44,7 @@ namespace {
     }
 
     auto y_scaled = scaled_view (scalingFactor, y);
-    for (size_t k = 0; k < vectorSize; ++k) {
+    for (ptrdiff_t k = 0; k < vectorSize; ++k) {
       const vector_element_type x_k = vector_element_type(k) + 1.0;
       EXPECT_EQ( x(k), x_k );
 

--- a/tests/swap.cpp
+++ b/tests/swap.cpp
@@ -23,14 +23,14 @@ namespace {
     using scalar_t = double;
     using vector_t = basic_mdspan<scalar_t, extents<dynamic_extent>>;
 
-    constexpr size_t vectorSize(5);
-    constexpr size_t storageSize = size_t(2) * vectorSize;
+    constexpr ptrdiff_t vectorSize(5);
+    constexpr ptrdiff_t storageSize = ptrdiff_t(2) * vectorSize;
     std::vector<scalar_t> storage(storageSize);
 
     vector_t x(storage.data(), vectorSize);
     vector_t y(storage.data() + vectorSize, vectorSize);
 
-    for (size_t k = 0; k < vectorSize; ++k) {
+    for (ptrdiff_t k = 0; k < vectorSize; ++k) {
       const scalar_t x_k = scalar_t (k) + 1.0;
       const scalar_t y_k = scalar_t (k) + 2.0;
       x(k) = x_k;
@@ -38,7 +38,7 @@ namespace {
     }
 
     linalg_swap(x, y);
-    for (size_t k = 0; k < vectorSize; ++k) {
+    for (ptrdiff_t k = 0; k < vectorSize; ++k) {
       const scalar_t x_k = scalar_t (k) + 1.0;
       const scalar_t y_k = scalar_t (k) + 2.0;
       EXPECT_EQ( x(k), y_k );
@@ -52,14 +52,14 @@ namespace {
     using scalar_t = std::complex<real_t>;
     using vector_t = basic_mdspan<scalar_t, extents<dynamic_extent>>;
 
-    constexpr size_t vectorSize(5);
-    constexpr size_t storageSize = size_t(2) * vectorSize;
+    constexpr ptrdiff_t vectorSize(5);
+    constexpr ptrdiff_t storageSize = ptrdiff_t(2) * vectorSize;
     std::vector<scalar_t> storage(storageSize);
 
     vector_t x(storage.data(), vectorSize);
     vector_t y(storage.data() + vectorSize, vectorSize);
 
-    for (size_t k = 0; k < vectorSize; ++k) {
+    for (ptrdiff_t k = 0; k < vectorSize; ++k) {
       const scalar_t x_k(real_t(k) + 4.0, -real_t(k) - 1.0);
       const scalar_t y_k(real_t(k) + 5.0, -real_t(k) - 2.0);
       x(k) = x_k;
@@ -67,7 +67,7 @@ namespace {
     }
 
     linalg_swap(x, y);
-    for (size_t k = 0; k < vectorSize; ++k) {
+    for (ptrdiff_t k = 0; k < vectorSize; ++k) {
       const scalar_t x_k(real_t(k) + 4.0, -real_t(k) - 1.0);
       const scalar_t y_k(real_t(k) + 5.0, -real_t(k) - 2.0);
       EXPECT_EQ( x(k), y_k );

--- a/tests/transpose_view.cpp
+++ b/tests/transpose_view.cpp
@@ -19,7 +19,7 @@ namespace {
     using matrix_static_t =
       basic_mdspan<scalar_t, extents<dim, dim>>;
 
-    constexpr size_t storageSize = size_t(dim*dim);
+    constexpr ptrdiff_t storageSize = ptrdiff_t(dim*dim);
     std::vector<scalar_t> A_storage (storageSize);
     std::vector<scalar_t> B_storage (storageSize);
 


### PR DESCRIPTION
1. VS 2019 doesn't compile if you give `size_t` as a run-time extent to `basic_mdspan`'s constructor.  I changed all those `size_t` in stdBLAS' tests to `ptrdiff_t`.

2. There was another issue in tests/iterator.cpp; it was a lower priority to fix, so I just commented out that code for now.

Note that we still need to fix BLAS detection (or make it optional) on Windows.  This PR does _not_ do that.