### PR TITLE
`matrix_rank_1_update`: kokkos impl

### DIFF
--- a/tests/kokkos-based/CMakeLists.txt
+++ b/tests/kokkos-based/CMakeLists.txt
@@ -51,3 +51,7 @@ add_executable(${testExe} mdspan_to_view.cpp gtest_main_kokkos.cpp)
 target_link_libraries(${testExe} linalg GTest::GTest)
 add_test(NAME utest_${testExe} COMMAND ${testExe})
 set_tests_properties(utest_${testExe} PROPERTIES FAIL_REGULAR_EXPRESSION "[^a-z]Error;ERROR;Failed;FAILED")
+
+linalg_add_test_kokkos(
+  matrix_rank1_update_kokkos
+  "matrix_rank1_update: kokkos impl")

--- a/tests/kokkos-based/matrix_rank1_update_kokkos.cpp
+++ b/tests/kokkos-based/matrix_rank1_update_kokkos.cpp
@@ -1,0 +1,289 @@
+
+#include "gtest_fixtures.hpp"
+#include "helpers.hpp"
+
+namespace{
+
+////////////////////////////////////////////////////////////
+// Utilities
+////////////////////////////////////////////////////////////
+
+// create rank-1 mdspan (vector)
+template <typename value_type,
+          typename mdspan_t = typename _blas2_signed_fixture<value_type>::mdspan_r1_t>
+inline mdspan_t make_mdspan(value_type *data, std::size_t ext) {
+  return mdspan_t(data, ext);
+}
+
+template <typename value_type,
+          typename mdspan_t = typename _blas2_signed_fixture<const value_type>::mdspan_r1_t>
+inline mdspan_t make_mdspan(const value_type *data, std::size_t ext) {
+  return mdspan_t(data, ext);
+}
+
+template <typename value_type>
+inline auto make_mdspan(std::vector<value_type> &v) {
+  return make_mdspan(v.data(), v.size());
+}
+
+template <typename value_type>
+inline auto make_mdspan(const std::vector<value_type> &v) {
+  return make_mdspan(v.data(), v.size());
+}
+
+// create rank-2 mdspan (matrix)
+template <typename value_type,
+          typename mdspan_t = typename _blas2_signed_fixture<value_type>::mdspan_r2_t>
+inline mdspan_t make_mdspan(value_type *data, std::size_t ext0, std::size_t ext1) {
+  return mdspan_t(data, ext0, ext1);
+}
+
+template <typename ElementType1,
+          typename LayoutPolicy1,
+          typename AccessorPolicy1,
+          typename ElementType2,
+          typename LayoutPolicy2,
+          typename AccessorPolicy2>
+inline bool is_same_vector(
+    const mdspan<ElementType1, extents<dynamic_extent>, LayoutPolicy1, AccessorPolicy1> &v1,
+    const mdspan<ElementType2, extents<dynamic_extent>, LayoutPolicy2, AccessorPolicy2> &v2)
+{
+  const auto size = v1.extent(0);
+  if (size != v2.extent(0))
+    return false;
+  int diff = false;
+  Kokkos::parallel_reduce(size,
+    KOKKOS_LAMBDA(const std::size_t i, decltype(diff) &d){
+        d = d || !(v1(i) == v2(i));
+	    }, diff);
+  return !diff;
+}
+
+template <typename ElementType1,
+          typename LayoutPolicy,
+          typename AccessorPolicy,
+          typename ElementType2>
+inline bool is_same_vector(
+    const mdspan<ElementType1, extents<dynamic_extent>, LayoutPolicy, AccessorPolicy> &v1,
+    const std::vector<ElementType2> &v2)
+{
+  return is_same_vector(v1, make_mdspan(v2));
+}
+
+template <typename ElementType1,
+          typename LayoutPolicy,
+          typename AccessorPolicy,
+          typename ElementType2>
+inline bool is_same_vector(
+    const std::vector<ElementType1> &v1,
+    const mdspan<ElementType2, extents<dynamic_extent>, LayoutPolicy, AccessorPolicy> &v2)
+{
+  return is_same_vector(v2, v1);
+}
+
+template <typename ElementType>
+inline bool is_same_vector(
+    const std::vector<ElementType> &v1,
+    const std::vector<ElementType> &v2)
+{
+  return is_same_vector(make_mdspan(v1), make_mdspan(v2));
+}
+
+// real diff: d = |v1 - v2|
+template <typename T, typename enabled=void>
+class value_diff {
+public:
+  value_diff(const T &val1, const T &val2): _v(fabs(val1 - val2)) {}
+  operator T() const { return _v; }
+protected:
+  value_diff() = default;
+  T _v;
+};
+
+// real diff: d = max(|R(v1) - R(v2)|, |I(v1) - I(v2)|)
+// Note: returned value is of underlying real type
+template <typename T>
+class value_diff<std::complex<T>>: public value_diff<T> {
+  using base = value_diff<T>;
+public:
+  value_diff(const std::complex<T> &val1, const std::complex<T> &val2) {
+    const T dreal = base(val1.real(), val2.real());
+    const T dimag = base(val1.imag(), val2.imag());
+    base::_v = std::max(dreal, dimag);
+  }
+};
+
+template <typename ElementType,
+          typename LayoutPolicy1,
+          typename AccessorPolicy1,
+          typename LayoutPolicy2,
+          typename AccessorPolicy2,
+          typename ToleranceType>
+inline bool is_same_matrix(
+    const mdspan<ElementType, extents<dynamic_extent, dynamic_extent>, LayoutPolicy1, AccessorPolicy1> &A,
+    const mdspan<ElementType, extents<dynamic_extent, dynamic_extent>, LayoutPolicy2, AccessorPolicy2> &B,
+    ToleranceType tolerance)
+{
+  const auto ext0 = A.extent(0);
+  const auto ext1 = A.extent(1);
+  if (B.extent(0) != ext0 or B.extent(1) != ext1)
+    return false;
+  int diff = false;
+  const auto size = ext0 * ext1;
+  Kokkos::parallel_reduce(size,
+    KOKKOS_LAMBDA(const std::size_t ij, decltype(diff) &d) {
+        const auto i = ij / ext1;
+        const auto j = ij - i * ext1;
+        if (value_diff(A(i, j), B(i, j)) > tolerance)
+          d = true;
+	    }, diff);
+  return !diff;
+}
+
+namespace Impl {
+
+template <typename T, typename enabled=void> struct _tolerance_out { using type = T; };
+template <typename T> struct _tolerance_out<std::complex<T>> { using type = T; };
+
+}
+
+template <typename T>
+Impl::_tolerance_out<T>::type tolerance(double double_tol, float float_tol);
+
+template <> double tolerance<double>(double double_tol, float float_tol) { return double_tol; }
+template <> float  tolerance<float>( double double_tol, float float_tol) { return float_tol; }
+template <> double tolerance<std::complex<double>>(double double_tol, float float_tol) { return double_tol; }
+template <> float  tolerance<std::complex<float>>( double double_tol, float float_tol) { return float_tol; }
+
+template <typename value_type, typename enabled = void>
+struct check_types: public std::true_type {};
+
+// checks if std::complex<T> and Kokkos::complex<T> are aligned
+// (they can get misalligned when Kokkos is build with Kokkos_ENABLE_COMPLEX_ALIGN=ON)
+template <typename T>
+struct check_types<std::complex<T>> {
+  static constexpr bool value = alignof(std::complex<T>) == alignof(Kokkos::complex<T>);
+};
+
+template <typename value_type>
+inline constexpr auto check_types_v = check_types<value_type>::value;
+
+template <typename value_type, typename cb_type>
+void run_checked_tests(const char *test_name, const char *type_spec, const cb_type cb) {
+  if constexpr (!check_types_v<value_type>) {
+    std::cout << "***\n"
+              << "***  Warning: " << test_name << " skipped for "
+              << type_spec << " (type check failed)\n"
+              << "***" << std::endl; \
+    /* avoid dispatcher check failure if all cases are skipped this way */
+    std::cout << "matrix_rank1_update: kokkos impl\n"; \
+    return;
+  }
+  cb();
+}
+
+#define FOR_ALL_BLAS2_TYPES(TEST_DEF) \
+  TEST_DEF(double) \
+  TEST_DEF(float) \
+  TEST_DEF(complex_double)
+
+
+////////////////////////////////////////////////////////////
+// Tests
+////////////////////////////////////////////////////////////
+
+template<class x_t, class y_t, class A_t>
+void matrix_rank_1_update_gold_solution(const x_t &x, const y_t &y, A_t &A)
+{
+  using size_type = std::experimental::extents<>::size_type;
+  for (size_type i = 0; i < A.extent(0); ++i) {
+    for (size_type j = 0; j < A.extent(1); ++j) {
+      A(i, j) += x(i) * y(j);
+    }
+  }
+}
+
+template<class x_t, class A_t, typename gold_t, typename action_t>
+void test_kokkos_matrix_update(const x_t &x, A_t &A, gold_t get_gold, action_t action)
+{
+  using value_type = typename x_t::value_type;
+
+  // backup x to verify it is not changed after kernel
+  auto x_preKernel = kokkostesting::create_stdvector_and_copy(x);
+
+  // compute gold
+  auto A_copy = kokkostesting::create_stdvector_and_copy_rowwise(A);
+  auto A_gold = make_mdspan(A_copy.data(), A.extent(0), A.extent(1));
+  get_gold(A_gold);
+
+  // run tested routine
+  action();
+
+  // compare results with gold
+  EXPECT_TRUE(is_same_matrix(A_gold, A, tolerance<value_type>(1e-9, 1e-2f)));
+
+  // x should not change after kernel
+  EXPECT_TRUE(is_same_vector(x, x_preKernel));
+}
+
+template<class x_t, class y_t, class A_t, typename gold_t, typename action_t>
+void test_kokkos_matrix_update(const x_t &x, const y_t &y, A_t &A,
+                               gold_t get_gold, action_t action)
+{
+  // backup y to verify it is not changed after kernel
+  auto y_preKernel = kokkostesting::create_stdvector_and_copy(y);
+  test_kokkos_matrix_update(x, A, get_gold, action);
+  EXPECT_TRUE(is_same_vector(y, y_preKernel));
+}
+
+template<class x_t, class y_t, class A_t>
+void test_kokkos_matrix_rank1_update_impl(const x_t &x, const y_t &y, A_t &A)
+{
+  const auto get_gold = [&](auto A_gold) {
+      matrix_rank_1_update_gold_solution(x, y, A_gold);
+    };
+  const auto compute = [&]() {
+      std::experimental::linalg::matrix_rank_1_update(
+          KokkosKernelsSTD::kokkos_exec<>(), x, y, A);
+    };
+  test_kokkos_matrix_update(x, y, A, get_gold, compute);
+}
+
+template<class x_t, class y_t, class A_t>
+void test_kokkos_matrix_rank1_update_conj_impl(const x_t &x, const y_t &y, A_t &A)
+{
+  const auto get_gold = [&](auto A_gold) {
+      matrix_rank_1_update_gold_solution(x,
+        std::experimental::linalg::conjugated(y), A_gold);
+    };
+  const auto compute = [&]() {
+      std::experimental::linalg::matrix_rank_1_update_c(
+          KokkosKernelsSTD::kokkos_exec<>(), x, y, A);
+    };
+  test_kokkos_matrix_update(x, y, A, get_gold, compute);
+}
+
+} // anonymous namespace
+
+#define DEFINE_TESTS(blas_val_type)                                          \
+TEST_F(blas2_signed_##blas_val_type##_fixture, kokkos_matrix_rank1_update) { \
+  using val_t = typename blas2_signed_##blas_val_type##_fixture::value_type; \
+  run_checked_tests<val_t>("kokkos_matrix_rank1_update",                     \
+                           #blas_val_type, [&]() {                           \
+                                                                             \
+   test_kokkos_matrix_rank1_update_impl(x_e0, x_e1, A_e0e1);                 \
+                                                                             \
+  });                                                                        \
+}                                                                            \
+TEST_F(blas2_signed_##blas_val_type##_fixture,                               \
+       kokkos_matrix_rank1_update_conjugated) {                              \
+  using val_t = typename blas2_signed_##blas_val_type##_fixture::value_type; \
+  run_checked_tests<val_t>("kokkos_matrix_rank1_update_conjugated",          \
+                           #blas_val_type, [&]() {                           \
+                                                                             \
+   test_kokkos_matrix_rank1_update_conj_impl(x_e0, x_e1, A_e0e1);            \
+                                                                             \
+  });                                                                        \
+}
+
+FOR_ALL_BLAS2_TYPES(DEFINE_TESTS);

