### PR TITLE
blas1 customization: address some PR comments

### DIFF
--- a/examples/kokkos-based/add_kokkos.cpp
+++ b/examples/kokkos-based/add_kokkos.cpp
@@ -39,7 +39,7 @@ int main(int argc, char* argv[])
     std::vector<value_type> gold(N);
     for(std::size_t i=0; i<x.extent(0); i++){
       x(i) = i;
-      y(i) = i + (value_type)10;
+      y(i) = i + static_cast<value_type>(10);
       z(i) = 0;
       gold[i] = x(i) + y(i);
     }

--- a/examples/kokkos-based/dotc_kokkos.cpp
+++ b/examples/kokkos-based/dotc_kokkos.cpp
@@ -20,9 +20,11 @@ int main(int argc, char* argv[])
     using mdspan_type  = std::experimental::mdspan<value_type, dyn_1d_ext_type>;
     mdspan_type a(a_ptr,N);
     mdspan_type b(b_ptr,N);
-    for(std::size_t i=0; i<a.extent(0); i++){
-      const value_type a_i(double(i) + 1.0, double(i) + 1.0);
-      const value_type b_i(double(i) - 2.0, double(i) - 2.0);
+    for(std::size_t i=0; i<a.extent(0); i++)
+    {
+      const auto i_double = static_cast<double>(i);
+      const value_type a_i(i_double + 1.0, i_double + 1.0);
+      const value_type b_i(i_double - 2.0, i_double - 2.0);
       a(i) = a_i;
       b(i) = b_i;
     }

--- a/examples/kokkos-based/vector_abs_sum_kokkos.cpp
+++ b/examples/kokkos-based/vector_abs_sum_kokkos.cpp
@@ -18,10 +18,10 @@ int main(int argc, char* argv[])
     mdspan_type x(x_ptr,N);
     for(std::size_t i=0; i<x.extent(0); i++){
       if (i % 2 == 0){
-	x(i) = i * (value_type) -1;
+	x(i) = i * static_cast<value_type>(-1);
       }
       else{
-	x(i) = (value_type) i;
+	x(i) = static_cast<value_type>(i);
       }
     }
 

--- a/examples/kokkos-based/vector_norm2_kokkos.cpp
+++ b/examples/kokkos-based/vector_norm2_kokkos.cpp
@@ -17,7 +17,7 @@ int main(int argc, char* argv[])
     using mdspan_type  = std::experimental::mdspan<value_type, dyn_1d_ext_type>;
     mdspan_type x(x_ptr,N);
     for(std::size_t i=0; i<x.extent(0); i++){
-      x(i) = (value_type) i;
+      x(i) = static_cast<value_type>(i);
     }
 
     namespace stdla = std::experimental::linalg;

--- a/include/experimental/__p1673_bits/blas1_dot.hpp
+++ b/include/experimental/__p1673_bits/blas1_dot.hpp
@@ -59,21 +59,29 @@ struct is_custom_dot_avail : std::false_type {};
 template <class Exec, class v1_t, class v2_t, class Scalar>
 struct is_custom_dot_avail<
   Exec, v1_t, v2_t, Scalar,
-  std::enable_if_t<
-    std::is_same<
-      decltype(dot
-	       (std::declval<Exec>(),
-		std::declval<v1_t>(),
-		std::declval<v2_t>(),
-		std::declval<Scalar>()
-		)
-	       ),
-      Scalar
-      >::value
+  std::void_t<
+    decltype(dot
+	     (std::declval<Exec>(),
+	      std::declval<v1_t>(),
+	      std::declval<v2_t>(),
+	      std::declval<Scalar>()
+	      )
+	     )
     >
   >
 {
-  static constexpr bool value = !std::is_same<Exec,std::experimental::linalg::impl::inline_exec_t>::value;
+  static constexpr bool has_matching_return_type = std::is_same_v<
+    Scalar,
+    decltype(
+	     dot(std::declval<Exec>(), std::declval<v1_t>(),
+		 std::declval<v2_t>(), std::declval<Scalar>())
+	     )
+    >;
+
+  static constexpr bool is_not_inline_exec_tag = !std::is_same_v<
+    Exec,std::experimental::linalg::impl::inline_exec_t>;
+
+  static constexpr bool value = has_matching_return_type && is_not_inline_exec_tag;
 };
 
 } // end anonymous namespace

