### PR TITLE
A few small fixes for compilation and installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,7 +122,7 @@ install(TARGETS linalg EXPORT linalgTargets
 install(EXPORT linalgTargets
     FILE linalgTargets.cmake
     NAMESPACE std::
-    DESTINATION cmake
+    DESTINATION lib/cmake/stdBLAS
 )
 
 export(TARGETS linalg
@@ -145,7 +145,7 @@ write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/LinAlgConfigVersion
 )
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/LinAlgConfig.cmake ${CMAKE_CURRENT_BINARY_DIR}/LinAlgConfigVersion.cmake
-    DESTINATION cmake
+    DESTINATION lib/cmake/stdBLAS
 )
 
 ################################################################################

--- a/include/experimental/__p1673_bits/layout_blas_general.hpp
+++ b/include/experimental/__p1673_bits/layout_blas_general.hpp
@@ -47,6 +47,10 @@
 #include "maybe_static_size.hpp"
 #include "layout_tags.hpp"
 
+#include <experimental/__p0009_bits/macros.hpp>
+#include <experimental/__p0009_bits/layout_left.hpp>
+#include <experimental/__p0009_bits/layout_right.hpp>
+
 namespace std {
 namespace experimental {
 inline namespace __p1673_version_0 {
@@ -151,22 +155,22 @@ public:
   MDSPAN_INLINE_FUNCTION constexpr __extents_type extents() const noexcept { return _base_layout.extents(); }
 
   MDSPAN_INLINE_FUNCTION
-  constexpr __extents_type::size_type required_span_size() const noexcept {
+  constexpr typename __extents_type::size_type required_span_size() const noexcept {
     return _base_layout.required_span_size() * __lda.value;
   }
 
   MDSPAN_INLINE_FUNCTION
-  constexpr __extents_type::size_type stride(size_t r) const noexcept {
+  constexpr typename __extents_type::size_type stride(size_t r) const noexcept {
     return _base_layout.stride(r) * __lda.value;
   }
 
-  template<class OtherExtents, __extents_type::size_type OtherLDA>
+  template<class OtherExtents, typename __extents_type::size_type OtherLDA>
   MDSPAN_INLINE_FUNCTION
   friend constexpr bool operator==(__layout_blas_impl const& a, __layout_blas_impl<OtherExtents, OtherLDA> const& b) noexcept {
     return a.extents() == b.extents() && a.__lda == b.__lda;
   }
 
-  template<class OtherExtents, __extents_type::size_type OtherLDA>
+  template<class OtherExtents, typename __extents_type::size_type OtherLDA>
   MDSPAN_INLINE_FUNCTION
   friend constexpr bool operator!=(__layout_blas_impl const& a, __layout_blas_impl<OtherExtents, OtherLDA> const& b) noexcept {
     return a.extents() != b.extents() || a.__lda != b.__lda;
@@ -175,7 +179,7 @@ public:
   // Needed to work with subspan()
   template <size_t N>
   struct __static_stride_workaround {
-    static constexpr __extents_type::size_type value = __lda_t::is_static ?
+    static constexpr typename __extents_type::size_type value = __lda_t::is_static ?
       (BaseLayout::template __static_stride_workaround<N>::value == dynamic_extent ? dynamic_extent :
         (__lda_t::value_static * BaseLayout::template __static_stride_workaround<N>::value)
       ) : dynamic_extent;

--- a/include/experimental/__p1673_bits/transposed.hpp
+++ b/include/experimental/__p1673_bits/transposed.hpp
@@ -75,7 +75,7 @@ public:
     // TODO insert other standard mapping things
 
     // for non-batched layouts
-    Extents::size_type operator() (Extents::size_type i, Extents::size_type j) const {
+    typename Extents::size_type operator() (typename Extents::size_type i, typename Extents::size_type j) const {
       return nested_mapping(j, i);
     }
 
@@ -93,7 +93,7 @@ public:
       return nested_mapping.is_strided();
     }
 
-    constexpr Extents::size_type stride(size_t r) const noexcept {
+    constexpr typename Extents::size_type stride(size_t r) const noexcept {
       // FIXME this only works for rank 2
       return nested_mapping.stride(size_t(1) - r);
     }


### PR DESCRIPTION
This was to get compilation and installation working with g++-11 on MacOS.  Added a few "typename" here and there in a couple of files.  Also changed "cmake" to lib/cmake/stdBLAS for installing the stdBLAS cmake file(s).

I note that compilation is only possible with -std=c++20 now -- many uses of concepts and requires clauses throughout.