### PR TITLE
Fetch dependencies from Github if not available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,7 @@ if (NOT mdspan_FOUND)
   FetchContent_Declare(
     mdspan
     GIT_REPOSITORY https://github.com/kokkos/mdspan.git
-    GIT_TAG        5694f21c39f3b948d06a0c63b9c219bf802e28a8
+    GIT_TAG        stable
   )
   FetchContent_GetProperties(mdspan)
   if(NOT mdspan_POPULATED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,21 @@ endif()
 
 ################################################################################
 
-find_package(mdspan REQUIRED)
+find_package(mdspan QUIET)
+if (NOT mdspan_FOUND)
+  message(STATUS "No installed mdspan found, fetching from Github")
+  include(FetchContent)
+  FetchContent_Declare(
+    mdspan
+    GIT_REPOSITORY https://github.com/kokkos/mdspan.git
+    GIT_TAG        5694f21c39f3b948d06a0c63b9c219bf802e28a8
+  )
+  FetchContent_GetProperties(mdspan)
+  if(NOT mdspan_POPULATED)
+    FetchContent_Populate(mdspan)
+    add_subdirectory(${mdspan_SOURCE_DIR} ${mdspan_BINARY_DIR} EXCLUDE_FROM_ALL)
+  endif()
+endif()
 
 find_package(BLAS)
 option(LINALG_ENABLE_BLAS

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,7 +5,7 @@ if (NOT GTest_FOUND)
   FetchContent_Declare(
     googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG        7153098229e88295f9655ff1d3b0e2fa9eada5f8
+    GIT_TAG        release-1.11.0
   )
   # need to set the variables in CACHE due to CMP0077
   set(gtest_disable_pthreads ON CACHE INTERNAL "")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,20 @@
-find_package(GTest REQUIRED)
+find_package(GTest)
+if (NOT GTest_FOUND)
+  message(STATUS "No installed GTest found, fetching from Github")
+  include(FetchContent)
+  FetchContent_Declare(
+    googletest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG        7153098229e88295f9655ff1d3b0e2fa9eada5f8
+  )
+  FetchContent_GetProperties(googletest)
+  if(NOT googletest_POPULATED)
+    FetchContent_Populate(googletest)
+    add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR} EXCLUDE_FROM_ALL)
+  endif()
+  add_library(GTest::Main ALIAS gtest_main)
+  add_library(GTest::GTest ALIAS gtest)
+endif()
 
 macro(linalg_add_test name)
   add_executable(${name} ${name}.cpp)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,6 +7,11 @@ if (NOT GTest_FOUND)
     GIT_REPOSITORY https://github.com/google/googletest.git
     GIT_TAG        7153098229e88295f9655ff1d3b0e2fa9eada5f8
   )
+  # need to set the variables in CACHE due to CMP0077
+  set(gtest_disable_pthreads ON CACHE INTERNAL "")
+  if(MSVC)
+    set(gtest_force_shared_crt ON CACHE INTERNAL "")
+  endif()
   FetchContent_GetProperties(googletest)
   if(NOT googletest_POPULATED)
     FetchContent_Populate(googletest)


### PR DESCRIPTION
Addressing #2, this PR fetches GoogleTest (and mdspan, as it currently relies on an installed mdspan, which causes a plain `cmake ..` to fail) as part of the configure step and builds them as part of the regular build step.

I needed to add two workarounds for GTest-specific issues on MSVC, which are
1. GTest seems to assume we have pthread support for some reason, so we need to explicitly disable it
2. GTest modifies `CMAKE_CXX_FLAGS*` with respect to `/MD` and `/MT`, so we need to force it to use the default `/MD`, which means we link against a shared CRT.

How could these changes impact the library?
If somebody included stdBLAS with tests enabled as a subdirectory in their own project, didn't have `GTest` installed and did build `GTest` themselves, these two variables would be overwritten. We could probably avoid that by checking whether the variables are set, or disabling tests by default if we are being built as part of another project.

I tested everything on GCC 11 and MSVC 19, so no obvious compilation issues :)

TODO: 
- [ ] Enable tests by default?