### PR TITLE
tests: replace ptrdiff_t with std::size_t

### DIFF
--- a/tests/add.cpp
+++ b/tests/add.cpp
@@ -23,15 +23,15 @@ namespace {
     using scalar_t = double;
     using vector_t = mdspan<scalar_t, extents<dynamic_extent>>;
 
-    constexpr ptrdiff_t vectorSize(5);
-    constexpr ptrdiff_t storageSize = ptrdiff_t(3) * vectorSize;
+    constexpr std::size_t vectorSize(5);
+    constexpr std::size_t storageSize = std::size_t(3) * vectorSize;
     std::vector<scalar_t> storage(storageSize);
 
     vector_t x(storage.data(), vectorSize);
     vector_t y(storage.data() + vectorSize, vectorSize);
     vector_t z(storage.data() + 2*vectorSize, vectorSize);
 
-    for (ptrdiff_t k = 0; k < vectorSize; ++k) {
+    for (std::size_t k = 0; k < vectorSize; ++k) {
       const scalar_t x_k = scalar_t (k) + 1.0;
       const scalar_t y_k = scalar_t (k) + 2.0;
       x(k) = x_k;
@@ -40,7 +40,7 @@ namespace {
     }
 
     add(x, y, z);
-    for (ptrdiff_t k = 0; k < vectorSize; ++k) {
+    for (std::size_t k = 0; k < vectorSize; ++k) {
       const scalar_t x_k = scalar_t (k) + 1.0;
       const scalar_t y_k = scalar_t (k) + 2.0;
       // Make sure the function didn't modify the input.
@@ -56,15 +56,15 @@ namespace {
     using scalar_t = std::complex<real_t>;
     using vector_t = mdspan<scalar_t, extents<dynamic_extent>>;
 
-    constexpr ptrdiff_t vectorSize(5);
-    constexpr ptrdiff_t storageSize = ptrdiff_t(3) * vectorSize;
+    constexpr std::size_t vectorSize(5);
+    constexpr std::size_t storageSize = std::size_t(3) * vectorSize;
     std::vector<scalar_t> storage(storageSize);
 
     vector_t x(storage.data(), vectorSize);
     vector_t y(storage.data() + vectorSize, vectorSize);
     vector_t z(storage.data() + 2*vectorSize, vectorSize);
 
-    for (ptrdiff_t k = 0; k < vectorSize; ++k) {
+    for (std::size_t k = 0; k < vectorSize; ++k) {
       const scalar_t x_k(real_t(k) + 4.0, -real_t(k) - 1.0);
       const scalar_t y_k(real_t(k) + 5.0, -real_t(k) - 2.0);
       x(k) = x_k;
@@ -73,7 +73,7 @@ namespace {
     }
 
     add(x, y, z);
-    for (ptrdiff_t k = 0; k < vectorSize; ++k) {
+    for (std::size_t k = 0; k < vectorSize; ++k) {
       const scalar_t x_k(real_t(k) + 4.0, -real_t(k) - 1.0);
       const scalar_t y_k(real_t(k) + 5.0, -real_t(k) - 2.0);
       // Make sure the function didn't modify the input.

--- a/tests/conjugate_transposed.cpp
+++ b/tests/conjugate_transposed.cpp
@@ -17,19 +17,19 @@ namespace {
     using scalar_t = std::complex<real_t>;
     using matrix_dynamic_t =
       mdspan<scalar_t, extents<dynamic_extent, dynamic_extent>>;
-    constexpr ptrdiff_t dim = 5;
+    constexpr std::size_t dim = 5;
     using matrix_static_t =
       mdspan<scalar_t, extents<dim, dim>>;
 
-    constexpr ptrdiff_t storageSize = ptrdiff_t(dim*dim);
+    constexpr std::size_t storageSize = std::size_t(dim*dim);
     std::vector<scalar_t> A_storage (storageSize);
     std::vector<scalar_t> B_storage (storageSize);
 
     matrix_dynamic_t A (A_storage.data (), dim, dim);
     matrix_static_t B (B_storage.data ());
 
-    for (ptrdiff_t i = 0; i < dim; ++i) {
-      for (ptrdiff_t j = 0; j < dim; ++j) {
+    for (std::size_t i = 0; i < dim; ++i) {
+      for (std::size_t j = 0; j < dim; ++j) {
         const real_t i_val_re (real_t(i) + 1.0);
         const scalar_t i_val (i_val_re, i_val_re);
         const real_t j_val_re = real_t(j) + 1.0;
@@ -44,8 +44,8 @@ namespace {
     auto A_h = conjugate_transposed (A);
     auto B_h = conjugate_transposed (B);
 
-    for (ptrdiff_t i = 0; i < dim; ++i) {
-      for (ptrdiff_t j = 0; j < dim; ++j) {
+    for (std::size_t i = 0; i < dim; ++i) {
+      for (std::size_t j = 0; j < dim; ++j) {
         const real_t i_val_re (real_t(i) + 1.0);
         const scalar_t i_val (i_val_re, i_val_re);
         const real_t j_val_re = real_t(j) + 1.0;

--- a/tests/conjugated.cpp
+++ b/tests/conjugated.cpp
@@ -15,14 +15,14 @@ namespace {
     using scalar_t = std::complex<real_t>;
     using vector_t = mdspan<scalar_t, extents<dynamic_extent>>;
 
-    constexpr ptrdiff_t vectorSize (5);
-    constexpr ptrdiff_t storageSize = ptrdiff_t (2) * vectorSize;
+    constexpr std::size_t vectorSize (5);
+    constexpr std::size_t storageSize = std::size_t (2) * vectorSize;
     std::vector<scalar_t> storage (storageSize);
 
     vector_t x (storage.data (), vectorSize);
     vector_t y (storage.data () + vectorSize, vectorSize);
 
-    for (ptrdiff_t k = 0; k < vectorSize; ++k) {
+    for (std::size_t k = 0; k < vectorSize; ++k) {
       const scalar_t x_k(real_t(k) + 1.0, real_t(k) + 1.0);
       const scalar_t y_k(real_t(k) + 2.0, real_t(k) + 2.0);
       x(k) = x_k;
@@ -41,7 +41,7 @@ namespace {
     }
 
     auto y_conj = conjugated (y);
-    for (ptrdiff_t k = 0; k < vectorSize; ++k) {
+    for (std::size_t k = 0; k < vectorSize; ++k) {
       const scalar_t x_k(real_t(k) + 1.0, real_t(k) + 1.0);
       EXPECT_EQ( x(k), x_k );
 

--- a/tests/copy.cpp
+++ b/tests/copy.cpp
@@ -21,7 +21,7 @@ namespace {
 
   template<class Real>
   struct MakeVectorValues {
-    static std::pair<Real, Real> make(const ptrdiff_t k) {
+    static std::pair<Real, Real> make(const std::size_t k) {
       const Real x_k = Real(k) + Real(1.0);
       const Real y_k = Real(k) + Real(2.0);
       return {x_k, y_k};
@@ -31,7 +31,7 @@ namespace {
   template<class Real>
   struct MakeVectorValues<std::complex<Real>> {
     static std::pair<std::complex<Real>, std::complex<Real>>
-    make (const ptrdiff_t k) {
+    make (const std::size_t k) {
       const std::complex<Real> x_k(Real(k) + 4.0, -Real(k) - 1.0);
       const std::complex<Real> y_k(Real(k) + 5.0, -Real(k) - 2.0);
       return {x_k, y_k};
@@ -39,7 +39,7 @@ namespace {
   };
 
   template<class Scalar>
-  std::pair<Scalar, Scalar> makeVectorValues(const ptrdiff_t k) {
+  std::pair<Scalar, Scalar> makeVectorValues(const std::size_t k) {
     return MakeVectorValues<Scalar>::make(k);
   }
 
@@ -48,21 +48,21 @@ namespace {
     using scalar_t = double;
     using vector_t = mdspan<scalar_t, extents<dynamic_extent>>;
 
-    constexpr ptrdiff_t vectorSize(5);
-    constexpr ptrdiff_t storageSize = ptrdiff_t(2) * vectorSize;
+    constexpr std::size_t vectorSize(5);
+    constexpr std::size_t storageSize = std::size_t(2) * vectorSize;
     std::vector<scalar_t> storage(storageSize);
 
     vector_t x(storage.data(), vectorSize);
     vector_t y(storage.data() + vectorSize, vectorSize);
 
-    for (ptrdiff_t k = 0; k < vectorSize; ++k) {
+    for (std::size_t k = 0; k < vectorSize; ++k) {
       const auto vals = makeVectorValues<scalar_t>(k);
       x(k) = vals.first;
       y(k) = vals.second;
     }
 
     copy(x, y);
-    for (ptrdiff_t k = 0; k < vectorSize; ++k) {
+    for (std::size_t k = 0; k < vectorSize; ++k) {
       const auto vals = makeVectorValues<scalar_t>(k);
       // Make sure the function didn't modify the input.
       EXPECT_EQ( x(k), vals.first );
@@ -76,21 +76,21 @@ namespace {
     using scalar_t = std::complex<real_t>;
     using vector_t = mdspan<scalar_t, extents<dynamic_extent>>;
 
-    constexpr ptrdiff_t vectorSize(5);
-    constexpr ptrdiff_t storageSize = ptrdiff_t(2) * vectorSize;
+    constexpr std::size_t vectorSize(5);
+    constexpr std::size_t storageSize = std::size_t(2) * vectorSize;
     std::vector<scalar_t> storage(storageSize);
 
     vector_t x(storage.data(), vectorSize);
     vector_t y(storage.data() + vectorSize, vectorSize);
 
-    for (ptrdiff_t k = 0; k < vectorSize; ++k) {
+    for (std::size_t k = 0; k < vectorSize; ++k) {
       const auto vals = makeVectorValues<scalar_t>(k);
       x(k) = vals.first;
       y(k) = vals.second;
     }
 
     copy(x, y);
-    for (ptrdiff_t k = 0; k < vectorSize; ++k) {
+    for (std::size_t k = 0; k < vectorSize; ++k) {
       const auto vals = makeVectorValues<scalar_t>(k);
       // Make sure the function didn't modify the input.
       EXPECT_EQ( x(k), vals.first );
@@ -102,7 +102,7 @@ namespace {
 template<class Real>
 struct MakeMatrixValues {
   static std::pair<Real, Real>
-  make(const ptrdiff_t i, const ptrdiff_t j, const ptrdiff_t numRows) {
+  make(const std::size_t i, const std::size_t j, const std::size_t numRows) {
     const Real A_ij = (Real(i) + Real(1.0)) +
       Real(numRows) * (Real(j) + Real(1.0));
     const Real B_ij = Real(i) + Real(2.0) +
@@ -114,7 +114,7 @@ struct MakeMatrixValues {
 template<class Real>
 struct MakeMatrixValues<std::complex<Real>> {
   static std::pair<std::complex<Real>, std::complex<Real>>
-  make(const ptrdiff_t i, const ptrdiff_t j, const ptrdiff_t numRows) {
+  make(const std::size_t i, const std::size_t j, const std::size_t numRows) {
     using scalar_t = std::complex<Real>;
     const scalar_t A_i(Real(i) + 4.0, -Real(i) - 1.0);
     const scalar_t B_i(Real(i) + 5.0, -Real(i) - 2.0);
@@ -129,7 +129,7 @@ struct MakeMatrixValues<std::complex<Real>> {
 
 template<class Scalar>
 std::pair<Scalar, Scalar>
-makeMatrixValues(const ptrdiff_t i, const ptrdiff_t j, const ptrdiff_t numRows) {
+makeMatrixValues(const std::size_t i, const std::size_t j, const std::size_t numRows) {
   return MakeMatrixValues<Scalar>::make(i, j, numRows);
 }
 
@@ -138,16 +138,16 @@ TEST(BLAS1_copy_matrix, mdspan_double)
   using scalar_t = double;
   using matrix_t = mdspan<scalar_t, extents<dynamic_extent, dynamic_extent>>;
 
-  constexpr ptrdiff_t numRows(5);
-  constexpr ptrdiff_t numCols(4);
-  constexpr ptrdiff_t storageSize = ptrdiff_t(2) * ptrdiff_t(numRows*numCols);
+  constexpr std::size_t numRows(5);
+  constexpr std::size_t numCols(4);
+  constexpr std::size_t storageSize = std::size_t(2) * std::size_t(numRows*numCols);
   std::vector<scalar_t> storage(storageSize);
 
   matrix_t A(storage.data(), numRows, numCols);
   matrix_t B(storage.data() + numRows*numCols, numRows, numCols);
 
-  for (ptrdiff_t j = 0; j < numCols; ++j) {
-    for (ptrdiff_t i = 0; i < numRows; ++i) {
+  for (std::size_t j = 0; j < numCols; ++j) {
+    for (std::size_t i = 0; i < numRows; ++i) {
       const auto vals = makeMatrixValues<scalar_t>(i, j, numRows);
       A(i,j) = vals.first;
       B(i,j) = vals.second;
@@ -155,8 +155,8 @@ TEST(BLAS1_copy_matrix, mdspan_double)
   }
 
   copy(A, B);
-  for (ptrdiff_t j = 0; j < numCols; ++j) {
-    for (ptrdiff_t i = 0; i < numRows; ++i) {
+  for (std::size_t j = 0; j < numCols; ++j) {
+    for (std::size_t i = 0; i < numRows; ++i) {
       const auto vals = makeMatrixValues<scalar_t>(i, j, numRows);
       // Make sure the function didn't modify the input.
       EXPECT_EQ( A(i,j), vals.first );
@@ -171,16 +171,16 @@ TEST(BLAS1_copy_matrix, mdspan_complex_double)
   using scalar_t = std::complex<real_t>;
   using matrix_t = mdspan<scalar_t, extents<dynamic_extent, dynamic_extent>>;
 
-  constexpr ptrdiff_t numRows(5);
-  constexpr ptrdiff_t numCols(4);
-  constexpr ptrdiff_t storageSize = ptrdiff_t(2) * ptrdiff_t(numRows*numCols);
+  constexpr std::size_t numRows(5);
+  constexpr std::size_t numCols(4);
+  constexpr std::size_t storageSize = std::size_t(2) * std::size_t(numRows*numCols);
   std::vector<scalar_t> storage(storageSize);
 
   matrix_t A(storage.data(), numRows, numCols);
   matrix_t B(storage.data() + numRows*numCols, numRows, numCols);
 
-  for (ptrdiff_t j = 0; j < numCols; ++j) {
-    for (ptrdiff_t i = 0; i < numRows; ++i) {
+  for (std::size_t j = 0; j < numCols; ++j) {
+    for (std::size_t i = 0; i < numRows; ++i) {
       const auto vals = makeMatrixValues<scalar_t>(i, j, numRows);
       A(i,j) = vals.first;
       B(i,j) = vals.second;
@@ -188,8 +188,8 @@ TEST(BLAS1_copy_matrix, mdspan_complex_double)
   }
 
   copy(A, B);
-  for (ptrdiff_t j = 0; j < numCols; ++j) {
-    for (ptrdiff_t i = 0; i < numRows; ++i) {
+  for (std::size_t j = 0; j < numCols; ++j) {
+    for (std::size_t i = 0; i < numRows; ++i) {
       const auto vals = makeMatrixValues<scalar_t>(i, j, numRows);
       // Make sure the function didn't modify the input.
       EXPECT_EQ( A(i,j), vals.first );

--- a/tests/dot.cpp
+++ b/tests/dot.cpp
@@ -37,15 +37,15 @@ namespace {
     using scalar_t = double;
     using vector_t = mdspan<scalar_t, extents<dynamic_extent>>;
 
-    constexpr ptrdiff_t vectorSize(5);
-    constexpr ptrdiff_t storageSize = ptrdiff_t(2) * vectorSize;
+    constexpr std::size_t vectorSize(5);
+    constexpr std::size_t storageSize = std::size_t(2) * vectorSize;
     std::vector<scalar_t> storage(storageSize);
 
     vector_t x(storage.data(), vectorSize);
     vector_t y(storage.data() + vectorSize, vectorSize);
 
     scalar_t expectedDotResult{};
-    for (ptrdiff_t k = 0; k < vectorSize; ++k) {
+    for (std::size_t k = 0; k < vectorSize; ++k) {
       const scalar_t x_k = scalar_t(k) + 1.0;
       const scalar_t y_k = scalar_t(k) + 2.0;
       x(k) = x_k;
@@ -68,9 +68,9 @@ namespace {
 #ifdef LINALG_ENABLE_BLAS
     const scalar_t blasResult =
       ddot_wrapper(x.extent(0), x.data(), 1, y.data(), 1);
-    EXPECT_EQ( dotResult, blasResult );    
+    EXPECT_EQ( dotResult, blasResult );
 #endif // LINALG_ENABLE_BLAS
-    
+
     const scalar_t conjDotResult = dotc(x, y, scalar_t{});
     EXPECT_EQ( conjDotResult, expectedDotResult );
 
@@ -90,8 +90,8 @@ namespace {
     using scalar_t = std::complex<real_t>;
     using vector_t = mdspan<scalar_t, extents<dynamic_extent>>;
 
-    constexpr ptrdiff_t vectorSize(5);
-    constexpr ptrdiff_t storageSize = ptrdiff_t(2) * vectorSize;
+    constexpr std::size_t vectorSize(5);
+    constexpr std::size_t storageSize = std::size_t(2) * vectorSize;
     std::vector<scalar_t> storage(storageSize);
 
     vector_t x(storage.data(), vectorSize);
@@ -99,7 +99,7 @@ namespace {
 
     scalar_t expectedDotResult{};
     scalar_t expectedConjDotResult{};
-    for (ptrdiff_t k = 0; k < vectorSize; ++k) {
+    for (std::size_t k = 0; k < vectorSize; ++k) {
       const scalar_t x_k(real_t(k) + 1.0, real_t(k) + 1.0);
       const scalar_t y_k(real_t(k) + 2.0, real_t(k) + 2.0);
       x(k) = x_k;

--- a/tests/gemm.cpp
+++ b/tests/gemm.cpp
@@ -32,10 +32,10 @@ namespace {
   struct FillMatrix<MdspanType, int> {
     static void fill(MdspanType A, const int startVal)
     {
-      const ptrdiff_t A_numRows = A.extent(0);
-      const ptrdiff_t A_numCols = A.extent(1);
-      for (ptrdiff_t j = 0; j < A_numCols; ++j) {
-        for (ptrdiff_t i = 0; i < A_numRows; ++i) {
+      const std::size_t A_numRows = A.extent(0);
+      const std::size_t A_numCols = A.extent(1);
+      for (std::size_t j = 0; j < A_numCols; ++j) {
+        for (std::size_t i = 0; i < A_numRows; ++i) {
           A(i,j) = int((i+startVal) + (j+startVal) * A_numRows);
         }
       }
@@ -46,10 +46,10 @@ namespace {
   struct FillMatrix<MdspanType, double> {
     static void fill(MdspanType A, const double startVal)
     {
-      const ptrdiff_t A_numRows = A.extent(0);
-      const ptrdiff_t A_numCols = A.extent(1);
-      for (ptrdiff_t j = 0; j < A_numCols; ++j) {
-        for (ptrdiff_t i = 0; i < A_numRows; ++i) {
+      const std::size_t A_numRows = A.extent(0);
+      const std::size_t A_numCols = A.extent(1);
+      for (std::size_t j = 0; j < A_numCols; ++j) {
+        for (std::size_t i = 0; i < A_numRows; ++i) {
           A(i,j) = (double(i)+startVal) +
             (double(j)+startVal) * double(A_numRows);
         }
@@ -80,19 +80,19 @@ namespace {
     using extents_t = extents<dynamic_extent, dynamic_extent>;
     using matrix_t = mdspan<scalar_t, extents_t, layout_left>;
 
-    constexpr ptrdiff_t maxDim = 7;
-    constexpr ptrdiff_t storageSize(7*maxDim*maxDim);
+    constexpr std::size_t maxDim = 7;
+    constexpr std::size_t storageSize(7*maxDim*maxDim);
     std::vector<scalar_t> storage(storageSize);
 
-    for (ptrdiff_t C_numRows : {1, 4, 7}) {
-      for (ptrdiff_t C_numCols : {1, 4, 7}) {
-        for (ptrdiff_t A_numCols : {1, 4, 7}) {
+    for (std::size_t C_numRows : {1, 4, 7}) {
+      for (std::size_t C_numCols : {1, 4, 7}) {
+        for (std::size_t A_numCols : {1, 4, 7}) {
 
-          const ptrdiff_t A_numRows = C_numRows;
-          const ptrdiff_t B_numRows = A_numCols;
-          const ptrdiff_t B_numCols = C_numCols;
+          const std::size_t A_numRows = C_numRows;
+          const std::size_t B_numRows = A_numCols;
+          const std::size_t B_numCols = C_numCols;
 
-          ptrdiff_t offset = 0;
+          std::size_t offset = 0;
           matrix_t A(storage.data() + offset, A_numRows, A_numCols);
           offset += A_numRows * A_numCols;
           matrix_t B(storage.data() + offset, B_numRows, B_numCols);
@@ -110,21 +110,21 @@ namespace {
 
           fill_matrix(A, scalar_t(real_t(1)));
           fill_matrix(B, scalar_t(real_t(2)));
-          for (ptrdiff_t j = 0; j < A_numCols; ++j) {
-            for (ptrdiff_t i = 0; i < A_numRows; ++i) {
+          for (std::size_t j = 0; j < A_numCols; ++j) {
+            for (std::size_t i = 0; i < A_numRows; ++i) {
               A_t(j,i) = A(i,j);
             }
           }
-          for (ptrdiff_t j = 0; j < B_numCols; ++j) {
-            for (ptrdiff_t i = 0; i < B_numRows; ++i) {
+          for (std::size_t j = 0; j < B_numCols; ++j) {
+            for (std::size_t i = 0; i < B_numRows; ++i) {
               B_t(j,i) = B(i,j);
             }
           }
 
-          for (ptrdiff_t j = 0; j < C_numCols; ++j) {
-            for (ptrdiff_t i = 0; i < C_numRows; ++i) {
+          for (std::size_t j = 0; j < C_numCols; ++j) {
+            for (std::size_t i = 0; i < C_numRows; ++i) {
               C(i,j) = scalar_t(0.0); // this works even for complex
-              for (ptrdiff_t k = 0; k < A_numCols; ++k) {
+              for (std::size_t k = 0; k < A_numCols; ++k) {
                 C(i,j) += A(i,k) * B(k,j);
               }
             }
@@ -132,8 +132,8 @@ namespace {
 
           // Fill result matrix with flag values to make sure that we
           // computed everything.
-          for (ptrdiff_t j = 0; j < C_numCols; ++j) {
-            for (ptrdiff_t i = 0; i < C_numRows; ++i) {
+          for (std::size_t j = 0; j < C_numCols; ++j) {
+            for (std::size_t i = 0; i < C_numRows; ++i) {
               C2(i,j) = std::numeric_limits<scalar_t>::min();
             }
           }
@@ -143,17 +143,17 @@ namespace {
                << ") * B(" << B_numRows << " x " << B_numCols
                << ")" << endl;
           matrix_product(A, B, C2);
-          for (ptrdiff_t j = 0; j < C_numCols; ++j) {
-            for (ptrdiff_t i = 0; i < C_numRows; ++i) {
-              EXPECT_DOUBLE_EQ(C2(i,j), C(i,j)) << "Matrices differ at index (" 
+          for (std::size_t j = 0; j < C_numCols; ++j) {
+            for (std::size_t i = 0; i < C_numRows; ++i) {
+              EXPECT_DOUBLE_EQ(C2(i,j), C(i,j)) << "Matrices differ at index ("
                   << i << "," << j << ")=\n";
             }
           }
 
           // Fill result matrix with flag values to make sure that
           // we computed everything.
-          for (ptrdiff_t j = 0; j < C_numCols; ++j) {
-            for (ptrdiff_t i = 0; i < C_numRows; ++i) {
+          for (std::size_t j = 0; j < C_numCols; ++j) {
+            for (std::size_t i = 0; i < C_numRows; ++i) {
               C3(i,j) = std::numeric_limits<scalar_t>::min();
             }
           }
@@ -166,9 +166,9 @@ namespace {
                << ")^T" << endl;
           matrix_product(transposed(A_t),
                          transposed(B_t), C3);
-          for (ptrdiff_t j = 0; j < C_numCols; ++j) {
-            for (ptrdiff_t i = 0; i < C_numRows; ++i) {
-              EXPECT_DOUBLE_EQ(C3(i,j), C(i,j)) << "Matrices differ at index (" 
+          for (std::size_t j = 0; j < C_numCols; ++j) {
+            for (std::size_t i = 0; i < C_numRows; ++i) {
+              EXPECT_DOUBLE_EQ(C3(i,j), C(i,j)) << "Matrices differ at index ("
                   << i << "," << j << ")=\n";
             }
           }
@@ -184,8 +184,8 @@ namespace {
             EXPECT_EQ(B_t.extent(1), B.extent(0));
             EXPECT_EQ(A_tt.extent(1), B_tt.extent(0));
 
-            for (ptrdiff_t j = 0; j < C_numCols; ++j) {
-              for (ptrdiff_t i = 0; i < C_numRows; ++i) {
+            for (std::size_t j = 0; j < C_numCols; ++j) {
+              for (std::size_t i = 0; i < C_numRows; ++i) {
                 C(i,j) = scalar_t(0.0); // this works even for complex
                 for (extents<>::size_type k = 0; k < A_tt.extent(1); ++k) {
                   C(i,j) += A_tt(i,k) * B_tt(k,j);
@@ -197,9 +197,9 @@ namespace {
           cout << " Compare using hand-rolled transposed loop"
                << endl;
 
-          for (ptrdiff_t j = 0; j < C_numCols; ++j) {
-            for (ptrdiff_t i = 0; i < C_numRows; ++i) {
-              EXPECT_DOUBLE_EQ(C3(i,j), C(i,j)) << "Matrices differ at index (" 
+          for (std::size_t j = 0; j < C_numCols; ++j) {
+            for (std::size_t i = 0; i < C_numRows; ++i) {
+              EXPECT_DOUBLE_EQ(C3(i,j), C(i,j)) << "Matrices differ at index ("
                 << i << "," << j << ")=\n";
             }
           }
@@ -213,10 +213,10 @@ namespace {
           matrix_product(scaled(scalar_t(2.0), transposed(A_t)),
                          transposed(B_t), C3);
 
-          for (ptrdiff_t j = 0; j < C_numCols; ++j) {
-            for (ptrdiff_t i = 0; i < C_numRows; ++i) {
-              EXPECT_DOUBLE_EQ(C3(i,j), scalar_t(2.0)*C(i,j)) 
-                << "Matrices differ at index (" 
+          for (std::size_t j = 0; j < C_numCols; ++j) {
+            for (std::size_t i = 0; i < C_numRows; ++i) {
+              EXPECT_DOUBLE_EQ(C3(i,j), scalar_t(2.0)*C(i,j))
+                << "Matrices differ at index ("
                 << i << "," << j << ")=\n";
             }
           }

--- a/tests/gemv.cpp
+++ b/tests/gemv.cpp
@@ -24,10 +24,10 @@ namespace {
   struct FillMatrix<MdspanType, int> {
     static void fill(MdspanType A, const int startVal)
     {
-      const ptrdiff_t A_numRows = A.extent(0);
-      const ptrdiff_t A_numCols = A.extent(1);
-      for (ptrdiff_t j = 0; j < A_numCols; ++j) {
-        for (ptrdiff_t i = 0; i < A_numRows; ++i) {
+      const std::size_t A_numRows = A.extent(0);
+      const std::size_t A_numCols = A.extent(1);
+      for (std::size_t j = 0; j < A_numCols; ++j) {
+        for (std::size_t i = 0; i < A_numRows; ++i) {
           A(i,j) = int((i+startVal) + (j+startVal) * A_numRows);
         }
       }
@@ -38,10 +38,10 @@ namespace {
   struct FillMatrix<MdspanType, double> {
     static void fill(MdspanType A, const double startVal)
     {
-      const ptrdiff_t A_numRows = A.extent(0);
-      const ptrdiff_t A_numCols = A.extent(1);
-      for (ptrdiff_t j = 0; j < A_numCols; ++j) {
-        for (ptrdiff_t i = 0; i < A_numRows; ++i) {
+      const std::size_t A_numRows = A.extent(0);
+      const std::size_t A_numCols = A.extent(1);
+      for (std::size_t j = 0; j < A_numCols; ++j) {
+        for (std::size_t i = 0; i < A_numRows; ++i) {
           A(i,j) = (double(i)+startVal) +
             (double(j)+startVal) * double(A_numRows);
         }
@@ -63,8 +63,8 @@ namespace {
   struct FillVector<MdspanType, int> {
     static void fill(MdspanType x, const int startVal)
     {
-      const ptrdiff_t numRows = x.extent(0);
-      for (ptrdiff_t i = 0; i < numRows; ++i) {
+      const std::size_t numRows = x.extent(0);
+      for (std::size_t i = 0; i < numRows; ++i) {
         x(i) = int(i+startVal);
       }
     }
@@ -74,8 +74,8 @@ namespace {
   struct FillVector<MdspanType, double> {
     static void fill(MdspanType x, const double startVal)
     {
-      const ptrdiff_t numRows = x.extent(0);
-      for (ptrdiff_t i = 0; i < numRows; ++i) {
+      const std::size_t numRows = x.extent(0);
+      for (std::size_t i = 0; i < numRows; ++i) {
         x(i) = double(i+startVal);
       }
     }
@@ -105,13 +105,13 @@ namespace {
     using matrix_t = mdspan<scalar_t, extents_t, layout_left>;
     using vector_t = mdspan<scalar_t, extents<dynamic_extent>, layout_left>;
 
-    constexpr ptrdiff_t maxDim = 7;
-    constexpr ptrdiff_t storageSize(maxDim*maxDim + 3*maxDim);
+    constexpr std::size_t maxDim = 7;
+    constexpr std::size_t storageSize(maxDim*maxDim + 3*maxDim);
     std::vector<scalar_t> storage(storageSize);
 
-    for (ptrdiff_t numRows : {1, 4, 7}) {
-      for (ptrdiff_t numCols : {1, 4, 7}) {
-        ptrdiff_t offset = 0;
+    for (std::size_t numRows : {1, 4, 7}) {
+      for (std::size_t numCols : {1, 4, 7}) {
+        std::size_t offset = 0;
         matrix_t A(storage.data() + offset, numRows, numCols);
         offset += numRows * numCols;
         vector_t x(storage.data() + offset, numCols);
@@ -124,27 +124,27 @@ namespace {
         fill_vector(x, scalar_t(real_t(2)));
 
         // Initialize vector to zero
-        for (ptrdiff_t i = 0; i < numRows; i++) {
+        for (std::size_t i = 0; i < numRows; i++) {
           gs(i) = scalar_t(0.0); // this works even for complex
         }
 
         // Perform matvec
-        for (ptrdiff_t j = 0; j < numCols; ++j) {
-          for (ptrdiff_t i = 0; i < numRows; ++i) {
+        for (std::size_t j = 0; j < numCols; ++j) {
+          for (std::size_t i = 0; i < numRows; ++i) {
             gs(i) += A(i,j) * x(j);
           }
         }
 
         // Fill result vector with flag values to make sure that we
         // computed everything.
-        for (ptrdiff_t j = 0; j < numRows; ++j) {
+        for (std::size_t j = 0; j < numRows; ++j) {
           y(j) = std::numeric_limits<scalar_t>::min();
         }
 
         cout << " Test y = A(" << numRows << " x " << numCols
              << ") * x = y\n";
         matrix_vector_product(A, x, y);
-        for (ptrdiff_t i = 0; i < numRows; ++i) {
+        for (std::size_t i = 0; i < numRows; ++i) {
           EXPECT_DOUBLE_EQ(y(i), gs(i)) << "Vectors differ at index " << i;
         }
       } // numCols

--- a/tests/givens.cpp
+++ b/tests/givens.cpp
@@ -157,14 +157,14 @@ namespace {
     using scalar_t = real_t;
     using vector_t = mdspan<scalar_t, extents<dynamic_extent>>;
 
-    constexpr ptrdiff_t vectorSize(5);
-    constexpr ptrdiff_t storageSize = ptrdiff_t(2) * vectorSize;
+    constexpr std::size_t vectorSize(5);
+    constexpr std::size_t storageSize = std::size_t(2) * vectorSize;
     std::vector<scalar_t> storage(storageSize);
 
     vector_t x(storage.data(), vectorSize);
     vector_t y(storage.data() + vectorSize, vectorSize);
 
-    for (ptrdiff_t k = 0; k < vectorSize; ++k) {
+    for (std::size_t k = 0; k < vectorSize; ++k) {
       const scalar_t x_k(real_t(k) + 4.0);
       const scalar_t y_k(real_t(k) + 5.0);
       x(k) = x_k;
@@ -176,7 +176,7 @@ namespace {
       const scalar_t s(0.0);
 
       givens_rotation_apply(x, y, c, s);
-      for (ptrdiff_t k = 0; k < vectorSize; ++k) {
+      for (std::size_t k = 0; k < vectorSize; ++k) {
         scalar_t x_k(real_t(k) + 4.0);
         scalar_t y_k(real_t(k) + 5.0);
 
@@ -193,7 +193,7 @@ namespace {
       const scalar_t s(1.0);
 
       givens_rotation_apply(x, y, c, s);
-      for (ptrdiff_t k = 0; k < vectorSize; ++k) {
+      for (std::size_t k = 0; k < vectorSize; ++k) {
         scalar_t x_k(real_t(k) + 4.0);
         scalar_t y_k(real_t(k) + 5.0);
 
@@ -213,14 +213,14 @@ namespace {
     using scalar_t = std::complex<real_t>;
     using vector_t = mdspan<scalar_t, extents<dynamic_extent>>;
 
-    constexpr ptrdiff_t vectorSize(5);
-    constexpr ptrdiff_t storageSize = ptrdiff_t(2) * vectorSize;
+    constexpr std::size_t vectorSize(5);
+    constexpr std::size_t storageSize = std::size_t(2) * vectorSize;
     std::vector<scalar_t> storage(storageSize);
 
     vector_t x(storage.data(), vectorSize);
     vector_t y(storage.data() + vectorSize, vectorSize);
 
-    for (ptrdiff_t k = 0; k < vectorSize; ++k) {
+    for (std::size_t k = 0; k < vectorSize; ++k) {
       const scalar_t x_k(real_t(k) + 4.0, -real_t(k) - 1.0);
       const scalar_t y_k(real_t(k) + 5.0, -real_t(k) - 2.0);
       x(k) = x_k;
@@ -234,7 +234,7 @@ namespace {
       const scalar_t s(0.0, 0.0);
 
       givens_rotation_apply(x, y, c, s);
-      for (ptrdiff_t k = 0; k < vectorSize; ++k) {
+      for (std::size_t k = 0; k < vectorSize; ++k) {
         scalar_t x_k(real_t(k) + 4.0, -real_t(k) - 1.0);
         scalar_t y_k(real_t(k) + 5.0, -real_t(k) - 2.0);
 
@@ -251,7 +251,7 @@ namespace {
       const scalar_t s(1.0, 0.0);
 
       givens_rotation_apply(x, y, c, s);
-      for (ptrdiff_t k = 0; k < vectorSize; ++k) {
+      for (std::size_t k = 0; k < vectorSize; ++k) {
         scalar_t x_k(real_t(k) + 4.0, -real_t(k) - 1.0);
         scalar_t y_k(real_t(k) + 5.0, -real_t(k) - 2.0);
 

--- a/tests/matrix_inf_norm.cpp
+++ b/tests/matrix_inf_norm.cpp
@@ -11,10 +11,10 @@ namespace {
   using std::experimental::linalg::matrix_inf_norm;
   using std::cout;
   using std::endl;
-  
+
   template<class ElementType, class Layout>
   using basic_matrix_t = std::experimental::mdspan<
-    ElementType, 
+    ElementType,
     std::experimental::extents<
       std::experimental::dynamic_extent,
       std::experimental::dynamic_extent>,
@@ -77,7 +77,7 @@ namespace {
         // to avoid a possible bug in the current mdspan implementation,
         // and/or an MSVC bug.  I'll need to check more recent MSVC versions;
         // I'm building right now with MSVC 2019 16.7.0.
-        matrix_t A(storage.data(), ptrdiff_t(A_numRows), ptrdiff_t(A_numCols));
+        matrix_t A(storage.data(), std::size_t(A_numRows), std::size_t(A_numCols));
 
         const auto startVal = scalar_t(real_t<scalar_t>(1.0));
         const real_t<scalar_t> expectedResult = fill_matrix(A, startVal);

--- a/tests/matrix_one_norm.cpp
+++ b/tests/matrix_one_norm.cpp
@@ -14,10 +14,10 @@ namespace {
   using std::experimental::linalg::matrix_one_norm;
   using std::cout;
   using std::endl;
-  
+
   template<class ElementType, class Layout>
   using basic_matrix_t = std::experimental::mdspan<
-    ElementType, 
+    ElementType,
     std::experimental::extents<
       std::experimental::dynamic_extent,
       std::experimental::dynamic_extent>,
@@ -80,7 +80,7 @@ namespace {
         // to avoid a possible bug in the current mdspan implementation,
         // and/or an MSVC bug.  I'll need to check more recent MSVC versions;
         // I'm building right now with MSVC 2019 16.7.0.
-        matrix_t A(storage.data(), ptrdiff_t(A_numRows), ptrdiff_t(A_numCols));
+        matrix_t A(storage.data(), std::size_t(A_numRows), std::size_t(A_numCols));
 
         const auto startVal = scalar_t(real_t<scalar_t>(1.0));
         const real_t<scalar_t> expectedResult = fill_matrix(A, startVal);

--- a/tests/norm2.cpp
+++ b/tests/norm2.cpp
@@ -38,7 +38,7 @@ namespace {
     using scalar_t = double;
     using vector_t = mdspan<scalar_t, extents<dynamic_extent>>;
 
-    constexpr ptrdiff_t vectorSize(0);
+    constexpr std::size_t vectorSize(0);
     std::vector<scalar_t> storage(vectorSize);
     vector_t x(storage.data(), vectorSize);
 
@@ -68,7 +68,7 @@ namespace {
     using scalar_t = std::complex<real_t>;
     using vector_t = mdspan<scalar_t, extents<dynamic_extent>>;
 
-    constexpr ptrdiff_t vectorSize(1);
+    constexpr std::size_t vectorSize(1);
     std::vector<scalar_t> storage(vectorSize);
     vector_t x(storage.data(), vectorSize);
 
@@ -98,18 +98,18 @@ namespace {
     using scalar_t = double;
     using vector_t = mdspan<scalar_t, extents<dynamic_extent>>;
 
-    constexpr ptrdiff_t vectorSize(5);
+    constexpr std::size_t vectorSize(5);
     constexpr mag_t tol =
       mag_t(vectorSize) * std::numeric_limits<mag_t>::epsilon();
 
-    constexpr ptrdiff_t storageSize = vectorSize;
+    constexpr std::size_t storageSize = vectorSize;
     std::vector<scalar_t> storage(storageSize);
 
     vector_t x(storage.data(), vectorSize);
 
     // Set elements in descending order so the scaling triggers
     mag_t expectedNormResultSquared {};
-    for (ptrdiff_t k = vectorSize; k > 1; --k) {
+    for (std::size_t k = vectorSize; k > 1; --k) {
       const scalar_t x_k = scalar_t(k);
       x(k-1) = x_k;
       expectedNormResultSquared += x_k * x_k;
@@ -139,18 +139,18 @@ namespace {
     using scalar_t = std::complex<real_t>;
     using vector_t = mdspan<scalar_t, extents<dynamic_extent>>;
 
-    constexpr ptrdiff_t vectorSize(5);
+    constexpr std::size_t vectorSize(5);
     // Complex numbers use more arithmetic than their real analogs.
     constexpr mag_t tol = 4.0 * mag_t(vectorSize) *
       std::numeric_limits<mag_t>::epsilon();
 
-    constexpr ptrdiff_t storageSize = vectorSize;
+    constexpr std::size_t storageSize = vectorSize;
     std::vector<scalar_t> storage(storageSize);
 
     vector_t x(storage.data(), vectorSize);
 
     mag_t expectedNormResultSquared {};
-    for (ptrdiff_t k = 0; k < vectorSize; ++k) {
+    for (std::size_t k = 0; k < vectorSize; ++k) {
       const scalar_t x_k(real_t(k) + 3.0, -real_t(k) - 1.0);
       x(k) = x_k;
       expectedNormResultSquared += abs(x_k) * abs(x_k);

--- a/tests/scale.cpp
+++ b/tests/scale.cpp
@@ -23,32 +23,32 @@ namespace {
     using scalar_t = double;
     using vector_t = mdspan<scalar_t, extents<dynamic_extent>>;
 
-    constexpr ptrdiff_t vectorSize(5);
-    constexpr ptrdiff_t storageSize = vectorSize;
+    constexpr std::size_t vectorSize(5);
+    constexpr std::size_t storageSize = vectorSize;
     std::vector<scalar_t> storage(storageSize);
 
     vector_t x(storage.data(), vectorSize);
 
     {
-      for (ptrdiff_t k = 0; k < vectorSize; ++k) {
+      for (std::size_t k = 0; k < vectorSize; ++k) {
         const scalar_t x_k = scalar_t (k) + 1.0;
         x(k) = x_k;
       }
       const scalar_t scaleFactor = 5.0;
       scale(scaleFactor, x);
-      for (ptrdiff_t k = 0; k < vectorSize; ++k) {
+      for (std::size_t k = 0; k < vectorSize; ++k) {
         const scalar_t x_k = scalar_t (k) + 1.0;
         EXPECT_EQ( x(k), scaleFactor * x_k );
       }
     }
     {
-      for (ptrdiff_t k = 0; k < vectorSize; ++k) {
+      for (std::size_t k = 0; k < vectorSize; ++k) {
         const scalar_t x_k = scalar_t (k) + 1.0;
         x(k) = x_k;
       }
       const float scaleFactor = 5.0;
       scale(scaleFactor, x);
-      for (ptrdiff_t k = 0; k < vectorSize; ++k) {
+      for (std::size_t k = 0; k < vectorSize; ++k) {
         const scalar_t x_k = scalar_t (k) + 1.0;
         EXPECT_EQ( x(k), scaleFactor * x_k );
       }
@@ -61,32 +61,32 @@ namespace {
     using scalar_t = std::complex<real_t>;
     using vector_t = mdspan<scalar_t, extents<dynamic_extent>>;
 
-    constexpr ptrdiff_t vectorSize(5);
-    constexpr ptrdiff_t storageSize = vectorSize;
+    constexpr std::size_t vectorSize(5);
+    constexpr std::size_t storageSize = vectorSize;
     std::vector<scalar_t> storage(storageSize);
 
     vector_t x(storage.data(), vectorSize);
 
     {
-      for (ptrdiff_t k = 0; k < vectorSize; ++k) {
+      for (std::size_t k = 0; k < vectorSize; ++k) {
         const scalar_t x_k(real_t(k) + 4.0, -real_t(k) - 1.0);
         x(k) = x_k;
       }
       const real_t scaleFactor = 5.0;
       scale(scaleFactor, x);
-      for (ptrdiff_t k = 0; k < vectorSize; ++k) {
+      for (std::size_t k = 0; k < vectorSize; ++k) {
         const scalar_t x_k(real_t(k) + 4.0, -real_t(k) - 1.0);
         EXPECT_EQ( x(k), scaleFactor * x_k );
       }
     }
     {
-      for (ptrdiff_t k = 0; k < vectorSize; ++k) {
+      for (std::size_t k = 0; k < vectorSize; ++k) {
         const scalar_t x_k(real_t(k) + 4.0, -real_t(k) - 1.0);
         x(k) = x_k;
       }
       const scalar_t scaleFactor (5.0, -1.0);
       scale(scaleFactor, x);
-      for (ptrdiff_t k = 0; k < vectorSize; ++k) {
+      for (std::size_t k = 0; k < vectorSize; ++k) {
         const scalar_t x_k(real_t(k) + 4.0, -real_t(k) - 1.0);
         EXPECT_EQ( x(k), scaleFactor * x_k );
       }

--- a/tests/scaled.cpp
+++ b/tests/scaled.cpp
@@ -17,14 +17,14 @@ namespace {
     using vector_t =
       mdspan<vector_element_type, extents<dynamic_extent>>;
 
-    constexpr ptrdiff_t vectorSize (5);
-    constexpr ptrdiff_t storageSize = ptrdiff_t (2) * vectorSize;
+    constexpr std::size_t vectorSize (5);
+    constexpr std::size_t storageSize = std::size_t (2) * vectorSize;
     std::vector<vector_element_type> storage (storageSize);
 
     vector_t x (storage.data (), vectorSize);
     vector_t y (storage.data () + vectorSize, vectorSize);
 
-    for (ptrdiff_t k = 0; k < vectorSize; ++k) {
+    for (std::size_t k = 0; k < vectorSize; ++k) {
       const vector_element_type x_k = vector_element_type(k) + 1.0;
       const vector_element_type y_k = vector_element_type(k) + 2.0;
       x(k) = x_k;
@@ -44,7 +44,7 @@ namespace {
     }
 
     auto y_scaled = scaled (scalingFactor, y);
-    for (ptrdiff_t k = 0; k < vectorSize; ++k) {
+    for (std::size_t k = 0; k < vectorSize; ++k) {
       const vector_element_type x_k = vector_element_type(k) + 1.0;
       EXPECT_EQ( x(k), x_k );
 

--- a/tests/swap.cpp
+++ b/tests/swap.cpp
@@ -23,14 +23,14 @@ namespace {
     using scalar_t = double;
     using vector_t = mdspan<scalar_t, extents<dynamic_extent>>;
 
-    constexpr ptrdiff_t vectorSize(5);
-    constexpr ptrdiff_t storageSize = ptrdiff_t(2) * vectorSize;
+    constexpr std::size_t vectorSize(5);
+    constexpr std::size_t storageSize = std::size_t(2) * vectorSize;
     std::vector<scalar_t> storage(storageSize);
 
     vector_t x(storage.data(), vectorSize);
     vector_t y(storage.data() + vectorSize, vectorSize);
 
-    for (ptrdiff_t k = 0; k < vectorSize; ++k) {
+    for (std::size_t k = 0; k < vectorSize; ++k) {
       const scalar_t x_k = scalar_t (k) + 1.0;
       const scalar_t y_k = scalar_t (k) + 2.0;
       x(k) = x_k;
@@ -38,7 +38,7 @@ namespace {
     }
 
     swap_elements(x, y);
-    for (ptrdiff_t k = 0; k < vectorSize; ++k) {
+    for (std::size_t k = 0; k < vectorSize; ++k) {
       const scalar_t x_k = scalar_t (k) + 1.0;
       const scalar_t y_k = scalar_t (k) + 2.0;
       EXPECT_EQ( x(k), y_k );
@@ -52,14 +52,14 @@ namespace {
     using scalar_t = std::complex<real_t>;
     using vector_t = mdspan<scalar_t, extents<dynamic_extent>>;
 
-    constexpr ptrdiff_t vectorSize(5);
-    constexpr ptrdiff_t storageSize = ptrdiff_t(2) * vectorSize;
+    constexpr std::size_t vectorSize(5);
+    constexpr std::size_t storageSize = std::size_t(2) * vectorSize;
     std::vector<scalar_t> storage(storageSize);
 
     vector_t x(storage.data(), vectorSize);
     vector_t y(storage.data() + vectorSize, vectorSize);
 
-    for (ptrdiff_t k = 0; k < vectorSize; ++k) {
+    for (std::size_t k = 0; k < vectorSize; ++k) {
       const scalar_t x_k(real_t(k) + 4.0, -real_t(k) - 1.0);
       const scalar_t y_k(real_t(k) + 5.0, -real_t(k) - 2.0);
       x(k) = x_k;
@@ -67,7 +67,7 @@ namespace {
     }
 
     swap_elements(x, y);
-    for (ptrdiff_t k = 0; k < vectorSize; ++k) {
+    for (std::size_t k = 0; k < vectorSize; ++k) {
       const scalar_t x_k(real_t(k) + 4.0, -real_t(k) - 1.0);
       const scalar_t y_k(real_t(k) + 5.0, -real_t(k) - 2.0);
       EXPECT_EQ( x(k), y_k );

--- a/tests/transposed.cpp
+++ b/tests/transposed.cpp
@@ -15,22 +15,22 @@ namespace {
     using scalar_t = double;
     using matrix_dynamic_t =
       mdspan<scalar_t, extents<dynamic_extent, dynamic_extent>>;
-    constexpr ptrdiff_t dim = 5;
+    constexpr std::size_t dim = 5;
     using matrix_static_t =
       mdspan<scalar_t, extents<dim, dim>>;
 
-    constexpr ptrdiff_t storageSize = ptrdiff_t(dim*dim);
+    constexpr std::size_t storageSize = std::size_t(dim*dim);
     std::vector<scalar_t> A_storage (storageSize);
     std::vector<scalar_t> B_storage (storageSize);
 
     matrix_dynamic_t A (A_storage.data (), dim, dim);
     matrix_static_t B (B_storage.data ());
 
-    for (ptrdiff_t i = 0; i < dim; ++i) {
-      for (ptrdiff_t j = 0; j < dim; ++j) {
+    for (std::size_t i = 0; i < dim; ++i) {
+      for (std::size_t j = 0; j < dim; ++j) {
         const scalar_t i_val = scalar_t(i) + 1.0;
         // If we generalize this test so scalar_t can be complex, then
-        // we'll need the intermediate ptrdiff_t -> real_t conversion.
+        // we'll need the intermediate std::size_t -> real_t conversion.
         const scalar_t j_val = scalar_t(real_t(dim)) * (scalar_t(j) + 1.0);
         const scalar_t val = i_val + j_val;
 
@@ -42,8 +42,8 @@ namespace {
     auto A_t = transposed (A);
     auto B_t = transposed (B);
 
-    for (ptrdiff_t i = 0; i < dim; ++i) {
-      for (ptrdiff_t j = 0; j < dim; ++j) {
+    for (std::size_t i = 0; i < dim; ++i) {
+      for (std::size_t j = 0; j < dim; ++j) {
         const scalar_t i_val = scalar_t(i) + 1.0;
         // If we generalize this test so scalar_t can be complex, then
         // we'll need the intermediate ptrdiff_t -> real_t conversion.


### PR DESCRIPTION
- I replaced in all tests. 
- in the impl, I noticed that in some cases `ptrdiff_t` is used for valid reasons, so I have not touched the impl stuff