--- a/include/experimental/__p1673_bits/blas1_givens.hpp
+++ b/include/experimental/__p1673_bits/blas1_givens.hpp
@@ -105,7 +105,7 @@ struct is_custom_givens_rotation_apply_avail<
     >
   >
 {
-  static constexpr bool value = !std::is_same<Exec,std::experimental::linalg::impl::inline_exec_t>::value;
+  static constexpr bool value = !std::is_same_v<Exec,std::experimental::linalg::impl::inline_exec_t>;
 };
 } // end anonymous namespace
 

--- a/include/experimental/__p1673_bits/blas1_linalg_add.hpp
+++ b/include/experimental/__p1673_bits/blas1_linalg_add.hpp
@@ -148,7 +148,7 @@ struct is_custom_add_avail<
     >
   >
 {
-  static constexpr bool value = !std::is_same<Exec,std::experimental::linalg::impl::inline_exec_t>::value;
+  static constexpr bool value = !std::is_same_v<Exec,std::experimental::linalg::impl::inline_exec_t>;
 };
 
 } // end anonymous namespace

--- a/include/experimental/__p1673_bits/blas1_linalg_copy.hpp
+++ b/include/experimental/__p1673_bits/blas1_linalg_copy.hpp
@@ -117,7 +117,7 @@ struct is_custom_copy_avail<
     >
   >
 {
-  static constexpr bool value = !std::is_same<Exec,std::experimental::linalg::impl::inline_exec_t>::value;
+  static constexpr bool value = !std::is_same_v<Exec,std::experimental::linalg::impl::inline_exec_t>;
 };
 
 } // end anonymous namespace

--- a/include/experimental/__p1673_bits/blas1_linalg_swap.hpp
+++ b/include/experimental/__p1673_bits/blas1_linalg_swap.hpp
@@ -122,9 +122,7 @@ struct is_custom_vector_swap_elements_avail<
   >
 {
   static constexpr bool value =
-    !std::is_same<Exec,
-		  std::experimental::linalg::impl::inline_exec_t
-		  >::value;
+    !std::is_same_v<Exec, std::experimental::linalg::impl::inline_exec_t>;
 };
 
 } // end anonymous namespace

--- a/include/experimental/__p1673_bits/blas1_matrix_frob_norm.hpp
+++ b/include/experimental/__p1673_bits/blas1_matrix_frob_norm.hpp
@@ -60,21 +60,27 @@ struct is_custom_matrix_frob_norm_avail : std::false_type {};
 template <class Exec, class A_t, class Scalar>
 struct is_custom_matrix_frob_norm_avail<
   Exec, A_t, Scalar,
-  std::enable_if_t<
-    std::is_same<
-      decltype(matrix_frob_norm
-	       (std::declval<Exec>(),
-		std::declval<A_t>(),
-		std::declval<Scalar>()
-		)
-	       ),
-      Scalar
-      >::value
+  std::void_t<
+    decltype(matrix_frob_norm
+	     (std::declval<Exec>(),
+	      std::declval<A_t>(),
+	      std::declval<Scalar>()
+	      )
+	     )
     >
   >
 {
-  static constexpr bool value =
-    !std::is_same<Exec, std::experimental::linalg::impl::inline_exec_t>::value;
+
+  static constexpr bool has_matching_return_type = std::is_same_v<
+    Scalar,
+    decltype(matrix_frob_norm(std::declval<Exec>(),
+			      std::declval<A_t>(),
+			      std::declval<Scalar>()))>;
+
+  static constexpr bool is_not_inline_exec_tag = !std::is_same_v<
+    Exec,std::experimental::linalg::impl::inline_exec_t>;
+
+  static constexpr bool value = has_matching_return_type && is_not_inline_exec_tag;
 };
 
 } // end anonymous namespace

