### PR TITLE
Make `conj_if_needed` work with `Kokkos::complex` #173

### DIFF
--- a/tests/kokkos-based/hermitian_matrix_rank1_update_kokkos.cpp
+++ b/tests/kokkos-based/hermitian_matrix_rank1_update_kokkos.cpp
@@ -52,12 +52,12 @@ template<class x_t, class A_t, class Triangle>
 void hermitian_matrix_rank_1_update_gold_solution(const x_t &x, A_t &A, Triangle /* t */)
 {
   using size_type = std::experimental::extents<>::size_type;
-  constexpr auto conj = std::experimental::linalg::impl::conj_if_needed;
+  using std::experimental::linalg::impl::conj_if_needed;
   constexpr bool low = std::is_same_v<Triangle, std::experimental::linalg::lower_triangle_t>;
   for (size_type j = 0; j < A.extent(1); ++j) {
     const size_type i1 = low ? A.extent(0) : j + 1;
     for (size_type i = low ? j : 0; i < i1; ++i) {
-      A(i,j) += x(i) * conj(x(j));
+      A(i,j) += x(i) * conj_if_needed(x(j));
     }
   }
 }

--- a/tests/kokkos-based/hermitian_matrix_rank2_update_kokkos.cpp
+++ b/tests/kokkos-based/hermitian_matrix_rank2_update_kokkos.cpp
@@ -51,13 +51,13 @@ using namespace kokkostesting;
 template<class x_t, class y_t, class A_t, class Triangle>
 void hermitian_matrix_rank_2_update_gold_solution(const x_t &x, const y_t &y, A_t &A, Triangle /* t */)
 {
+  using std::experimental::linalg::impl::conj_if_needed;
   using size_type = std::experimental::extents<>::size_type;
-  constexpr auto conj = std::experimental::linalg::impl::conj_if_needed;
   constexpr bool low = std::is_same_v<Triangle, std::experimental::linalg::lower_triangle_t>;
   for (size_type j = 0; j < A.extent(1); ++j) {
     const size_type i1 = low ? A.extent(0) : j + 1;
     for (size_type i = low ? j : 0; i < i1; ++i) {
-      A(i,j) += x(i) * conj(y(j)) + y(i) * conj(x(j));
+      A(i,j) += x(i) * conj_if_needed(y(j)) + y(i) * conj_if_needed(x(j));
     }
   }
 }

--- a/tests/kokkos-based/hermitian_matrix_rank2_update_kokkos.cpp
+++ b/tests/kokkos-based/hermitian_matrix_rank2_update_kokkos.cpp
@@ -51,14 +51,13 @@ using namespace kokkostesting;
 template<class x_t, class y_t, class A_t, class Triangle>
 void hermitian_matrix_rank_2_update_gold_solution(const x_t &x, const y_t &y, A_t &A, Triangle /* t */)
 {
-  using KokkosKernelsSTD::mtxr2update_impl::conj_if_needed;
   using size_type = std::experimental::extents<>::size_type;
+  constexpr auto conj = std::experimental::linalg::impl::conj_if_needed;
   constexpr bool low = std::is_same_v<Triangle, std::experimental::linalg::lower_triangle_t>;
   for (size_type j = 0; j < A.extent(1); ++j) {
     const size_type i1 = low ? A.extent(0) : j + 1;
     for (size_type i = low ? j : 0; i < i1; ++i) {
-      A(i,j) += x(i) * conj_if_needed(y(j))
-              + y(i) * conj_if_needed(x(j));
+      A(i,j) += x(i) * conj(y(j)) + y(i) * conj(x(j));
     }
   }
 }

--- a/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas2_matrix_rank_1_update.hpp
+++ b/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas2_matrix_rank_1_update.hpp
@@ -251,12 +251,12 @@ void matrix_rank_1_update(kokkos_exec<ExecSpace> &&/* exec */,
   auto y_view = Impl::mdspan_to_view(y);
   auto A_view = Impl::mdspan_to_view(A);
 
-  constexpr auto conj = std::experimental::linalg::impl::conj_if_needed;
+  using std::experimental::linalg::impl::conj_if_needed;
   Impl::ParallelMatrixVisitor v(ExecSpace(), A_view);
   v.for_each_matrix_element(
     KOKKOS_LAMBDA(const auto i, const auto j) {
       // apply conjugation explicitly (accessor is no longer on the view, see #122)
-      A_view(i, j) += x_view(i) * conj(y_view(j));
+      A_view(i, j) += x_view(i) * conj_if_needed(y_view(j));
     });
 }
 
