### PR TITLE
`{symmetric,hermitian}_matrix_rank_2_update`: kokkos impl

### DIFF
--- a/tests/kokkos-based/hermitian_matrix_rank2_update_kokkos.cpp
+++ b/tests/kokkos-based/hermitian_matrix_rank2_update_kokkos.cpp
@@ -1,0 +1,331 @@
+ /*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2019) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include "gtest_fixtures.hpp"
+#include "helpers.hpp"
+
+namespace{
+
+////////////////////////////////////////////////////////////
+// Utilities
+////////////////////////////////////////////////////////////
+
+// create rank-1 mdspan (vector)
+template <typename value_type,
+          typename mdspan_t = typename _blas2_signed_fixture<value_type>::mdspan_r1_t>
+inline mdspan_t make_mdspan(value_type *data, std::size_t ext) {
+  return mdspan_t(data, ext);
+}
+
+template <typename value_type,
+          typename mdspan_t = typename _blas2_signed_fixture<const value_type>::mdspan_r1_t>
+inline mdspan_t make_mdspan(const value_type *data, std::size_t ext) {
+  return mdspan_t(data, ext);
+}
+
+template <typename value_type>
+inline auto make_mdspan(std::vector<value_type> &v) {
+  return make_mdspan(v.data(), v.size());
+}
+
+template <typename value_type>
+inline auto make_mdspan(const std::vector<value_type> &v) {
+  return make_mdspan(v.data(), v.size());
+}
+
+// create rank-2 mdspan (matrix)
+template <typename value_type,
+          typename mdspan_t = typename _blas2_signed_fixture<value_type>::mdspan_r2_t>
+inline mdspan_t make_mdspan(value_type *data, std::size_t ext0, std::size_t ext1) {
+  return mdspan_t(data, ext0, ext1);
+}
+
+template <typename ElementType1,
+          typename LayoutPolicy1,
+          typename AccessorPolicy1,
+          typename ElementType2,
+          typename LayoutPolicy2,
+          typename AccessorPolicy2>
+inline bool is_same_vector(
+    const mdspan<ElementType1, extents<dynamic_extent>, LayoutPolicy1, AccessorPolicy1> &v1,
+    const mdspan<ElementType2, extents<dynamic_extent>, LayoutPolicy2, AccessorPolicy2> &v2)
+{
+  const auto size = v1.extent(0);
+  if (size != v2.extent(0))
+    return false;
+  const auto v1_view = KokkosKernelsSTD::Impl::mdspan_to_view(v1);
+  const auto v2_view = KokkosKernelsSTD::Impl::mdspan_to_view(v2);
+  int diff = false;
+  Kokkos::parallel_reduce(size,
+    KOKKOS_LAMBDA(const std::size_t i, decltype(diff) &d){
+        d = d || !(v1_view(i) == v2_view(i));
+	    }, diff);
+  return !diff;
+}
+
+template <typename ElementType1,
+          typename LayoutPolicy,
+          typename AccessorPolicy,
+          typename ElementType2>
+inline bool is_same_vector(
+    const mdspan<ElementType1, extents<dynamic_extent>, LayoutPolicy, AccessorPolicy> &v1,
+    const std::vector<ElementType2> &v2)
+{
+  return is_same_vector(v1, make_mdspan(v2));
+}
+
+template <typename ElementType1,
+          typename LayoutPolicy,
+          typename AccessorPolicy,
+          typename ElementType2>
+inline bool is_same_vector(
+    const std::vector<ElementType1> &v1,
+    const mdspan<ElementType2, extents<dynamic_extent>, LayoutPolicy, AccessorPolicy> &v2)
+{
+  return is_same_vector(v2, v1);
+}
+
+template <typename ElementType>
+inline bool is_same_vector(
+    const std::vector<ElementType> &v1,
+    const std::vector<ElementType> &v2)
+{
+  return is_same_vector(make_mdspan(v1), make_mdspan(v2));
+}
+
+// real diff: d = |v1 - v2|
+template <typename T, typename enabled=void>
+class value_diff {
+public:
+  value_diff(const T &val1, const T &val2): _v(fabs(val1 - val2)) {}
+  operator T() const { return _v; }
+protected:
+  value_diff() = default;
+  T _v;
+};
+
+// real diff: d = max(|R(v1) - R(v2)|, |I(v1) - I(v2)|)
+// Note: returned value is of underlying real type
+template <typename T>
+class value_diff<std::complex<T>>: public value_diff<T> {
+  using base = value_diff<T>;
+public:
+  value_diff(const std::complex<T> &val1, const std::complex<T> &val2) {
+    const T dreal = base(val1.real(), val2.real());
+    const T dimag = base(val1.imag(), val2.imag());
+    base::_v = std::max(dreal, dimag);
+  }
+};
+
+template <typename T>
+class value_diff<Kokkos::complex<T>>: public value_diff<T> {
+  using base = value_diff<T>;
+public:
+  KOKKOS_INLINE_FUNCTION
+  value_diff(const Kokkos::complex<T> &val1, const Kokkos::complex<T> &val2) {
+    const T dreal = base(val1.real(), val2.real());
+    const T dimag = base(val1.imag(), val2.imag());
+    base::_v = dreal > dimag ? dreal : dimag; // can't use std::max on GPU
+  }
+};
+
+template <typename ElementType,
+          typename LayoutPolicy1,
+          typename AccessorPolicy1,
+          typename LayoutPolicy2,
+          typename AccessorPolicy2,
+          typename ToleranceType>
+inline bool is_same_matrix(
+    const mdspan<ElementType, extents<dynamic_extent, dynamic_extent>, LayoutPolicy1, AccessorPolicy1> &A,
+    const mdspan<ElementType, extents<dynamic_extent, dynamic_extent>, LayoutPolicy2, AccessorPolicy2> &B,
+    ToleranceType tolerance)
+{
+  const auto ext0 = A.extent(0);
+  const auto ext1 = A.extent(1);
+  if (B.extent(0) != ext0 or B.extent(1) != ext1)
+    return false;
+  const auto A_view = KokkosKernelsSTD::Impl::mdspan_to_view(A);
+  const auto B_view = KokkosKernelsSTD::Impl::mdspan_to_view(B);
+  int diff = false;
+  Kokkos::parallel_reduce(ext0,
+    KOKKOS_LAMBDA(std::size_t i, decltype(diff) &d) {
+        for (decltype(i) j = 0; j < ext1; ++j) {
+          d = d || (value_diff(A_view(i, j), B_view(i, j)) > tolerance);
+        }
+	    }, diff);
+  return !diff;
+}
+
+namespace Impl {
+
+template <typename T, typename enabled=void> struct _tolerance_out { using type = T; };
+template <typename T> struct _tolerance_out<std::complex<T>> { using type = T; };
+
+}
+
+template <typename T>
+Impl::_tolerance_out<T>::type tolerance(double double_tol, float float_tol);
+
+template <> double tolerance<double>(double double_tol, float float_tol) { return double_tol; }
+template <> float  tolerance<float>( double double_tol, float float_tol) { return float_tol; }
+template <> double tolerance<std::complex<double>>(double double_tol, float float_tol) { return double_tol; }
+template <> float  tolerance<std::complex<float>>( double double_tol, float float_tol) { return float_tol; }
+
+template <typename value_type, typename enabled = void>
+struct check_types: public std::true_type {};
+
+// checks if std::complex<T> and Kokkos::complex<T> are aligned
+// (they can get misalligned when Kokkos is build with Kokkos_ENABLE_COMPLEX_ALIGN=ON)
+template <typename T>
+struct check_types<std::complex<T>> {
+  static constexpr bool value = alignof(std::complex<T>) == alignof(Kokkos::complex<T>);
+};
+
+template <typename value_type>
+inline constexpr auto check_types_v = check_types<value_type>::value;
+
+template <typename value_type, typename cb_type>
+void run_checked_tests(const std::string_view test_prefix, const std::string_view method_name,
+                       const std::string_view test_postfix, const std::string_view type_spec,
+                       const cb_type cb) {
+  if constexpr (check_types_v<value_type>) {
+    cb();
+  } else {
+    std::cout << "***\n"
+              << "***  Warning: " << test_prefix << method_name << test_postfix << " skipped for "
+              << type_spec << " (type check failed)\n"
+              << "***" << std::endl;
+    /* avoid dispatcher check failure if all cases are skipped this way */
+    KokkosKernelsSTD::Impl::signal_kokkos_impl_called(method_name);
+  }
+}
+
+#define FOR_ALL_BLAS2_TYPES(TEST_DEF) \
+  TEST_DEF(double) \
+  TEST_DEF(float) \
+  TEST_DEF(complex_double)
+
+
+////////////////////////////////////////////////////////////
+// Tests
+////////////////////////////////////////////////////////////
+
+template<class x_t, class y_t, class A_t, class Triangle>
+void hermitian_matrix_rank_2_update_gold_solution(const x_t &x, const y_t &y, A_t &A, Triangle /* t */)
+{
+  using KokkosKernelsSTD::mtxr2update_impl::conj_if_needed;
+  using size_type = std::experimental::extents<>::size_type;
+  constexpr bool low = std::is_same_v<Triangle, std::experimental::linalg::lower_triangle_t>;
+  for (size_type j = 0; j < A.extent(1); ++j) {
+    const size_type i1 = low ? A.extent(0) : j + 1;
+    for (size_type i = low ? j : 0; i < i1; ++i) {
+      A(i,j) += x(i) * conj_if_needed(y(j))
+              + y(i) * conj_if_needed(x(j));
+    }
+  }
+}
+
+template<class x_t, class A_t, typename gold_t, typename action_t>
+void test_kokkos_matrix_update(const x_t &x, A_t &A, gold_t get_gold, action_t action)
+{
+  using value_type = typename x_t::value_type;
+
+  // backup x to verify it is not changed after kernel
+  auto x_preKernel = kokkostesting::create_stdvector_and_copy(x);
+
+  // compute gold
+  auto A_copy = kokkostesting::create_stdvector_and_copy_rowwise(A);
+  auto A_gold = make_mdspan(A_copy.data(), A.extent(0), A.extent(1));
+  get_gold(A_gold);
+
+  // run tested routine
+  action();
+
+  // compare results with gold
+  EXPECT_TRUE(is_same_matrix(A_gold, A, tolerance<value_type>(1e-9, 1e-2f)));
+
+  // x should not change after kernel
+  EXPECT_TRUE(is_same_vector(x, x_preKernel));
+}
+
+template<class x_t, class y_t, class A_t, typename gold_t, typename action_t>
+void test_kokkos_matrix_update(const x_t &x, const y_t &y, A_t &A,
+                               gold_t get_gold, action_t action)
+{
+  // backup y to verify it is not changed after kernel
+  auto y_preKernel = kokkostesting::create_stdvector_and_copy(y);
+  test_kokkos_matrix_update(x, A, get_gold, action);
+  EXPECT_TRUE(is_same_vector(y, y_preKernel));
+}
+
+template<class x_t, class y_t, class A_t, class Triangle, class Scalar = typename x_t::element_type>
+void test_kokkos_hermitian_matrix_rank2_update_impl(const x_t &x, const y_t &y, A_t &A, Triangle t)
+{
+  const auto get_gold = [&](auto A_gold) {
+      hermitian_matrix_rank_2_update_gold_solution(x, y, A_gold, t);
+    };
+  const auto compute = [&]() {
+      std::experimental::linalg::hermitian_matrix_rank_2_update(
+        KokkosKernelsSTD::kokkos_exec<>(), x, y, A, t);
+    };
+  test_kokkos_matrix_update(x, y, A, get_gold, compute);
+}
+
+} // anonymous namespace
+
+#define DEFINE_TESTS(blas_val_type)                                          \
+TEST_F(blas2_signed_##blas_val_type##_fixture,                               \
+       kokkos_hermitian_matrix_rank2_update) {                               \
+  using val_t = typename blas2_signed_##blas_val_type##_fixture::value_type; \
+  run_checked_tests<val_t>("kokkos_", "hermitian_matrix_rank2_update", "",   \
+                           #blas_val_type, [&]() {                           \
+                                                                             \
+    test_kokkos_hermitian_matrix_rank2_update_impl(x_e0, y_e0, A_sym_e0,     \
+                            std::experimental::linalg::lower_triangle);      \
+    test_kokkos_hermitian_matrix_rank2_update_impl(x_e0, y_e0, A_sym_e0,     \
+                            std::experimental::linalg::upper_triangle);      \
+                                                                             \
+  });                                                                        \
+}
+
+FOR_ALL_BLAS2_TYPES(DEFINE_TESTS);