--- a/include/experimental/__p1673_bits/blas1_matrix_inf_norm.hpp
+++ b/include/experimental/__p1673_bits/blas1_matrix_inf_norm.hpp
@@ -60,21 +60,27 @@ struct is_custom_matrix_inf_norm_avail : std::false_type {};
 template <class Exec, class A_t, class Scalar>
 struct is_custom_matrix_inf_norm_avail<
   Exec, A_t, Scalar,
-  std::enable_if_t<
-    std::is_same<
-      decltype(matrix_inf_norm
-	       (std::declval<Exec>(),
-		std::declval<A_t>(),
-		std::declval<Scalar>()
-		)
-	       ),
-      Scalar
-      >::value
+  std::void_t<
+    decltype(matrix_inf_norm
+	     (std::declval<Exec>(),
+	      std::declval<A_t>(),
+	      std::declval<Scalar>()
+	      )
+	     )
     >
   >
 {
-  static constexpr bool value =
-    !std::is_same<Exec, std::experimental::linalg::impl::inline_exec_t>::value;
+
+  static constexpr bool has_matching_return_type = std::is_same_v<
+    Scalar,
+    decltype(matrix_inf_norm(std::declval<Exec>(),
+			      std::declval<A_t>(),
+			      std::declval<Scalar>()))>;
+
+  static constexpr bool is_not_inline_exec_tag = !std::is_same_v<
+    Exec,std::experimental::linalg::impl::inline_exec_t>;
+
+  static constexpr bool value = has_matching_return_type && is_not_inline_exec_tag;
 };
 
 } // end anonymous namespace

--- a/include/experimental/__p1673_bits/blas1_matrix_one_norm.hpp
+++ b/include/experimental/__p1673_bits/blas1_matrix_one_norm.hpp
@@ -60,21 +60,27 @@ struct is_custom_matrix_one_norm_avail : std::false_type {};
 template <class Exec, class A_t, class Scalar>
 struct is_custom_matrix_one_norm_avail<
   Exec, A_t, Scalar,
-  std::enable_if_t<
-    std::is_same<
-      decltype(matrix_one_norm
-	       (std::declval<Exec>(),
-		std::declval<A_t>(),
-		std::declval<Scalar>()
-		)
-	       ),
-      Scalar
-      >::value
+  std::void_t<
+    decltype(matrix_one_norm
+	     (std::declval<Exec>(),
+	      std::declval<A_t>(),
+	      std::declval<Scalar>()
+	      )
+	     )
     >
   >
 {
-  static constexpr bool value =
-    !std::is_same<Exec, std::experimental::linalg::impl::inline_exec_t>::value;
+
+  static constexpr bool has_matching_return_type = std::is_same_v<
+    Scalar,
+    decltype(matrix_one_norm(std::declval<Exec>(),
+			     std::declval<A_t>(),
+			     std::declval<Scalar>()))>;
+
+  static constexpr bool is_not_inline_exec_tag = !std::is_same_v<
+    Exec,std::experimental::linalg::impl::inline_exec_t>;
+
+  static constexpr bool value = has_matching_return_type && is_not_inline_exec_tag;
 };
 
 } // end anonymous namespace

--- a/include/experimental/__p1673_bits/blas1_scale.hpp
+++ b/include/experimental/__p1673_bits/blas1_scale.hpp
@@ -95,8 +95,8 @@ struct is_custom_scale_avail<
 			     std::declval<Scalar>(),
 			     std::declval<x_t>())) >>
 {
-  static constexpr bool value = !std::is_same
-    <Exec, std::experimental::linalg::impl::inline_exec_t>::value;
+  static constexpr bool value = !std::is_same_v
+    <Exec, std::experimental::linalg::impl::inline_exec_t>;
 };
 } // end anonymous namespace
 