@@ -353,11 +353,11 @@ void hermitian_matrix_rank_1_update(kokkos_exec<ExecSpace> &&exec,
   auto x_view = Impl::mdspan_to_view(x);
   auto A_view = Impl::mdspan_to_view(A);
 
-  constexpr auto conj = std::experimental::linalg::impl::conj_if_needed;
+  using std::experimental::linalg::impl::conj_if_needed;
   Impl::ParallelMatrixVisitor v(ExecSpace(), A_view);
   v.for_each_triangle_matrix_element(t,
     KOKKOS_LAMBDA(const auto i, const auto j) {
-      A_view(i, j) += x_view(i) * conj(x_view(j));
+      A_view(i, j) += x_view(i) * conj_if_needed(x_view(j));
     });
 }
 

--- a/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas2_matrix_rank_1_update.hpp
+++ b/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas2_matrix_rank_1_update.hpp
@@ -144,28 +144,6 @@ struct triangle_layout_match<
 template <typename Layout, typename Triangle>
 inline constexpr bool triangle_layout_match_v = triangle_layout_match<Layout, Triangle>::value;
 
-// This version of conj_if_needed() also handles Kokkos::complex<T>
-template <class T>
-KOKKOS_INLINE_FUNCTION
-T conj_if_needed(const T &value)
-{
-  return value;
-}
-
-template <class T>
-KOKKOS_INLINE_FUNCTION
-auto conj_if_needed(const Kokkos::complex<T> &value)
-{
-  return Kokkos::conj(value);
-}
-
-template <class T>
-KOKKOS_INLINE_FUNCTION
-auto conj_if_needed(const std::complex<T> &value)
-{
-  return std::conj(value);
-}
-
 template <class size_type>
 KOKKOS_INLINE_FUNCTION
 constexpr bool static_extent_match(size_type extent1, size_type extent2)
@@ -273,11 +251,12 @@ void matrix_rank_1_update(kokkos_exec<ExecSpace> &&/* exec */,
   auto y_view = Impl::mdspan_to_view(y);
   auto A_view = Impl::mdspan_to_view(A);
 
+  constexpr auto conj = std::experimental::linalg::impl::conj_if_needed;
   Impl::ParallelMatrixVisitor v(ExecSpace(), A_view);
   v.for_each_matrix_element(
     KOKKOS_LAMBDA(const auto i, const auto j) {
       // apply conjugation explicitly (accessor is no longer on the view, see #122)
-      A_view(i, j) += x_view(i) * Impl::conj_if_needed(y_view(j));
+      A_view(i, j) += x_view(i) * conj(y_view(j));
     });
 }
 
@@ -373,10 +352,12 @@ void hermitian_matrix_rank_1_update(kokkos_exec<ExecSpace> &&exec,
 
   auto x_view = Impl::mdspan_to_view(x);
   auto A_view = Impl::mdspan_to_view(A);
+
+  constexpr auto conj = std::experimental::linalg::impl::conj_if_needed;
   Impl::ParallelMatrixVisitor v(ExecSpace(), A_view);
   v.for_each_triangle_matrix_element(t,
     KOKKOS_LAMBDA(const auto i, const auto j) {
-      A_view(i, j) += x_view(i) * Impl::conj_if_needed(x_view(j));
+      A_view(i, j) += x_view(i) * conj(x_view(j));
     });
 }
 

--- a/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas2_matrix_rank_2_update.hpp
+++ b/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas2_matrix_rank_2_update.hpp
@@ -144,27 +144,6 @@ struct triangle_layout_match<
 template <typename Layout, typename Triangle>
 inline constexpr bool triangle_layout_match_v = triangle_layout_match<Layout, Triangle>::value;
 
-// This version of conj_if_needed() also handles Kokkos::complex<T>
-template <class T>
-KOKKOS_INLINE_FUNCTION
-T conj_if_needed(const T &value)
-{
-  return value;
-}
-
-template <class T>
-KOKKOS_INLINE_FUNCTION
-auto conj_if_needed(const Kokkos::complex<T> &value)
-{
-  return Kokkos::conj(value);
-}
-
-template <class T>
-KOKKOS_INLINE_FUNCTION
-auto conj_if_needed(const std::complex<T> &value)
-{
-  return std::conj(value);
-}
 
 template <class size_type>
 KOKKOS_INLINE_FUNCTION
