### PR TITLE
Install generated linalg_config.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,9 @@ export(TARGETS linalg
 )
 
 install(DIRECTORY include/experimental DESTINATION include)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/include/experimental/__p1673_bits/linalg_config.h
+    DESTINATION include/experimental/__p1673_bits
+)
 
 include(CMakePackageConfigHelpers)
 configure_package_config_file(cmake/LinAlgConfig.cmake.in


### PR DESCRIPTION
Currently linalg_config.h is generated but not included in the files installed by cmake.