--- a/tests/kokkos-based/symmetric_matrix_rank2_update_kokkos.cpp
+++ b/tests/kokkos-based/symmetric_matrix_rank2_update_kokkos.cpp
@@ -1,0 +1,329 @@
+ /*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2019) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include "gtest_fixtures.hpp"
+#include "helpers.hpp"
+
+namespace{
+
+////////////////////////////////////////////////////////////
+// Utilities
+////////////////////////////////////////////////////////////
+
+// create rank-1 mdspan (vector)
+template <typename value_type,
+          typename mdspan_t = typename _blas2_signed_fixture<value_type>::mdspan_r1_t>
+inline mdspan_t make_mdspan(value_type *data, std::size_t ext) {
+  return mdspan_t(data, ext);
+}
+
+template <typename value_type,
+          typename mdspan_t = typename _blas2_signed_fixture<const value_type>::mdspan_r1_t>
+inline mdspan_t make_mdspan(const value_type *data, std::size_t ext) {
+  return mdspan_t(data, ext);
+}
+
+template <typename value_type>
+inline auto make_mdspan(std::vector<value_type> &v) {
+  return make_mdspan(v.data(), v.size());
+}
+
+template <typename value_type>
+inline auto make_mdspan(const std::vector<value_type> &v) {
+  return make_mdspan(v.data(), v.size());
+}
+
+// create rank-2 mdspan (matrix)
+template <typename value_type,
+          typename mdspan_t = typename _blas2_signed_fixture<value_type>::mdspan_r2_t>
+inline mdspan_t make_mdspan(value_type *data, std::size_t ext0, std::size_t ext1) {
+  return mdspan_t(data, ext0, ext1);
+}
+
+template <typename ElementType1,
+          typename LayoutPolicy1,
+          typename AccessorPolicy1,
+          typename ElementType2,
+          typename LayoutPolicy2,
+          typename AccessorPolicy2>
+inline bool is_same_vector(
+    const mdspan<ElementType1, extents<dynamic_extent>, LayoutPolicy1, AccessorPolicy1> &v1,
+    const mdspan<ElementType2, extents<dynamic_extent>, LayoutPolicy2, AccessorPolicy2> &v2)
+{
+  const auto size = v1.extent(0);
+  if (size != v2.extent(0))
+    return false;
+  const auto v1_view = KokkosKernelsSTD::Impl::mdspan_to_view(v1);
+  const auto v2_view = KokkosKernelsSTD::Impl::mdspan_to_view(v2);
+  int diff = false;
+  Kokkos::parallel_reduce(size,
+    KOKKOS_LAMBDA(const std::size_t i, decltype(diff) &d){
+        d = d || !(v1_view(i) == v2_view(i));
+	    }, diff);
+  return !diff;
+}
+
+template <typename ElementType1,
+          typename LayoutPolicy,
+          typename AccessorPolicy,
+          typename ElementType2>
+inline bool is_same_vector(
+    const mdspan<ElementType1, extents<dynamic_extent>, LayoutPolicy, AccessorPolicy> &v1,
+    const std::vector<ElementType2> &v2)
+{
+  return is_same_vector(v1, make_mdspan(v2));
+}
+
+template <typename ElementType1,
+          typename LayoutPolicy,
+          typename AccessorPolicy,
+          typename ElementType2>
+inline bool is_same_vector(
+    const std::vector<ElementType1> &v1,
+    const mdspan<ElementType2, extents<dynamic_extent>, LayoutPolicy, AccessorPolicy> &v2)
+{
+  return is_same_vector(v2, v1);
+}
+
+template <typename ElementType>
+inline bool is_same_vector(
+    const std::vector<ElementType> &v1,
+    const std::vector<ElementType> &v2)
+{
+  return is_same_vector(make_mdspan(v1), make_mdspan(v2));
+}
+
+// real diff: d = |v1 - v2|
+template <typename T, typename enabled=void>
+class value_diff {
+public:
+  value_diff(const T &val1, const T &val2): _v(fabs(val1 - val2)) {}
+  operator T() const { return _v; }
+protected:
+  value_diff() = default;
+  T _v;
+};
+
+// real diff: d = max(|R(v1) - R(v2)|, |I(v1) - I(v2)|)
+// Note: returned value is of underlying real type
+template <typename T>
+class value_diff<std::complex<T>>: public value_diff<T> {
+  using base = value_diff<T>;
+public:
+  value_diff(const std::complex<T> &val1, const std::complex<T> &val2) {
+    const T dreal = base(val1.real(), val2.real());
+    const T dimag = base(val1.imag(), val2.imag());
+    base::_v = std::max(dreal, dimag);
+  }
+};
+
+template <typename T>
+class value_diff<Kokkos::complex<T>>: public value_diff<T> {
+  using base = value_diff<T>;
+public:
+  KOKKOS_INLINE_FUNCTION
+  value_diff(const Kokkos::complex<T> &val1, const Kokkos::complex<T> &val2) {
+    const T dreal = base(val1.real(), val2.real());
+    const T dimag = base(val1.imag(), val2.imag());
+    base::_v = dreal > dimag ? dreal : dimag; // can't use std::max on GPU
+  }
+};
+
+template <typename ElementType,
+          typename LayoutPolicy1,
+          typename AccessorPolicy1,
+          typename LayoutPolicy2,
+          typename AccessorPolicy2,
+          typename ToleranceType>
+inline bool is_same_matrix(
+    const mdspan<ElementType, extents<dynamic_extent, dynamic_extent>, LayoutPolicy1, AccessorPolicy1> &A,
+    const mdspan<ElementType, extents<dynamic_extent, dynamic_extent>, LayoutPolicy2, AccessorPolicy2> &B,
+    ToleranceType tolerance)
+{
+  const auto ext0 = A.extent(0);
+  const auto ext1 = A.extent(1);
+  if (B.extent(0) != ext0 or B.extent(1) != ext1)
+    return false;
+  const auto A_view = KokkosKernelsSTD::Impl::mdspan_to_view(A);
+  const auto B_view = KokkosKernelsSTD::Impl::mdspan_to_view(B);
+  int diff = false;
+  Kokkos::parallel_reduce(ext0,
+    KOKKOS_LAMBDA(std::size_t i, decltype(diff) &d) {
+        for (decltype(i) j = 0; j < ext1; ++j) {
+          d = d || (value_diff(A_view(i, j), B_view(i, j)) > tolerance);
+        }
+	    }, diff);
+  return !diff;
+}
+
+namespace Impl {
+
+template <typename T, typename enabled=void> struct _tolerance_out { using type = T; };
+template <typename T> struct _tolerance_out<std::complex<T>> { using type = T; };
+
+}
+
+template <typename T>
+Impl::_tolerance_out<T>::type tolerance(double double_tol, float float_tol);
+
+template <> double tolerance<double>(double double_tol, float float_tol) { return double_tol; }
+template <> float  tolerance<float>( double double_tol, float float_tol) { return float_tol; }
+template <> double tolerance<std::complex<double>>(double double_tol, float float_tol) { return double_tol; }
+template <> float  tolerance<std::complex<float>>( double double_tol, float float_tol) { return float_tol; }
+
+template <typename value_type, typename enabled = void>
+struct check_types: public std::true_type {};
+
+// checks if std::complex<T> and Kokkos::complex<T> are aligned
+// (they can get misalligned when Kokkos is build with Kokkos_ENABLE_COMPLEX_ALIGN=ON)
+template <typename T>
+struct check_types<std::complex<T>> {
+  static constexpr bool value = alignof(std::complex<T>) == alignof(Kokkos::complex<T>);
+};
+
+template <typename value_type>
+inline constexpr auto check_types_v = check_types<value_type>::value;
+
+template <typename value_type, typename cb_type>
+void run_checked_tests(const std::string_view test_prefix, const std::string_view method_name,
+                       const std::string_view test_postfix, const std::string_view type_spec,
+                       const cb_type cb) {
+  if constexpr (check_types_v<value_type>) {
+    cb();
+  } else {
+    std::cout << "***\n"
+              << "***  Warning: " << test_prefix << method_name << test_postfix << " skipped for "
+              << type_spec << " (type check failed)\n"
+              << "***" << std::endl;
+    /* avoid dispatcher check failure if all cases are skipped this way */
+    KokkosKernelsSTD::Impl::signal_kokkos_impl_called(method_name);
+  }
+}
+
+#define FOR_ALL_BLAS2_TYPES(TEST_DEF) \
+  TEST_DEF(double) \
+  TEST_DEF(float) \
+  TEST_DEF(complex_double)
+
+
+////////////////////////////////////////////////////////////
+// Tests
+////////////////////////////////////////////////////////////
+
+template<class x_t, class y_t, class A_t, class Triangle>
+void symmetric_matrix_rank_2_update_gold_solution(const x_t &x, const y_t &y, A_t &A, Triangle /* t */)
+{
+  using size_type = std::experimental::extents<>::size_type;
+  constexpr bool low = std::is_same_v<Triangle, std::experimental::linalg::lower_triangle_t>;
+  for (size_type j = 0; j < A.extent(1); ++j) {
+    const size_type i1 = low ? A.extent(0) : j + 1;
+    for (size_type i = low ? j : 0; i < i1; ++i) {
+      A(i,j) += x(i) * y(j) + y(i) * x(j);
+    }
+  }
+}
+
+template<class x_t, class A_t, typename gold_t, typename action_t>
+void test_kokkos_matrix_update(const x_t &x, A_t &A, gold_t get_gold, action_t action)
+{
+  using value_type = typename x_t::value_type;
+
+  // backup x to verify it is not changed after kernel
+  auto x_preKernel = kokkostesting::create_stdvector_and_copy(x);
+
+  // compute gold
+  auto A_copy = kokkostesting::create_stdvector_and_copy_rowwise(A);
+  auto A_gold = make_mdspan(A_copy.data(), A.extent(0), A.extent(1));
+  get_gold(A_gold);
+
+  // run tested routine
+  action();
+
+  // compare results with gold
+  EXPECT_TRUE(is_same_matrix(A_gold, A, tolerance<value_type>(1e-9, 1e-2f)));
+
+  // x should not change after kernel
+  EXPECT_TRUE(is_same_vector(x, x_preKernel));
+}
+
+template<class x_t, class y_t, class A_t, typename gold_t, typename action_t>
+void test_kokkos_matrix_update(const x_t &x, const y_t &y, A_t &A,
+                               gold_t get_gold, action_t action)
+{
+  // backup y to verify it is not changed after kernel
+  auto y_preKernel = kokkostesting::create_stdvector_and_copy(y);
+  test_kokkos_matrix_update(x, A, get_gold, action);
+  EXPECT_TRUE(is_same_vector(y, y_preKernel));
+}
+
+template<class x_t, class y_t, class A_t, class Triangle, class Scalar = typename x_t::element_type>
+void test_kokkos_symmetric_matrix_rank2_update_impl(const x_t &x, const y_t &y, A_t &A, Triangle t)
+{
+  const auto get_gold = [&](auto A_gold) {
+      symmetric_matrix_rank_2_update_gold_solution(x, y, A_gold, t);
+    };
+  const auto compute = [&]() {
+      std::experimental::linalg::symmetric_matrix_rank_2_update(
+        KokkosKernelsSTD::kokkos_exec<>(), x, y, A, t);
+    };
+  test_kokkos_matrix_update(x, y, A, get_gold, compute);
+}
+
+} // anonymous namespace
+
+#define DEFINE_TESTS(blas_val_type)                                          \
+TEST_F(blas2_signed_##blas_val_type##_fixture,                               \
+       kokkos_symmetric_matrix_rank2_update) {                               \
+  using val_t = typename blas2_signed_##blas_val_type##_fixture::value_type; \
+  run_checked_tests<val_t>("kokkos_", "symmetric_matrix_rank2_update", "",   \
+                           #blas_val_type, [&]() {                           \
+                                                                             \
+    test_kokkos_symmetric_matrix_rank2_update_impl(x_e0, y_e0, A_sym_e0,     \
+                            std::experimental::linalg::lower_triangle);      \
+    test_kokkos_symmetric_matrix_rank2_update_impl(x_e0, y_e0, A_sym_e0,     \
+                            std::experimental::linalg::upper_triangle);      \
+                                                                             \
+  });                                                                        \
+}
+
+FOR_ALL_BLAS2_TYPES(DEFINE_TESTS);