--- a/include/experimental/__p1673_bits/blas1_vector_abs_sum.hpp
+++ b/include/experimental/__p1673_bits/blas1_vector_abs_sum.hpp
@@ -59,22 +59,28 @@ struct is_custom_vector_abs_sum_avail : std::false_type {};
 template <class Exec, class v_t, class Scalar>
 struct is_custom_vector_abs_sum_avail<
   Exec, v_t, Scalar,
-  std::enable_if_t<
-    std::is_same<
-      decltype(vector_abs_sum(std::declval<Exec>(),
-			      std::declval<v_t>(),
-			      std::declval<Scalar>())
-	       ),
-      Scalar
-      >::value
+  std::void_t<
+    decltype(vector_abs_sum(std::declval<Exec>(),
+			    std::declval<v_t>(),
+			    std::declval<Scalar>())
+	     )
     >
   >
 {
-  static constexpr bool value =
-    !std::is_same<Exec,
-		  std::experimental::linalg::impl::inline_exec_t
-		  >::value;
+
+  static constexpr bool has_matching_return_type = std::is_same_v<
+    Scalar,
+    decltype(vector_abs_sum(std::declval<Exec>(),
+			    std::declval<v_t>(),
+			    std::declval<Scalar>())
+	     )>;
+
+  static constexpr bool is_not_inline_exec_tag = !std::is_same_v<
+    Exec,std::experimental::linalg::impl::inline_exec_t>;
+
+  static constexpr bool value = has_matching_return_type && is_not_inline_exec_tag;
 };
+
 } // end anonymous namespace
 
 template<class ElementType,

--- a/include/experimental/__p1673_bits/blas1_vector_idx_abs_max.hpp
+++ b/include/experimental/__p1673_bits/blas1_vector_idx_abs_max.hpp
@@ -57,16 +57,21 @@ struct is_custom_idx_abs_max_avail : std::false_type {};
 template <class Exec, class v_t>
 struct is_custom_idx_abs_max_avail<
   Exec, v_t,
-  std::enable_if_t<
-    //FRizzi: maybe should use is_convertible?
-    std::is_same<
-      decltype(idx_abs_max(std::declval<Exec>(), std::declval<v_t>())),
-      extents<>::size_type
-      >::value
+  std::void_t<
+    decltype(idx_abs_max(std::declval<Exec>(), std::declval<v_t>()))
     >
   >
 {
-  static constexpr bool value = !std::is_same<Exec,std::experimental::linalg::impl::inline_exec_t>::value;
+
+  static constexpr bool has_matching_return_type = std::is_same_v<
+    extents<>::size_type,
+    decltype(idx_abs_max(std::declval<Exec>(), std::declval<v_t>()))
+    >;
+
+  static constexpr bool is_not_inline_exec_tag = !std::is_same_v<
+    Exec,std::experimental::linalg::impl::inline_exec_t>;
+
+  static constexpr bool value = has_matching_return_type && is_not_inline_exec_tag;
 };
 
 template<class ElementType,
