### PR TITLE
[ready] kokkos-based tests: update cmakelist for add, swap, scale

### DIFF
--- a/tests/kokkos-based/CMakeLists.txt
+++ b/tests/kokkos-based/CMakeLists.txt
@@ -62,3 +62,19 @@ linalg_add_test_kokkos(
 linalg_add_test_kokkos(
   dotc_kokkos
   "dot: kokkos impl") # this his not a typo, dotc calls dot underneath
+
+linalg_add_test_kokkos(
+  swap_elements_rank1_kokkos
+  "swap_elements: kokkos impl")
+linalg_add_test_kokkos(
+  swap_elements_rank2_kokkos
+  "swap_elements: kokkos impl")
+linalg_add_test_kokkos(
+  add_kokkos
+  "add: kokkos impl")
+linalg_add_test_kokkos(
+  scale_rank1_kokkos
+  "scale: kokkos impl")
+linalg_add_test_kokkos(
+  scale_rank2_kokkos
+  "scale: kokkos impl")


### PR DESCRIPTION
this PR takes care of updating the CMakeLists inside tests/kokkos-based PRs #159 , #160 , #161 
The reason for this is that it allows those PRs to be merged independently without generating conflicts. 