--- a/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas2_matrix_rank_2_update.hpp
+++ b/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas2_matrix_rank_2_update.hpp
@@ -1,0 +1,305 @@
+ /*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2019) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef LINALG_TPLIMPLEMENTATIONS_INCLUDE_EXPERIMENTAL___P1673_BITS_KOKKOSKERNELS_BLAS2_MATRIX_RANK_2_UPDATE_HPP_
+#define LINALG_TPLIMPLEMENTATIONS_INCLUDE_EXPERIMENTAL___P1673_BITS_KOKKOSKERNELS_BLAS2_MATRIX_RANK_2_UPDATE_HPP_
+
+#include <complex>
+#include "signal_kokkos_impl_called.hpp"
+
+namespace KokkosKernelsSTD {
+
+namespace mtxr2update_impl {
+
+// manages parallel execution of independent action
+// called like action(i, j) for each matrix element A(i, j)
+template <typename ExecSpace, typename MatrixType>
+class ParallelMatrixVisitor {
+public:
+  KOKKOS_INLINE_FUNCTION ParallelMatrixVisitor(ExecSpace &&exec_in, MatrixType A_in):
+    exec(exec_in), A(A_in), ext0(A.extent(0)), ext1(A.extent(1))
+  {}
+
+  template <typename ActionType>
+  KOKKOS_INLINE_FUNCTION
+  void for_each_matrix_element(ActionType action) {
+    if (ext0 > ext1) { // parallel rows
+      Kokkos::parallel_for(Kokkos::RangePolicy(exec, 0, ext0),
+        KOKKOS_LAMBDA(const auto i) {
+          using idx_type = std::remove_const_t<decltype(i)>;
+          for (idx_type j = 0; j < ext1; ++j) {
+            action(i, j);
+          }
+        });
+    } else { // parallel columns
+      Kokkos::parallel_for(Kokkos::RangePolicy(exec, 0, ext1),
+        KOKKOS_LAMBDA(const auto j) {
+          using idx_type = std::remove_const_t<decltype(j)>;
+          for (idx_type i = 0; i < ext0; ++i) {
+            action(i, j);
+          }
+        });
+    }
+    exec.fence();
+  }
+
+  template <typename ActionType>
+  void for_each_triangle_matrix_element(std::experimental::linalg::upper_triangle_t t, ActionType action) {
+    Kokkos::parallel_for(Kokkos::RangePolicy(exec, 0, ext1),
+      KOKKOS_LAMBDA(const auto j) {
+        using idx_type = std::remove_const_t<decltype(j)>;
+        for (idx_type i = 0; i <= j; ++i) {
+          action(i, j);
+        }
+      });
+    exec.fence();
+  }
+
+  template <typename ActionType>
+  void for_each_triangle_matrix_element(std::experimental::linalg::lower_triangle_t t, ActionType action) {
+    for_each_triangle_matrix_element(std::experimental::linalg::upper_triangle,
+        [action](const auto i, const auto j) {
+          action(j, i);
+      });
+  }
+
+private:
+  ExecSpace exec;
+  MatrixType A;
+  size_t ext0;
+  size_t ext1;
+};
+
+// Note: phrase it simply and the same as in specification ("has unique layout")
+template <typename Layout,
+          std::experimental::extents<>::size_type numRows,
+          std::experimental::extents<>::size_type numCols>
+
+inline constexpr bool is_unique_layout_v = Layout::template mapping<
+    std::experimental::extents<numRows, numCols> >::is_always_unique();
+
+template <typename Layout>
+struct is_layout_blas_packed: public std::false_type {};
+
+template <typename Triangle, typename StorageOrder>
+struct is_layout_blas_packed<
+  std::experimental::linalg::layout_blas_packed<Triangle, StorageOrder>>:
+    public std::true_type {};
+
+template <typename Layout>
+inline constexpr bool is_layout_blas_packed_v = is_layout_blas_packed<Layout>::value;
+
+// Note: will only signal failure for layout_blas_packed with different triangle
+template <typename Layout, typename Triangle>
+struct triangle_layout_match: public std::true_type {};
+
+template <typename StorageOrder, typename Triangle1, typename Triangle2>
+struct triangle_layout_match<
+  std::experimental::linalg::layout_blas_packed<Triangle1, StorageOrder>,
+  Triangle2>
+{
+  static constexpr bool value = std::is_same_v<Triangle1, Triangle2>;
+};
+
+template <typename Layout, typename Triangle>
+inline constexpr bool triangle_layout_match_v = triangle_layout_match<Layout, Triangle>::value;
+
+// This version of conj_if_needed() also handles Kokkos::complex<T>
+template <class T>
+KOKKOS_INLINE_FUNCTION
+T conj_if_needed(const T &value)
+{
+  return value;
+}
+
+template <class T>
+KOKKOS_INLINE_FUNCTION
+auto conj_if_needed(const Kokkos::complex<T> &value)
+{
+  return Kokkos::conj(value);
+}
+
+template <class T>
+KOKKOS_INLINE_FUNCTION
+auto conj_if_needed(const std::complex<T> &value)
+{
+  return std::conj(value);
+}
+
+template <class size_type>
+KOKKOS_INLINE_FUNCTION
+constexpr bool static_extent_match(size_type extent1, size_type extent2)
+{
+  return extent1 == std::experimental::dynamic_extent ||
+         extent2 == std::experimental::dynamic_extent ||
+         extent1 == extent2;
+}
+
+} // namespace mtxr2update_impl
+
+// Rank-2 update of a symmetric matrix
+// performs BLAS xSYR2/xSPR2: A[i,j] += x[i] * y[j] + y[i] * x[j]
+
+template<class ExecSpace,
+         class ElementType_x,
+         std::experimental::extents<>::size_type ext_x,
+         class Layout_x,
+         class ElementType_y,
+         std::experimental::extents<>::size_type ext_y,
+         class Layout_y,
+         class ElementType_A,
+         std::experimental::extents<>::size_type numRows_A,
+         std::experimental::extents<>::size_type numCols_A,
+         class Layout_A,
+         class Triangle>
+  requires (mtxr2update_impl::is_unique_layout_v<Layout_A, numRows_A, numCols_A>
+            or mtxr2update_impl::is_layout_blas_packed_v<Layout_A>)
+void symmetric_matrix_rank_2_update(kokkos_exec<ExecSpace> &&exec,
+  std::experimental::mdspan<ElementType_x, std::experimental::extents<ext_x>, Layout_x,
+    std::experimental::default_accessor<ElementType_x>> x,
+  std::experimental::mdspan<ElementType_y, std::experimental::extents<ext_y>, Layout_y,
+    std::experimental::default_accessor<ElementType_y>> y,
+  std::experimental::mdspan<ElementType_A, std::experimental::extents<numRows_A, numCols_A>, Layout_A,
+    std::experimental::default_accessor<ElementType_A>> A,
+  Triangle t)
+{
+  // P1673 constraints (redundant to mdspan extents in the header)
+  static_assert(A.rank() == 2);
+  static_assert(x.rank() == 1);
+  static_assert(y.rank() == 1);
+  static_assert(mtxr2update_impl::triangle_layout_match_v<Layout_A, Triangle>);
+
+  // P1673 mandates
+  static_assert(mtxr2update_impl::static_extent_match(A.static_extent(0), A.static_extent(1)));
+  static_assert(mtxr2update_impl::static_extent_match(A.static_extent(0), x.static_extent(0)));
+  static_assert(mtxr2update_impl::static_extent_match(A.static_extent(0), y.static_extent(0)));
+
+  // P1673 preconditions
+  if ( A.extent(0) != A.extent(1) ){
+    throw std::runtime_error("KokkosBlas: symmetric_matrix_rank_1_update: A.extent(0) != A.extent(1)");
+  }
+  if ( A.extent(0) != x.extent(0) ){
+    throw std::runtime_error("KokkosBlas: symmetric_matrix_rank_1_update: A.extent(0) != x.extent(0)");
+  }
+  if ( A.extent(0) != y.extent(0) ){
+    throw std::runtime_error("KokkosBlas: symmetric_matrix_rank_1_update: A.extent(0) != y.extent(0)");
+  }
+
+  Impl::signal_kokkos_impl_called("symmetric_matrix_rank2_update");
+
+  // convert mdspans to views
+  const auto x_view = Impl::mdspan_to_view(x);
+  const auto y_view = Impl::mdspan_to_view(y);
+  auto A_view = Impl::mdspan_to_view(A);
+  mtxr2update_impl::ParallelMatrixVisitor v(ExecSpace(), A_view);
+  v.for_each_triangle_matrix_element(t,
+    KOKKOS_LAMBDA(const auto i, const auto j) {
+      A_view(i, j) += x_view(i) * y_view(j) + y_view(i) * x_view(j);
+    });
+}
+
+// Rank-2 update of a Hermitian matrix
+// performs BLAS xHER2/xHPR2: x[i] * conj(y[j]) + y[i] * conj(x[j])
+
+template<class ExecSpace,
+         class ElementType_x,
+         std::experimental::extents<>::size_type ext_x,
+         class Layout_x,
+         class ElementType_y,
+         std::experimental::extents<>::size_type ext_y,
+         class Layout_y,
+         class ElementType_A,
+         std::experimental::extents<>::size_type numRows_A,
+         std::experimental::extents<>::size_type numCols_A,
+         class Layout_A,
+         class Triangle>
+  requires (mtxr2update_impl::is_unique_layout_v<Layout_A, numRows_A, numCols_A>
+            or mtxr2update_impl::is_layout_blas_packed_v<Layout_A>)
+void hermitian_matrix_rank_2_update(kokkos_exec<ExecSpace> &&exec,
+  std::experimental::mdspan<ElementType_x, std::experimental::extents<ext_x>, Layout_x,
+    std::experimental::default_accessor<ElementType_x>> x,
+  std::experimental::mdspan<ElementType_y, std::experimental::extents<ext_y>, Layout_y,
+    std::experimental::default_accessor<ElementType_y>> y,
+  std::experimental::mdspan<ElementType_A, std::experimental::extents<numRows_A, numCols_A>, Layout_A,
+    std::experimental::default_accessor<ElementType_A>> A,
+  Triangle t)
+{
+  // P1673 constraints (redundant to mdspan extents in the header)
+  static_assert(A.rank() == 2);
+  static_assert(x.rank() == 1);
+  static_assert(y.rank() == 1);
+  static_assert(mtxr2update_impl::triangle_layout_match_v<Layout_A, Triangle>);
+
+  // P1673 mandates
+  static_assert(mtxr2update_impl::static_extent_match(A.static_extent(0), A.static_extent(1)));
+  static_assert(mtxr2update_impl::static_extent_match(A.static_extent(0), x.static_extent(0)));
+  static_assert(mtxr2update_impl::static_extent_match(A.static_extent(0), y.static_extent(0)));
+
+  // P1673 preconditions
+  if ( A.extent(0) != A.extent(1) ){
+    throw std::runtime_error("KokkosBlas: hermitian_matrix_rank_1_update: A.extent(0) != A.extent(1)");
+  }
+  if ( A.extent(0) != x.extent(0) ){
+    throw std::runtime_error("KokkosBlas: hermitian_matrix_rank_1_update: A.extent(0) != x.extent(0)");
+  }
+  if ( A.extent(0) != y.extent(0) ){
+    throw std::runtime_error("KokkosBlas: hermitian_matrix_rank_1_update: A.extent(0) != y.extent(0)");
+  }
+
+  Impl::signal_kokkos_impl_called("hermitian_matrix_rank2_update");
+
+  // convert mdspans to views
+  const auto x_view = Impl::mdspan_to_view(x);
+  const auto y_view = Impl::mdspan_to_view(y);
+  auto A_view = Impl::mdspan_to_view(A);
+  mtxr2update_impl::ParallelMatrixVisitor v(ExecSpace(), A_view);
+  v.for_each_triangle_matrix_element(t,
+    KOKKOS_LAMBDA(const auto i, const auto j) {
+      const auto yjc = mtxr2update_impl::conj_if_needed(y_view(j));
+      const auto xjc = mtxr2update_impl::conj_if_needed(x_view(j));
+      A_view(i, j) += x_view(i) * yjc + y_view(i) * xjc;
+    });
+}
+
+} // namespace KokkosKernelsSTD
+#endif

--- a/tpl-implementations/include/experimental/linalg_kokkoskernels
+++ b/tpl-implementations/include/experimental/linalg_kokkoskernels
@@ -10,6 +10,7 @@
 #include "__p1673_bits/kokkos-kernels/blas1_vector_abs_sum_kk.hpp"
 #include "__p1673_bits/kokkos-kernels/blas1_vector_sum_of_squares_kk.hpp"
 #include "__p1673_bits/kokkos-kernels/blas2_matrix_rank_1_update.hpp"
+#include "__p1673_bits/kokkos-kernels/blas2_matrix_rank_2_update.hpp"
 #include "__p1673_bits/kokkos-kernels/blas1_swap_elements_kk.hpp"
 #include "__p1673_bits/kokkos-kernels/blas2_gemv_kk.hpp"
 #include "__p1673_bits/kokkos-kernels/blas2_symv_kk.hpp"


### PR DESCRIPTION
This PR adds Kokkos implementations of `symmetric_matrix_rank_2_update()` and `hermitian_matrix_rank_2_update()`.

> CMake tests are supplied by follow-up PR https://github.com/kokkos/stdBLAS/pull/178.

> This PR is related to rank-1 routines: #167 (symmetric), #168 (hermitian) and  #157 (regular)