@@ -79,6 +84,11 @@ extents<>::size_type idx_abs_max_default_impl(
   using std::abs;
   using size_type = typename extents<>::size_type;
   using magnitude_type = decltype(abs(v(0)));
+
+  // if vector is empty, always return according to our proposal
+  if (v.extent(0) == 0) {
+    return std::numeric_limits<typename extents<>::size_type>::max();
+  }
 
   size_type maxInd = 0;
   magnitude_type maxVal = abs(v(0));
@@ -114,7 +124,7 @@ typename extents<>::size_type idx_abs_max(
   std::experimental::mdspan<ElementType, std::experimental::extents<ext0>, Layout, Accessor> v)
 {
 
-  // if vector is empty, always retun according to our proposal
+  // if vector is empty, always return according to our proposal
   if (v.extent(0) == 0) {
     return std::numeric_limits<typename extents<>::size_type>::max();
   }

--- a/include/experimental/__p1673_bits/blas1_vector_norm2.hpp
+++ b/include/experimental/__p1673_bits/blas1_vector_norm2.hpp
@@ -60,21 +60,31 @@ struct is_custom_vector_norm2_avail : std::false_type {};
 template <class Exec, class x_t, class Scalar>
 struct is_custom_vector_norm2_avail<
   Exec, x_t, Scalar,
-  std::enable_if_t<
-    std::is_same<
-      decltype(
-	       vector_norm2(std::declval<Exec>(),
-			    std::declval<x_t>(),
-			    std::declval<Scalar>())
-	       ),
-      Scalar
-      >::value
+  std::void_t<
+    decltype(
+	     vector_norm2(std::declval<Exec>(),
+			  std::declval<x_t>(),
+			  std::declval<Scalar>())
+	     )
     >
   >
 {
-  static constexpr bool value =
-    !std::is_same<Exec, std::experimental::linalg::impl::inline_exec_t>::value;
+
+  static constexpr bool has_matching_return_type = std::is_same_v<
+    Scalar,
+    decltype(
+	     vector_norm2(std::declval<Exec>(),
+			  std::declval<x_t>(),
+			  std::declval<Scalar>())
+	     )
+    >;
+
+  static constexpr bool is_not_inline_exec_tag = !std::is_same_v<
+    Exec,std::experimental::linalg::impl::inline_exec_t>;
+
+  static constexpr bool value = has_matching_return_type && is_not_inline_exec_tag;
 };
+
 } // end anonymous namespace
 
 template<class ElementType,

--- a/include/experimental/__p1673_bits/blas1_vector_sum_of_squares.hpp
+++ b/include/experimental/__p1673_bits/blas1_vector_sum_of_squares.hpp
@@ -66,23 +66,31 @@ struct is_custom_vector_sum_of_squares_avail : std::false_type {};
 template <class Exec, class x_t, class Scalar>
 struct is_custom_vector_sum_of_squares_avail<
   Exec, x_t, Scalar,
-  std::enable_if_t<
-    std::is_same<
-      decltype(vector_sum_of_squares(std::declval<Exec>(),
-				     std::declval<x_t>(),
-				     std::declval<sum_of_squares_result<Scalar>>()
-				     )
-	       ),
-      sum_of_squares_result<Scalar>
-      >::value
+  std::void_t<
+    decltype(vector_sum_of_squares(std::declval<Exec>(),
+				   std::declval<x_t>(),
+				   std::declval<sum_of_squares_result<Scalar>>()
+				   )
+	     )
     >
   >
 {
-  static constexpr bool value =
-    !std::is_same<Exec,
-		  std::experimental::linalg::impl::inline_exec_t
-		  >::value;
+
+  static constexpr bool has_matching_return_type = std::is_same_v<
+    sum_of_squares_result<Scalar>,
+    decltype(vector_sum_of_squares(std::declval<Exec>(),
+				   std::declval<x_t>(),
+				   std::declval<sum_of_squares_result<Scalar>>()
+				   )
+	     )
+    >;
+
+  static constexpr bool is_not_inline_exec_tag = !std::is_same_v<
+    Exec,std::experimental::linalg::impl::inline_exec_t>;
+
+  static constexpr bool value = has_matching_return_type && is_not_inline_exec_tag;
 };
+
 } // end anonymous namespace
 
 template<class ElementType,


### PR DESCRIPTION
- fixed casting to use `static_cast<>()`
- change to use `is_same_v`
- fixed customization struct for non-void return functions to work as:
```cpp
template <class Exec, class v1_t, class v2_t, class Scalar>
struct is_custom_dot_avail<
  Exec, v1_t, v2_t, Scalar, std::void_t< ... >
  >
{
  static constexpr bool has_matching_return_type = std::is_same_v<
    Scalar, decltype(dot(...)) >;

  static constexpr bool is_not_inline_exec_tag = !std::is_same_v<
    Exec,std::experimental::linalg::impl::inline_exec_t>;

  static constexpr bool value = has_matching_return_type && is_not_inline_exec_tag;
};
```