@@ -292,12 +271,12 @@ void hermitian_matrix_rank_2_update(kokkos_exec<ExecSpace> &&exec,
   const auto x_view = Impl::mdspan_to_view(x);
   const auto y_view = Impl::mdspan_to_view(y);
   auto A_view = Impl::mdspan_to_view(A);
+
+  constexpr auto conj = std::experimental::linalg::impl::conj_if_needed;
   mtxr2update_impl::ParallelMatrixVisitor v(ExecSpace(), A_view);
   v.for_each_triangle_matrix_element(t,
     KOKKOS_LAMBDA(const auto i, const auto j) {
-      const auto yjc = mtxr2update_impl::conj_if_needed(y_view(j));
-      const auto xjc = mtxr2update_impl::conj_if_needed(x_view(j));
-      A_view(i, j) += x_view(i) * yjc + y_view(i) * xjc;
+      A_view(i, j) += x_view(i) * conj(y_view(j)) + y_view(i) * conj(x_view(j));
     });
 }
 

--- a/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas2_matrix_rank_2_update.hpp
+++ b/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas2_matrix_rank_2_update.hpp
@@ -272,11 +272,12 @@ void hermitian_matrix_rank_2_update(kokkos_exec<ExecSpace> &&exec,
   const auto y_view = Impl::mdspan_to_view(y);
   auto A_view = Impl::mdspan_to_view(A);
 
-  constexpr auto conj = std::experimental::linalg::impl::conj_if_needed;
+  using std::experimental::linalg::impl::conj_if_needed;
   mtxr2update_impl::ParallelMatrixVisitor v(ExecSpace(), A_view);
   v.for_each_triangle_matrix_element(t,
     KOKKOS_LAMBDA(const auto i, const auto j) {
-      A_view(i, j) += x_view(i) * conj(y_view(j)) + y_view(i) * conj(x_view(j));
+      A_view(i, j) += x_view(i) * conj_if_needed(y_view(j))
+                    + y_view(i) * conj_if_needed(x_view(j));
     });
 }
 

--- a/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/kokkos_conjugate.hpp
+++ b/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/kokkos_conjugate.hpp
@@ -1,0 +1,61 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2019) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software. //
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef LINALG_TPLIMPLEMENTATIONS_INCLUDE_EXPERIMENTAL___P1673_BITS_KOKKOSKERNELS_CONJUGATE_IF_NEEDED_HPP_
+#define LINALG_TPLIMPLEMENTATIONS_INCLUDE_EXPERIMENTAL___P1673_BITS_KOKKOSKERNELS_CONJUGATE_IF_NEEDED_HPP_
+
+#include "experimental/__p1673_bits/conjugate_if_needed.hpp"
+
+namespace std {
+namespace experimental {
+namespace linalg {
+namespace impl{
+
+// add Kokkos::complex<T> to scalar types conjugated by conj_if_needed()
+template<class T> struct is_complex<Kokkos::complex<T>> : std::true_type{};
+
+} // end namespace impl
+} // end namespace linalg
+} // end namespace experimental
+} // end namespace std
+
+#endif //LINALG_TPLIMPLEMENTATIONS_INCLUDE_EXPERIMENTAL___P1673_BITS_KOKKOSKERNELS_CONJUGATE_IF_NEEDED_HPP_

--- a/tpl-implementations/include/experimental/linalg_kokkoskernels
+++ b/tpl-implementations/include/experimental/linalg_kokkoskernels
@@ -2,6 +2,7 @@
 #include<experimental/mdspan>
 #include<KokkosBlas.hpp>
 #include "__p1673_bits/kokkos-kernels/mdspan_to_view_mapper_kk.hpp"
+#include "__p1673_bits/kokkos-kernels/kokkos_conjugate.hpp"
 #include "__p1673_bits/kokkos-kernels/blas1_dot_kk.hpp"
 #include "__p1673_bits/kokkos-kernels/blas1_add_kk.hpp"
 #include "__p1673_bits/kokkos-kernels/blas1_scale_kk.hpp"


### PR DESCRIPTION
Fixes #173 by adding `Kokkos::complex<T>` support to `std::experimental::linalg::impl::conj_if_needed()` and removing replicated definitions.