--- a/tests/kokkos-based/matrix_rank1_update_kokkos.cpp
+++ b/tests/kokkos-based/matrix_rank1_update_kokkos.cpp
@@ -211,17 +211,19 @@ template <typename value_type>
 inline constexpr auto check_types_v = check_types<value_type>::value;
 
 template <typename value_type, typename cb_type>
-void run_checked_tests(const char *test_name, const char *type_spec, const cb_type cb) {
-  if constexpr (!check_types_v<value_type>) {
+void run_checked_tests(const std::string_view test_prefix, const std::string_view method_name,
+                       const std::string_view test_postfix, const std::string_view type_spec,
+                       const cb_type cb) {
+  if constexpr (check_types_v<value_type>) {
+    cb();
+  } else {
     std::cout << "***\n"
-              << "***  Warning: " << test_name << " skipped for "
+              << "***  Warning: " << test_prefix << method_name << test_postfix << " skipped for "
               << type_spec << " (type check failed)\n"
-              << "***" << std::endl; \
+              << "***" << std::endl;
     /* avoid dispatcher check failure if all cases are skipped this way */
-    std::cout << "matrix_rank1_update: kokkos impl\n"; \
-    return;
+    KokkosKernelsSTD::Impl::signal_kokkos_impl_called(method_name);
   }
-  cb();
 }
 
 #define FOR_ALL_BLAS2_TYPES(TEST_DEF) \
@@ -310,7 +312,7 @@ void test_kokkos_matrix_rank1_update_conj_impl(const x_t &x, const y_t &y, A_t &
 #define DEFINE_TESTS(blas_val_type)                                          \
 TEST_F(blas2_signed_##blas_val_type##_fixture, kokkos_matrix_rank1_update) { \
   using val_t = typename blas2_signed_##blas_val_type##_fixture::value_type; \
-  run_checked_tests<val_t>("kokkos_matrix_rank1_update",                     \
+  run_checked_tests<val_t>("kokkos_", "matrix_rank1_update", "",             \
                            #blas_val_type, [&]() {                           \
                                                                              \
    test_kokkos_matrix_rank1_update_impl(x_e0, x_e1, A_e0e1);                 \
@@ -320,7 +322,7 @@ TEST_F(blas2_signed_##blas_val_type##_fixture, kokkos_matrix_rank1_update) { \
 TEST_F(blas2_signed_##blas_val_type##_fixture,                               \
        kokkos_matrix_rank1_update_conjugated) {                              \
   using val_t = typename blas2_signed_##blas_val_type##_fixture::value_type; \
-  run_checked_tests<val_t>("kokkos_matrix_rank1_update_conjugated",          \
+  run_checked_tests<val_t>("kokkos_", "matrix_rank1_update", "_conjugated",  \
                            #blas_val_type, [&]() {                           \
                                                                              \
    test_kokkos_matrix_rank1_update_conj_impl(x_e0, x_e1, A_e0e1);            \

--- a/tests/kokkos-based/matrix_rank1_update_kokkos.cpp
+++ b/tests/kokkos-based/matrix_rank1_update_kokkos.cpp
@@ -1,3 +1,45 @@
+ /*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2019) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
 
 #include "gtest_fixtures.hpp"
 #include "helpers.hpp"

--- a/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas2_matrix_rank_1_update.hpp
+++ b/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas2_matrix_rank_1_update.hpp
@@ -56,7 +56,7 @@ namespace Impl {
 template <typename ExecSpace, typename MatrixType>
 class ParallelMatrixVisitor {
 public:
-  KOKKOS_INLINE_FUNCTION ParallelMatrixVisitor(ExecSpace &&exec_in, MatrixType &A_in):
+  KOKKOS_INLINE_FUNCTION ParallelMatrixVisitor(ExecSpace &&exec_in, MatrixType A_in):
     exec(exec_in), A(A_in), ext0(A.extent(0)), ext1(A.extent(1))
   {}
 
@@ -84,10 +84,10 @@ public:
   }
 
 private:
-  const ExecSpace exec;
+  ExecSpace exec;
   MatrixType A;
-  const size_t ext0;
-  const size_t ext1;
+  size_t ext0;
+  size_t ext1;
 };
 
 // This version of conj_if_needed() also handles Kokkos::complex<T>

--- a/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas2_matrix_rank_1_update.hpp
+++ b/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas2_matrix_rank_1_update.hpp
@@ -45,6 +45,7 @@
 #define LINALG_TPLIMPLEMENTATIONS_INCLUDE_EXPERIMENTAL___P1673_BITS_KOKKOSKERNELS_BLAS2_MATRIX_RANK_1_UPDATE_HPP_
 
 #include <complex>
+#include "signal_kokkos_impl_called.hpp"
 
 namespace KokkosKernelsSTD {
 
@@ -148,9 +149,7 @@ void matrix_rank_1_update(kokkos_exec<ExecSpace> &&/* exec */,
     throw std::runtime_error("KokkosBlas: matrix_rank_1_update: A.extent(1) != y.extent(0)");
   }
 
-#if defined KOKKOS_STDBLAS_ENABLE_TESTS
-  std::cout << "matrix_rank1_update: kokkos impl\n";
-#endif
+  Impl::signal_kokkos_impl_called("matrix_rank1_update");
 
   // convert mdspans to views and wrap input with original accessors
   const auto x_view = Impl::mdspan_to_view(x);
@@ -197,9 +196,7 @@ void matrix_rank_1_update(kokkos_exec<ExecSpace> &&/* exec */,
     throw std::runtime_error("KokkosBlas: matrix_rank_1_update: A.extent(1) != y.extent(0)");
   }
 
-#if defined KOKKOS_STDBLAS_ENABLE_TESTS
-  std::cout << "matrix_rank1_update: kokkos impl\n";
-#endif
+  Impl::signal_kokkos_impl_called("matrix_rank1_update");
 
   auto x_view = Impl::mdspan_to_view(x);
   auto y_view = Impl::mdspan_to_view(y);

--- a/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas2_matrix_rank_1_update.hpp
+++ b/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas2_matrix_rank_1_update.hpp
@@ -1,0 +1,174 @@
+#ifndef LINALG_TPLIMPLEMENTATIONS_INCLUDE_EXPERIMENTAL___P1673_BITS_KOKKOSKERNELS_BLAS2_MATRIX_RANK_1_UPDATE_HPP_
+#define LINALG_TPLIMPLEMENTATIONS_INCLUDE_EXPERIMENTAL___P1673_BITS_KOKKOSKERNELS_BLAS2_MATRIX_RANK_1_UPDATE_HPP_
+
+#include <complex>
+
+namespace KokkosKernelsSTD {
+
+namespace Impl {
+
+// manages parallel execution of independent action
+// called like action(i, j) for each matrix element A(i, j)
+template <typename ExecSpace, typename MatrixType>
+class ParallelMatrixVisitor {
+public:
+  KOKKOS_INLINE_FUNCTION ParallelMatrixVisitor(ExecSpace &&exec_in, MatrixType &A_in):
+    exec(exec_in), A(A_in), ext0(A.extent(0)), ext1(A.extent(1))
+  {}
+
+  template <typename ActionType>
+  KOKKOS_INLINE_FUNCTION
+  void for_each_matrix_element(ActionType action) {
+    if (ext0 > ext1) { // parallel rows
+      Kokkos::parallel_for(Kokkos::RangePolicy(exec, 0, ext0),
+        KOKKOS_LAMBDA(const auto i) {
+          using idx_type = std::remove_const_t<decltype(i)>;
+          for (idx_type j = 0; j < ext1; ++j) {
+            action(i, j);
+          }
+        });
+    } else { // parallel columns
+      Kokkos::parallel_for(Kokkos::RangePolicy(exec, 0, ext1),
+        KOKKOS_LAMBDA(const auto j) {
+          using idx_type = std::remove_const_t<decltype(j)>;
+          for (idx_type i = 0; i < ext0; ++i) {
+            action(i, j);
+          }
+        });
+    }
+    exec.fence();
+  }
+
+private:
+  const ExecSpace &exec;
+  MatrixType &A;
+  const size_t ext0;
+  const size_t ext1;
+};
+
+// This version of conj_if_needed() also handles Kokkos::complex<T>
+template <class T>
+KOKKOS_INLINE_FUNCTION
+T conj_if_needed(const T &value)
+{
+  return value;
+};
+
+template <class T>
+KOKKOS_INLINE_FUNCTION
+auto conj_if_needed(const Kokkos::complex<T> &value)
+{
+  return Kokkos::conj(value);
+};
+
+template <class T>
+KOKKOS_INLINE_FUNCTION
+auto conj_if_needed(const std::complex<T> &value)
+{
+  return std::conj(value);
+};
+
+} // namespace Impl
+
+// Nonsymmetric non-conjugated rank-1 update
+// Performs BLAS xGER/xGERU (for real/complex types) A[i,j] += x[i] * y[j]
+
+template<class ExecSpace,
+         class ElementType_x,
+         std::experimental::extents<>::size_type ext_x,
+         class Layout_x,
+         class ElementType_y,
+         std::experimental::extents<>::size_type ext_y,
+         class Layout_y,
+         class ElementType_A,
+         std::experimental::extents<>::size_type numRows_A,
+         std::experimental::extents<>::size_type numCols_A,
+         class Layout_A>
+void matrix_rank_1_update(kokkos_exec<ExecSpace> &&/* exec */,
+  std::experimental::mdspan<ElementType_x, std::experimental::extents<ext_x>, Layout_x,
+    std::experimental::default_accessor<ElementType_x>> x,
+  std::experimental::mdspan<ElementType_y, std::experimental::extents<ext_y>, Layout_y,
+    std::experimental::default_accessor<ElementType_y>> y,
+  std::experimental::mdspan<ElementType_A, std::experimental::extents<numRows_A, numCols_A>, Layout_A,
+    std::experimental::default_accessor<ElementType_A>> A)
+{
+  // constraints
+  static_assert(A.rank() == 2);
+  static_assert(x.rank() == 1);
+  static_assert(y.rank() == 1);
+
+  // preconditions
+  if ( A.extent(0) != x.extent(0) ){
+    throw std::runtime_error("KokkosBlas: matrix_rank_1_update: A.extent(0) != x.extent(0)");
+  }
+  if ( A.extent(1) != y.extent(0) ){
+    throw std::runtime_error("KokkosBlas: matrix_rank_1_update: A.extent(1) != y.extent(0)");
+  }
+
+#if defined KOKKOS_STDBLAS_ENABLE_TESTS
+  std::cout << "matrix_rank1_update: kokkos impl\n";
+#endif
+
+  // convert mdspans to views and wrap input with original accessors
+  const auto x_view = Impl::mdspan_to_view(x);
+  const auto y_view = Impl::mdspan_to_view(y);
+  auto A_view = Impl::mdspan_to_view(A);
+  Impl::ParallelMatrixVisitor v(ExecSpace(), A_view);
+  v.for_each_matrix_element(
+    KOKKOS_LAMBDA(const auto i, const auto j) {
+      A_view(i, j) += x_view(i) * y_view(j);
+    });
+}
+
+// conjugated(y) specialization dispatched by matrix_rank_1_update_c
+template<class ExecSpace,
+         class ElementType_x,
+         std::experimental::extents<>::size_type ext_x,
+         class Layout_x,
+         class ElementType_y,
+         std::experimental::extents<>::size_type ext_y,
+         class Layout_y,
+         class ElementType_A,
+         std::experimental::extents<>::size_type numRows_A,
+         std::experimental::extents<>::size_type numCols_A,
+         class Layout_A>
+void matrix_rank_1_update(kokkos_exec<ExecSpace> &&/* exec */,
+  std::experimental::mdspan<ElementType_x, std::experimental::extents<ext_x>, Layout_x,
+    std::experimental::default_accessor<ElementType_x>> x,
+  std::experimental::mdspan<ElementType_y, std::experimental::extents<ext_y>, Layout_y,
+    std::experimental::linalg::accessor_conjugate<
+      std::experimental::default_accessor<ElementType_y>, ElementType_y>> y,
+  std::experimental::mdspan<ElementType_A, std::experimental::extents<numRows_A, numCols_A>, Layout_A,
+    std::experimental::default_accessor<ElementType_A>> A)
+{
+  // constraints
+  static_assert(A.rank() == 2);
+  static_assert(x.rank() == 1);
+  static_assert(y.rank() == 1);
+
+  // preconditions
+  if ( A.extent(0) != x.extent(0) ){
+    throw std::runtime_error("KokkosBlas: matrix_rank_1_update: A.extent(0) != x.extent(0)");
+  }
+  if ( A.extent(1) != y.extent(0) ){
+    throw std::runtime_error("KokkosBlas: matrix_rank_1_update: A.extent(1) != y.extent(0)");
+  }
+
+#if defined KOKKOS_STDBLAS_ENABLE_TESTS
+  std::cout << "matrix_rank1_update: kokkos impl\n";
+#endif
+
+  auto x_view = Impl::mdspan_to_view(x);
+  auto y_view = Impl::mdspan_to_view(y);
+  auto A_view = Impl::mdspan_to_view(A);
+
+  Impl::ParallelMatrixVisitor v(ExecSpace(), A_view);
+  v.for_each_matrix_element(
+    KOKKOS_LAMBDA(const auto i, const auto j) {
+      // apply conjugation explicitly (accessor is no longer on the view, see #122)
+      A_view(i, j) += x_view(i) * Impl::conj_if_needed(y_view(j));
+    });
+}
+
+} // namespace KokkosKernelsSTD
+#endif

--- a/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas2_matrix_rank_1_update.hpp
+++ b/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas2_matrix_rank_1_update.hpp
@@ -145,7 +145,7 @@ void matrix_rank_1_update(kokkos_exec<ExecSpace> &&/* exec */,
   std::experimental::mdspan<ElementType_A, std::experimental::extents<numRows_A, numCols_A>, Layout_A,
     std::experimental::default_accessor<ElementType_A>> A)
 {
-  // constraints
+  // P1673 constraints (redundant to mdspan extents in the header)
   static_assert(A.rank() == 2);
   static_assert(x.rank() == 1);
   static_assert(y.rank() == 1);
@@ -196,7 +196,7 @@ void matrix_rank_1_update(kokkos_exec<ExecSpace> &&/* exec */,
   std::experimental::mdspan<ElementType_A, std::experimental::extents<numRows_A, numCols_A>, Layout_A,
     std::experimental::default_accessor<ElementType_A>> A)
 {
-  // constraints
+  // P1673 constraints (redundant to mdspan extents in the header)
   static_assert(A.rank() == 2);
   static_assert(x.rank() == 1);
   static_assert(y.rank() == 1);
@@ -205,7 +205,7 @@ void matrix_rank_1_update(kokkos_exec<ExecSpace> &&/* exec */,
   static_assert(Impl::static_extent_match(A.static_extent(0), x.static_extent(0)));
   static_assert(Impl::static_extent_match(A.static_extent(1), y.static_extent(0)));
 
-  // preconditions
+  // P1673 preconditions
   if ( A.extent(0) != x.extent(0) ){
     throw std::runtime_error("KokkosBlas: matrix_rank_1_update: A.extent(0) != x.extent(0)");
   }

--- a/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas2_matrix_rank_1_update.hpp
+++ b/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas2_matrix_rank_1_update.hpp
@@ -112,6 +112,15 @@ auto conj_if_needed(const std::complex<T> &value)
   return std::conj(value);
 };
 
+template <class size_type>
+KOKKOS_INLINE_FUNCTION
+constexpr bool static_extent_match(size_type extent1, size_type extent2)
+{
+  return extent1 == std::experimental::dynamic_extent ||
+         extent2 == std::experimental::dynamic_extent ||
+         extent1 == extent2;
+}
+
 } // namespace Impl
 
 // Nonsymmetric non-conjugated rank-1 update
@@ -141,7 +150,11 @@ void matrix_rank_1_update(kokkos_exec<ExecSpace> &&/* exec */,
   static_assert(x.rank() == 1);
   static_assert(y.rank() == 1);
 
-  // preconditions
+  // P1673 mandates
+  static_assert(Impl::static_extent_match(A.static_extent(0), x.static_extent(0)));
+  static_assert(Impl::static_extent_match(A.static_extent(1), y.static_extent(0)));
+
+  // P1673 preconditions
   if ( A.extent(0) != x.extent(0) ){
     throw std::runtime_error("KokkosBlas: matrix_rank_1_update: A.extent(0) != x.extent(0)");
   }
@@ -187,6 +200,10 @@ void matrix_rank_1_update(kokkos_exec<ExecSpace> &&/* exec */,
   static_assert(A.rank() == 2);
   static_assert(x.rank() == 1);
   static_assert(y.rank() == 1);
+
+  // P1673 mandates
+  static_assert(Impl::static_extent_match(A.static_extent(0), x.static_extent(0)));
+  static_assert(Impl::static_extent_match(A.static_extent(1), y.static_extent(0)));
 
   // preconditions
   if ( A.extent(0) != x.extent(0) ){

--- a/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas2_matrix_rank_1_update.hpp
+++ b/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas2_matrix_rank_1_update.hpp
@@ -84,8 +84,8 @@ public:
   }
 
 private:
-  const ExecSpace &exec;
-  MatrixType &A;
+  const ExecSpace exec;
+  MatrixType A;
   const size_t ext0;
   const size_t ext1;
 };

--- a/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas2_matrix_rank_1_update.hpp
+++ b/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas2_matrix_rank_1_update.hpp
@@ -1,3 +1,46 @@
+ /*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2019) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
 #ifndef LINALG_TPLIMPLEMENTATIONS_INCLUDE_EXPERIMENTAL___P1673_BITS_KOKKOSKERNELS_BLAS2_MATRIX_RANK_1_UPDATE_HPP_
 #define LINALG_TPLIMPLEMENTATIONS_INCLUDE_EXPERIMENTAL___P1673_BITS_KOKKOSKERNELS_BLAS2_MATRIX_RANK_1_UPDATE_HPP_
 

--- a/tpl-implementations/include/experimental/linalg_kokkoskernels
+++ b/tpl-implementations/include/experimental/linalg_kokkoskernels
@@ -10,3 +10,4 @@
 #include "__p1673_bits/kokkos-kernels/blas1_vector_abs_sum_kk.hpp"
 #include "__p1673_bits/kokkos-kernels/blas1_vector_sum_of_squares_kk.hpp"
 #include "__p1673_bits/kokkos-kernels/blas2_matrix_vector_product_kk.hpp"
+#include "__p1673_bits/kokkos-kernels/blas2_matrix_rank_1_update.hpp"


### PR DESCRIPTION
This is Kokkos implementation of `matrix_rank_1_update`, including conjugate overload for `matrix_rank_1_update_c`.
 #162  is a prerequisite for this, I can rebase once that is merged
