### PR TITLE
[ready] kokkos-based tests: update cmakelist for symv, gemv

### DIFF
--- a/tests/kokkos-based/CMakeLists.txt
+++ b/tests/kokkos-based/CMakeLists.txt
@@ -81,3 +81,22 @@ linalg_add_test_kokkos(
 linalg_add_test_kokkos(
   symmetric_matrix_rank1_update_kokkos
   "symmetric_matrix_rank1_update: kokkos impl")
+
+linalg_add_test_kokkos(
+  overwriting_matrix_vector_product
+  "overwriting_matrix_vector_product: kokkos impl")
+linalg_add_test_kokkos(
+  updating_matrix_vector_product
+  "updating_matrix_vector_product: kokkos impl")
+linalg_add_test_kokkos(
+  overwriting_symmetric_matrix_vector_product
+  "overwriting_symmetric_matrix_vector_product_lower: kokkos impl" USE_LOWER lower)
+linalg_add_test_kokkos(
+  overwriting_symmetric_matrix_vector_product
+  "overwriting_symmetric_matrix_vector_product_upper: kokkos impl" USE_UPPER upper)
+linalg_add_test_kokkos(
+  updating_symmetric_matrix_vector_product
+  "updating_symmetric_matrix_vector_product_lower: kokkos impl" USE_LOWER lower)
+linalg_add_test_kokkos(
+  updating_symmetric_matrix_vector_product
+  "updating_symmetric_matrix_vector_product_upper: kokkos impl" USE_UPPER upper)


### PR DESCRIPTION
this PR takes care of updating the CMakeLists inside tests/kokkos-based PRs #163  #164 
The reason for this is that it allows those PRs to be merged independently without generating conflicts. 