### PR TITLE
Encapsulate Kokkos dispatch testing

### DIFF
--- a/tests/kokkos-based/gtest_main_kokkos.cpp
+++ b/tests/kokkos-based/gtest_main_kokkos.cpp
@@ -1,6 +1,20 @@
 
+#include <iostream>
 #include <gtest/gtest.h>
 #include <Kokkos_Core.hpp>
+
+namespace KokkosKernelsSTD {
+namespace Impl {
+
+#if defined(KOKKOS_STDBLAS_ENABLE_TESTS)
+void signal_kokkos_impl_called(std::string_view functionName)
+{
+  std::cout << functionName << ": kokkos impl" << std::endl;
+}
+#endif
+
+} // namespace Impl
+} // namespace KokkosKernelsSTD
 
 int main(int argc, char *argv[])
 {

--- a/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/signal_kokkos_impl_called.hpp
+++ b/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/signal_kokkos_impl_called.hpp
@@ -56,5 +56,5 @@ void signal_kokkos_impl_called(std::string_view /* functionName */) {}
 #endif
 
 } // namespace Impl
-} // namespac KokkosKernelsSTD
+} // namespace KokkosKernelsSTD
 #endif

--- a/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/signal_kokkos_impl_called.hpp
+++ b/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/signal_kokkos_impl_called.hpp
@@ -59,6 +59,8 @@ inline void signal_kokkos_impl_called(std::string_view functionName)
 {
 #if defined(KOKKOS_STDBLAS_ENABLE_TESTS)
   std::cout << functionName << ": kokkos impl" << std::endl;
+#else
+  (void)functionName;
 #endif
 }
 

--- a/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/signal_kokkos_impl_called.hpp
+++ b/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/signal_kokkos_impl_called.hpp
@@ -1,0 +1,67 @@
+ /*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2019) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef LINALG_TPLIMPLEMENTATIONS_INCLUDE_EXPERIMENTAL___P1673_BITS_KOKKOSKERNELS_UTILS_HPP_
+#define LINALG_TPLIMPLEMENTATIONS_INCLUDE_EXPERIMENTAL___P1673_BITS_KOKKOSKERNELS_UTILS_HPP_
+
+#include <string_view>
+
+// Note: dependencies required only for compiling tests
+#if defined(KOKKOS_STDBLAS_ENABLE_TESTS)
+#include <iostream>
+#endif
+
+namespace KokkosKernelsSTD {
+namespace Impl {
+
+// For testing: signal that Kokkos implementation was called
+inline void signal_kokkos_impl_called(std::string_view functionName)
+{
+#if defined(KOKKOS_STDBLAS_ENABLE_TESTS)
+  std::cout << functionName << ": kokkos impl" << std::endl;
+#endif
+}
+
+} // namespace Impl
+} // namespac KokkosKernelsSTD
+#endif

--- a/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/signal_kokkos_impl_called.hpp
+++ b/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/signal_kokkos_impl_called.hpp
@@ -46,23 +46,14 @@
 
 #include <string_view>
 
-// Note: dependencies required only for compiling tests
-#if defined(KOKKOS_STDBLAS_ENABLE_TESTS)
-#include <iostream>
-#endif
-
 namespace KokkosKernelsSTD {
 namespace Impl {
 
-// For testing: signal that Kokkos implementation was called
-inline void signal_kokkos_impl_called(std::string_view functionName)
-{
 #if defined(KOKKOS_STDBLAS_ENABLE_TESTS)
-  std::cout << functionName << ": kokkos impl" << std::endl;
+extern void signal_kokkos_impl_called(std::string_view functionName);
 #else
-  (void)functionName;
+void signal_kokkos_impl_called(std::string_view /* functionName */) {}
 #endif
-}
 
 } // namespace Impl
 } // namespac KokkosKernelsSTD


### PR DESCRIPTION
Encapsulate testing signals sent by Kokkos implementations to confirm the correct dispatch.