### PR TITLE
Fix MSVC test build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,48 @@
-# Reference Implementation for BLAS in the C++ standard
+# P1673 reference implementation
+
+This is a reference implementation of P1673,
+"A free function linear algebra interface based on the BLAS."
+You can find the latest revision of P1673 at wg21.link/p1673.
 
 ## Requirements
 
-  - CMake >= 3.12
-  - C++14 or greater compiler (requirement of mdspan)
+  - CMake >= 3.17 (earlier versions may work, but are not tested)
+  - C++ build environment that supports C++17 or greater
 
-## Build instructions
+## Tested compilers
 
-1. Download and install googletest
+We run github's automated tests on every pull request.
+Automated tests use "ubuntu-latest",
+which presumably defaults to a fairly new GCC.
+
+MSVC 2019 16.7.0 is able to build and run tests and examples as of 2021/05/27.
+
+## Brief build instructions
+
+1. Download and install googletest (GTest)
    - https://github.com/google/googletest
-   - (master appears to work)
 2. Download and install mdspan:
    - git@github.com:kokkos/mdspan.git
+3. Run CMake, pointing it to your googletest and mdspan install locations
+   - If you want to build tests, set LINALG_ENABLE_TESTS=ON
+   - If you want to build examples, set LINALG_ENABLE_EXAMPLES=ON
+   - If you have a BLAS installation, set LINALG_ENABLE_BLAS=ON.
+     BLAS support is currently experimental.
+4. Build and install as usual
+5. If you enabled tests, use "ctest" to run them
+
+## More detailed MSVC build instructions
+
+Be sure to build mdspan and googletest in the Release configuration before installing.
+
+The following CMake options are known to work:
+
+- mdspan_DIR=${MDSPAN_INSTALL_DIR}\lib\cmake\mdspan
+  (where MDSPAN_INSTALL_DIR is the path to your mdspan installation)
+- GTEST_INCLUDE_DIR=${GTEST_INSTALL_DIR}\include
+  (where GTEST_INSTALL_DIR is the path to your googletest installation)
+- GTEST_LIBRARY=${GTEST_INSTALL_DIR}\lib\gtest.lib
+- GTEST_MAIN_LIBRARY=${GTEST_INSTALL_DIR}\lib\gtest_main.lib
+
+When building tests, for all CMAKE_CXX_FLAGS_* options,
+you might need to change "/MD" to "/MT", depending on how googletest was built.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,11 +1,17 @@
+find_package(GTest REQUIRED)
 
 macro(linalg_add_test name)
   add_executable(${name} ${name}.cpp)
-  target_link_libraries(${name} linalg GTest::GTest GTest::Main ${BLAS_LIBRARIES})
+  if(BLAS_FOUND)
+    target_link_libraries(${name} linalg GTest::GTest GTest::Main ${BLAS_LIBRARIES})
+  else()
+    # BLAS_LIBRARIES is literally "FALSE" if the BLAS was not found.
+    # Linking against that causes linker errors involving "FALSE.lib".
+    # Thus, we exclude BLAS_LIBRARIES completely if the BLAS was not found.
+    target_link_libraries(${name} linalg GTest::GTest GTest::Main)
+  endif()
   add_test(${name} ${name})
 endmacro()
-
-find_package(GTest REQUIRED)
 
 linalg_add_test(add)
 linalg_add_test(conjugate_transposed)

--- a/tests/matrix_one_norm.cpp
+++ b/tests/matrix_one_norm.cpp
@@ -97,15 +97,10 @@ namespace {
     }
   }
 
-  //TEST(matrix_one_norm, mdspan_int)
-  //{
-  //  test_matrix_one_norm<int>();
-  //} 
-
-  //TEST(matrix_one_norm, mdspan_unsigned_int)
-  //{
-  //  test_matrix_one_norm<unsigned int>();
-  //}
+  TEST(matrix_one_norm, mdspan_int)
+  {
+    test_matrix_one_norm<int>();
+  }
 
   TEST(matrix_one_norm, mdspan_double)
   {


### PR DESCRIPTION
Fix building tests on MSVC, by preventing (BLAS-related) linker errors that involve "FALSE.lib".  Give an example in README.md of how to set CMake options for an MSVC build.  Also, add a `matrix_one_norm` test for a matrix of `int`.

