### PR TITLE
Misc changes to make it work for C++17

### DIFF
--- a/include/experimental/__p1673_bits/blas1_givens.hpp
+++ b/include/experimental/__p1673_bits/blas1_givens.hpp
@@ -45,7 +45,6 @@
 
 #include <cmath>
 #include <complex>
-#include <concepts>
 
 namespace std {
 namespace experimental {
@@ -112,7 +111,7 @@ struct is_custom_givens_rotation_apply_avail<
 
 
 
-template<std::floating_point Real>
+MDSPAN_TEMPLATE_REQUIRES( class Real, /* requires */ ( _MDSPAN_TRAIT(is_floating_point, Real) ) )
 void givens_rotation_setup(const Real f,
                            const Real g,
                            Real& cs,
@@ -218,7 +217,7 @@ void givens_rotation_setup(const Real f,
 }
 
 namespace impl {
-template<std::floating_point Real>
+MDSPAN_TEMPLATE_REQUIRES( class Real, /* requires */ ( _MDSPAN_TRAIT(is_floating_point, Real) ) )
 Real abs1(const complex<Real>& ff) {
   using std::abs;
   using std::imag;
@@ -228,7 +227,7 @@ Real abs1(const complex<Real>& ff) {
   return max(abs(real(ff)), abs(imag(ff)));
 }
 
-template<std::floating_point Real>
+MDSPAN_TEMPLATE_REQUIRES( class Real, /* requires */ ( _MDSPAN_TRAIT(is_floating_point, Real) ) )
 Real abssq(const complex<Real>& ff) {
   using std::imag;
   using std::real;
@@ -237,7 +236,7 @@ Real abssq(const complex<Real>& ff) {
 }
 }
 
-template<std::floating_point Real>
+MDSPAN_TEMPLATE_REQUIRES( class Real, /* requires */ ( _MDSPAN_TRAIT(is_floating_point, Real) ) )
 void givens_rotation_setup(const complex<Real>& f,
                            const complex<Real>& g,
                            Real& cs,
@@ -372,8 +371,8 @@ label20:
   }
 }
 
-// c and s are std::floating_point
-template<class ElementType1,
+MDSPAN_TEMPLATE_REQUIRES(
+         class ElementType1,
          extents<>::size_type ext1,
          class Layout1,
          class Accessor1,
@@ -381,7 +380,9 @@ template<class ElementType1,
          extents<>::size_type ext2,
          class Layout2,
          class Accessor2,
-         std::floating_point Real>
+         class Real,
+         /* requires */ (_MDSPAN_TRAIT(is_floating_point, Real))
+)
 void givens_rotation_apply(
   std::experimental::linalg::impl::inline_exec_t&& /* exec */,
   std::experimental::mdspan<ElementType1, std::experimental::extents<ext1>, Layout1, Accessor1> x,
@@ -400,7 +401,8 @@ void givens_rotation_apply(
   }
 }
 
-template<class ExecutionPolicy,
+MDSPAN_TEMPLATE_REQUIRES(
+         class ExecutionPolicy,
          class ElementType1,
          extents<>::size_type ext1,
          class Layout1,
@@ -409,7 +411,9 @@ template<class ExecutionPolicy,
          extents<>::size_type ext2,
          class Layout2,
          class Accessor2,
-         std::floating_point Real>
+         class Real,
+         /* requires */ (_MDSPAN_TRAIT(is_floating_point, Real))
+)
 void givens_rotation_apply(
   ExecutionPolicy&& exec,
   std::experimental::mdspan<ElementType1, std::experimental::extents<ext1>, Layout1, Accessor1> x,
@@ -431,7 +435,8 @@ void givens_rotation_apply(
   }
 }
 
-template<class ElementType1,
+MDSPAN_TEMPLATE_REQUIRES(
+         class ElementType1,
          extents<>::size_type ext1,
          class Layout1,
          class Accessor1,
@@ -439,7 +444,9 @@ template<class ElementType1,
          extents<>::size_type ext2,
          class Layout2,
          class Accessor2,
-         std::floating_point Real>
+         class Real,
+         /* requires */ (_MDSPAN_TRAIT(is_floating_point, Real))
+)
 void givens_rotation_apply(
   std::experimental::mdspan<ElementType1, std::experimental::extents<ext1>, Layout1, Accessor1> x,
   std::experimental::mdspan<ElementType2, std::experimental::extents<ext2>, Layout2, Accessor2> y,
@@ -452,7 +459,8 @@ void givens_rotation_apply(
 
 // c is std::floating_point
 // s is complex<std::floating_point>
-template<class ElementType1,
+MDSPAN_TEMPLATE_REQUIRES(
+         class ElementType1,
          extents<>::size_type ext1,
          class Layout1,
          class Accessor1,
@@ -460,7 +468,9 @@ template<class ElementType1,
          extents<>::size_type ext2,
          class Layout2,
          class Accessor2,
-         std::floating_point Real>
+         class Real,
+         /* requires */ (_MDSPAN_TRAIT(is_floating_point, Real))
+)
 void givens_rotation_apply(
   std::experimental::linalg::impl::inline_exec_t&& /* exec */,
   std::experimental::mdspan<ElementType1, std::experimental::extents<ext1>, Layout1, Accessor1> x,
@@ -480,7 +490,8 @@ void givens_rotation_apply(
   }
 }
 
-template<class ExecutionPolicy,
+MDSPAN_TEMPLATE_REQUIRES(
+         class ExecutionPolicy,
          class ElementType1,
          extents<>::size_type ext1,
          class Layout1,
@@ -489,7 +500,9 @@ template<class ExecutionPolicy,
          extents<>::size_type ext2,
          class Layout2,
          class Accessor2,
-         std::floating_point Real>
+         class Real,
+         /* requires */ (_MDSPAN_TRAIT(is_floating_point, Real))
+)
 void givens_rotation_apply(
   ExecutionPolicy&& exec,
   std::experimental::mdspan<ElementType1, std::experimental::extents<ext1>, Layout1, Accessor1> x,
@@ -511,7 +524,8 @@ void givens_rotation_apply(
   }
 }
 
-template<class ElementType1,
+MDSPAN_TEMPLATE_REQUIRES(
+         class ElementType1,
          extents<>::size_type ext1,
          class Layout1,
          class Accessor1,
@@ -519,7 +533,9 @@ template<class ElementType1,
          extents<>::size_type ext2,
          class Layout2,
          class Accessor2,
-         std::floating_point Real>
+         class Real,
+         /* requires */ (_MDSPAN_TRAIT(is_floating_point, Real))
+)
 void givens_rotation_apply(
   std::experimental::mdspan<ElementType1, std::experimental::extents<ext1>, Layout1, Accessor1> x,
   std::experimental::mdspan<ElementType2, std::experimental::extents<ext2>, Layout2, Accessor2> y,

--- a/include/experimental/__p1673_bits/blas1_linalg_add.hpp
+++ b/include/experimental/__p1673_bits/blas1_linalg_add.hpp
@@ -155,19 +155,21 @@ struct is_custom_add_avail<
 } // end anonymous namespace
 
 
-template<class ElementType_x,
-         extents<>::size_type ... ext_x,
+MDSPAN_TEMPLATE_REQUIRES(
+         class ElementType_x,
          class Layout_x,
          class Accessor_x,
          class ElementType_y,
-         extents<>::size_type ... ext_y,
          class Layout_y,
          class Accessor_y,
          class ElementType_z,
-         extents<>::size_type ... ext_z,
          class Layout_z,
-         class Accessor_z>
-  requires (sizeof...(ext_x) == sizeof...(ext_y) && sizeof...(ext_x) == sizeof...(ext_z))
+         class Accessor_z,
+         extents<>::size_type ... ext_x,
+         extents<>::size_type ... ext_y,
+         extents<>::size_type ... ext_z,
+         /* requires */ (sizeof...(ext_x) == sizeof...(ext_y) && sizeof...(ext_x) == sizeof...(ext_z))
+)
 void add(
   std::experimental::linalg::impl::inline_exec_t&& /* exec */,
   std::experimental::mdspan<ElementType_x, std::experimental::extents<ext_x ...>, Layout_x, Accessor_x> x,
@@ -186,20 +188,22 @@ void add(
   }
 }
 
-template<class ExecutionPolicy,
+MDSPAN_TEMPLATE_REQUIRES(
+         class ExecutionPolicy,
          class ElementType_x,
-         extents<>::size_type ... ext_x,
          class Layout_x,
          class Accessor_x,
          class ElementType_y,
-         extents<>::size_type ... ext_y,
          class Layout_y,
          class Accessor_y,
          class ElementType_z,
-         extents<>::size_type ... ext_z,
          class Layout_z,
-         class Accessor_z>
-  requires (sizeof...(ext_x) == sizeof...(ext_y) && sizeof...(ext_x) == sizeof...(ext_z))
+         class Accessor_z,
+         extents<>::size_type ... ext_x,
+         extents<>::size_type ... ext_y,
+         extents<>::size_type ... ext_z,
+         /* requires */ (sizeof...(ext_x) == sizeof...(ext_y) && sizeof...(ext_x) == sizeof...(ext_z))
+)
 void add(
   ExecutionPolicy&& exec,
   std::experimental::mdspan<ElementType_x, std::experimental::extents<ext_x ...>, Layout_x, Accessor_x> x,
@@ -221,19 +225,21 @@ void add(
   }
 }
 
-template<class ElementType_x,
-         extents<>::size_type ... ext_x,
+MDSPAN_TEMPLATE_REQUIRES(
+         class ElementType_x,
          class Layout_x,
          class Accessor_x,
          class ElementType_y,
-         extents<>::size_type ... ext_y,
          class Layout_y,
          class Accessor_y,
          class ElementType_z,
-         extents<>::size_type ... ext_z,
          class Layout_z,
-         class Accessor_z>
-  requires (sizeof...(ext_x) == sizeof...(ext_y) && sizeof...(ext_x) == sizeof...(ext_z))
+         class Accessor_z,
+         extents<>::size_type ... ext_x,
+         extents<>::size_type ... ext_y,
+         extents<>::size_type ... ext_z,
+         /* requires */ (sizeof...(ext_x) == sizeof...(ext_y) && sizeof...(ext_x) == sizeof...(ext_z))
+)
 void add(
   std::experimental::mdspan<ElementType_x, std::experimental::extents<ext_x ...>, Layout_x, Accessor_x> x,
   std::experimental::mdspan<ElementType_y, std::experimental::extents<ext_y ...>, Layout_y, Accessor_y> y,

--- a/include/experimental/__p1673_bits/blas1_linalg_add.hpp
+++ b/include/experimental/__p1673_bits/blas1_linalg_add.hpp
@@ -157,17 +157,17 @@ struct is_custom_add_avail<
 
 MDSPAN_TEMPLATE_REQUIRES(
          class ElementType_x,
+         extents<>::size_type ... ext_x,
          class Layout_x,
          class Accessor_x,
          class ElementType_y,
+         extents<>::size_type ... ext_y,
          class Layout_y,
          class Accessor_y,
          class ElementType_z,
+         extents<>::size_type ... ext_z,
          class Layout_z,
          class Accessor_z,
-         extents<>::size_type ... ext_x,
-         extents<>::size_type ... ext_y,
-         extents<>::size_type ... ext_z,
          /* requires */ (sizeof...(ext_x) == sizeof...(ext_y) && sizeof...(ext_x) == sizeof...(ext_z))
 )
 void add(
@@ -191,17 +191,17 @@ void add(
 MDSPAN_TEMPLATE_REQUIRES(
          class ExecutionPolicy,
          class ElementType_x,
+         extents<>::size_type ... ext_x,
          class Layout_x,
          class Accessor_x,
          class ElementType_y,
+         extents<>::size_type ... ext_y,
          class Layout_y,
          class Accessor_y,
          class ElementType_z,
+         extents<>::size_type ... ext_z,
          class Layout_z,
          class Accessor_z,
-         extents<>::size_type ... ext_x,
-         extents<>::size_type ... ext_y,
-         extents<>::size_type ... ext_z,
          /* requires */ (sizeof...(ext_x) == sizeof...(ext_y) && sizeof...(ext_x) == sizeof...(ext_z))
 )
 void add(
@@ -227,17 +227,17 @@ void add(
 
 MDSPAN_TEMPLATE_REQUIRES(
          class ElementType_x,
+         extents<>::size_type ... ext_x,
          class Layout_x,
          class Accessor_x,
          class ElementType_y,
+         extents<>::size_type ... ext_y,
          class Layout_y,
          class Accessor_y,
          class ElementType_z,
+         extents<>::size_type ... ext_z,
          class Layout_z,
          class Accessor_z,
-         extents<>::size_type ... ext_x,
-         extents<>::size_type ... ext_y,
-         extents<>::size_type ... ext_z,
          /* requires */ (sizeof...(ext_x) == sizeof...(ext_y) && sizeof...(ext_x) == sizeof...(ext_z))
 )
 void add(

--- a/include/experimental/__p1673_bits/blas1_linalg_copy.hpp
+++ b/include/experimental/__p1673_bits/blas1_linalg_copy.hpp
@@ -124,15 +124,17 @@ struct is_custom_copy_avail<
 } // end anonymous namespace
 
 
-template<class ElementType_x,
-         extents<>::size_type ... ext_x,
+MDSPAN_TEMPLATE_REQUIRES(
+         class ElementType_x,
          class Layout_x,
          class Accessor_x,
          class ElementType_y,
-         extents<>::size_type ... ext_y,
          class Layout_y,
-         class Accessor_y>
-  requires (sizeof...(ext_x) == sizeof...(ext_y))
+         class Accessor_y,
+         extents<>::size_type ... ext_x,
+         extents<>::size_type ... ext_y,
+         /* requires */ (sizeof...(ext_x) == sizeof...(ext_y))
+)
 void copy(
   std::experimental::linalg::impl::inline_exec_t&& /* exec */,
   std::experimental::mdspan<ElementType_x, std::experimental::extents<ext_x ...>, Layout_x, Accessor_x> x,
@@ -148,16 +150,18 @@ void copy(
   }
 }
 
-template<class ExecutionPolicy,
+MDSPAN_TEMPLATE_REQUIRES(
+         class ExecutionPolicy,
          class ElementType_x,
-         extents<>::size_type ... ext_x,
          class Layout_x,
          class Accessor_x,
          class ElementType_y,
-         extents<>::size_type ... ext_y,
          class Layout_y,
-         class Accessor_y>
-  requires (sizeof...(ext_x) == sizeof...(ext_y))
+         class Accessor_y,
+         extents<>::size_type ... ext_x,
+         extents<>::size_type ... ext_y,
+         /* requires */ (sizeof...(ext_x) == sizeof...(ext_y))
+)
 void copy(
   ExecutionPolicy&& exec,
   std::experimental::mdspan<ElementType_x, std::experimental::extents<ext_x ...>, Layout_x, Accessor_x> x,
@@ -177,15 +181,17 @@ void copy(
   }
 }
 
-template<class ElementType_x,
-         extents<>::size_type ... ext_x,
+MDSPAN_TEMPLATE_REQUIRES(
+         class ElementType_x,
          class Layout_x,
          class Accessor_x,
          class ElementType_y,
-         extents<>::size_type ... ext_y,
          class Layout_y,
-         class Accessor_y>
-  requires (sizeof...(ext_x) == sizeof...(ext_y))
+         class Accessor_y,
+         extents<>::size_type ... ext_x,
+         extents<>::size_type ... ext_y,
+         /* requires */ (sizeof...(ext_x) == sizeof...(ext_y))
+)
 void copy(
   std::experimental::mdspan<ElementType_x, std::experimental::extents<ext_x ...>, Layout_x, Accessor_x> x,
   std::experimental::mdspan<ElementType_y, std::experimental::extents<ext_y ...>, Layout_y, Accessor_y> y)

--- a/include/experimental/__p1673_bits/blas1_linalg_copy.hpp
+++ b/include/experimental/__p1673_bits/blas1_linalg_copy.hpp
@@ -126,13 +126,13 @@ struct is_custom_copy_avail<
 
 MDSPAN_TEMPLATE_REQUIRES(
          class ElementType_x,
+         extents<>::size_type ... ext_x,
          class Layout_x,
          class Accessor_x,
          class ElementType_y,
+         extents<>::size_type ... ext_y,
          class Layout_y,
          class Accessor_y,
-         extents<>::size_type ... ext_x,
-         extents<>::size_type ... ext_y,
          /* requires */ (sizeof...(ext_x) == sizeof...(ext_y))
 )
 void copy(
@@ -153,13 +153,13 @@ void copy(
 MDSPAN_TEMPLATE_REQUIRES(
          class ExecutionPolicy,
          class ElementType_x,
+         extents<>::size_type ... ext_x,
          class Layout_x,
          class Accessor_x,
          class ElementType_y,
+         extents<>::size_type ... ext_y,
          class Layout_y,
          class Accessor_y,
-         extents<>::size_type ... ext_x,
-         extents<>::size_type ... ext_y,
          /* requires */ (sizeof...(ext_x) == sizeof...(ext_y))
 )
 void copy(
@@ -183,13 +183,13 @@ void copy(
 
 MDSPAN_TEMPLATE_REQUIRES(
          class ElementType_x,
+         extents<>::size_type ... ext_x,
          class Layout_x,
          class Accessor_x,
          class ElementType_y,
+         extents<>::size_type ... ext_y,
          class Layout_y,
          class Accessor_y,
-         extents<>::size_type ... ext_x,
-         extents<>::size_type ... ext_y,
          /* requires */ (sizeof...(ext_x) == sizeof...(ext_y))
 )
 void copy(

--- a/include/experimental/__p1673_bits/blas1_linalg_swap.hpp
+++ b/include/experimental/__p1673_bits/blas1_linalg_swap.hpp
@@ -127,15 +127,17 @@ struct is_custom_vector_swap_elements_avail<
 
 } // end anonymous namespace
 
-template<class ElementType_x,
-         extents<>::size_type ... ext_x,
+MDSPAN_TEMPLATE_REQUIRES(
+         class ElementType_x,
          class Layout_x,
          class Accessor_x,
          class ElementType_y,
-         extents<>::size_type ... ext_y,
          class Layout_y,
-         class Accessor_y>
-  requires (sizeof...(ext_x) == sizeof...(ext_y))
+         class Accessor_y,
+         extents<>::size_type ... ext_x,
+         extents<>::size_type ... ext_y,
+         /* requires */ (sizeof...(ext_x) == sizeof...(ext_y))
+)
 void swap_elements(
   std::experimental::linalg::impl::inline_exec_t&& /* exec */,
   std::experimental::mdspan<ElementType_x, std::experimental::extents<ext_x ...>, Layout_x, Accessor_x> x,
@@ -151,16 +153,18 @@ void swap_elements(
   }
 }
 
-template<class ExecutionPolicy,
+MDSPAN_TEMPLATE_REQUIRES(
+         class ExecutionPolicy,
          class ElementType_x,
-         extents<>::size_type ... ext_x,
          class Layout_x,
          class Accessor_x,
          class ElementType_y,
-         extents<>::size_type ... ext_y,
          class Layout_y,
-         class Accessor_y>
-  requires (sizeof...(ext_x) == sizeof...(ext_y))
+         class Accessor_y,
+         extents<>::size_type ... ext_x,
+         extents<>::size_type ... ext_y,
+         /* requires */ (sizeof...(ext_x) == sizeof...(ext_y))
+)
 void swap_elements(
   ExecutionPolicy&& exec,
   std::experimental::mdspan<ElementType_x, std::experimental::extents<ext_x ...>, Layout_x, Accessor_x> x,
@@ -179,15 +183,17 @@ void swap_elements(
   }
 }
 
-template<class ElementType_x,
-         extents<>::size_type ... ext_x,
+MDSPAN_TEMPLATE_REQUIRES(
+         class ElementType_x,
          class Layout_x,
          class Accessor_x,
          class ElementType_y,
-         extents<>::size_type ... ext_y,
          class Layout_y,
-         class Accessor_y>
-  requires (sizeof...(ext_x) == sizeof...(ext_y))
+         class Accessor_y,
+         extents<>::size_type ... ext_x,
+         extents<>::size_type ... ext_y,
+         /* requires */ (sizeof...(ext_x) == sizeof...(ext_y))
+)
 void swap_elements(
   std::experimental::mdspan<ElementType_x, std::experimental::extents<ext_x ...>, Layout_x, Accessor_x> x,
   std::experimental::mdspan<ElementType_y, std::experimental::extents<ext_y ...>, Layout_y, Accessor_y> y)

--- a/include/experimental/__p1673_bits/blas1_linalg_swap.hpp
+++ b/include/experimental/__p1673_bits/blas1_linalg_swap.hpp
@@ -129,13 +129,13 @@ struct is_custom_vector_swap_elements_avail<
 
 MDSPAN_TEMPLATE_REQUIRES(
          class ElementType_x,
+         extents<>::size_type ... ext_x,
          class Layout_x,
          class Accessor_x,
          class ElementType_y,
+         extents<>::size_type ... ext_y,
          class Layout_y,
          class Accessor_y,
-         extents<>::size_type ... ext_x,
-         extents<>::size_type ... ext_y,
          /* requires */ (sizeof...(ext_x) == sizeof...(ext_y))
 )
 void swap_elements(
@@ -155,14 +155,14 @@ void swap_elements(
 
 MDSPAN_TEMPLATE_REQUIRES(
          class ExecutionPolicy,
+         extents<>::size_type ... ext_x,
          class ElementType_x,
          class Layout_x,
          class Accessor_x,
          class ElementType_y,
+         extents<>::size_type ... ext_y,
          class Layout_y,
          class Accessor_y,
-         extents<>::size_type ... ext_x,
-         extents<>::size_type ... ext_y,
          /* requires */ (sizeof...(ext_x) == sizeof...(ext_y))
 )
 void swap_elements(
@@ -185,13 +185,13 @@ void swap_elements(
 
 MDSPAN_TEMPLATE_REQUIRES(
          class ElementType_x,
+         extents<>::size_type ... ext_x,
          class Layout_x,
          class Accessor_x,
          class ElementType_y,
+         extents<>::size_type ... ext_y,
          class Layout_y,
          class Accessor_y,
-         extents<>::size_type ... ext_x,
-         extents<>::size_type ... ext_y,
          /* requires */ (sizeof...(ext_x) == sizeof...(ext_y))
 )
 void swap_elements(

--- a/include/experimental/__p1673_bits/blas1_linalg_swap.hpp
+++ b/include/experimental/__p1673_bits/blas1_linalg_swap.hpp
@@ -155,8 +155,8 @@ void swap_elements(
 
 MDSPAN_TEMPLATE_REQUIRES(
          class ExecutionPolicy,
-         extents<>::size_type ... ext_x,
          class ElementType_x,
+         extents<>::size_type ... ext_x,
          class Layout_x,
          class Accessor_x,
          class ElementType_y,

--- a/include/experimental/__p1673_bits/blas2_matrix_vector_product.hpp
+++ b/include/experimental/__p1673_bits/blas2_matrix_vector_product.hpp
@@ -227,7 +227,8 @@ struct is_custom_tri_mat_vec_product_with_update_avail<
 
 } // end anonymous namespace
 
-template<class ElementType_A,
+MDSPAN_TEMPLATE_REQUIRES(
+         class ElementType_A,
          extents<>::size_type numRows_A,
          extents<>::size_type numCols_A,
          class Layout_A,
@@ -239,8 +240,9 @@ template<class ElementType_A,
          class ElementType_y,
          extents<>::size_type ext_y,
          class Layout_y,
-         class Accessor_y>
-  requires (Layout_A::template mapping<extents<numRows_A, numCols_A> >::is_always_unique())
+         class Accessor_y,
+         /* requires */ (Layout_A::template mapping<extents<numRows_A, numCols_A> >::is_always_unique())
+)
 void matrix_vector_product(
   std::experimental::linalg::impl::inline_exec_t&& /* exec */,
   std::experimental::mdspan<ElementType_A, std::experimental::extents<numRows_A, numCols_A>, Layout_A, Accessor_A> A,
@@ -310,7 +312,8 @@ void matrix_vector_product(
 
 // Updating general matrix-vector product: z := y + A * x
 
-template<class ElementType_A,
+MDSPAN_TEMPLATE_REQUIRES(
+         class ElementType_A,
          extents<>::size_type numRows_A,
          extents<>::size_type numCols_A,
          class Layout_A,
@@ -326,8 +329,9 @@ template<class ElementType_A,
          class ElementType_z,
          extents<>::size_type ext_z,
          class Layout_z,
-         class Accessor_z>
-  requires (Layout_A::template mapping<std::experimental::extents<numRows_A, numCols_A>>::is_always_unique())
+         class Accessor_z,
+         /* requires */ (Layout_A::template mapping<std::experimental::extents<numRows_A, numCols_A>>::is_always_unique())
+)
 void matrix_vector_product(
   std::experimental::linalg::impl::inline_exec_t&& /* exec */,
   std::experimental::mdspan<ElementType_A, std::experimental::extents<numRows_A, numCols_A>, Layout_A, Accessor_A> A,
@@ -381,7 +385,8 @@ void matrix_vector_product(
   }
 }
 
-template<class ElementType_A,
+MDSPAN_TEMPLATE_REQUIRES(
+         class ElementType_A,
          extents<>::size_type numRows_A,
          extents<>::size_type numCols_A,
          class Layout_A,
@@ -397,8 +402,9 @@ template<class ElementType_A,
          class ElementType_z,
          extents<>::size_type ext_z,
          class Layout_z,
-         class Accessor_z>
-  requires (Layout_A::template mapping<std::experimental::extents<numRows_A, numCols_A>>::is_always_unique())
+         class Accessor_z,
+         /* requires */ (Layout_A::template mapping<std::experimental::extents<numRows_A, numCols_A>>::is_always_unique())
+)
 void matrix_vector_product(
   std::experimental::mdspan<ElementType_A, std::experimental::extents<numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   std::experimental::mdspan<ElementType_x, std::experimental::extents<ext_x>, Layout_x, Accessor_x> x,
@@ -411,7 +417,8 @@ void matrix_vector_product(
 
 // Overwriting symmetric matrix-vector product: y := A * x
 
-template<class ElementType_A,
+MDSPAN_TEMPLATE_REQUIRES(
+         class ElementType_A,
          extents<>::size_type numRows_A,
          extents<>::size_type numCols_A,
          class Layout_A,
@@ -424,8 +431,9 @@ template<class ElementType_A,
          class ElementType_y,
          extents<>::size_type ext_y,
          class Layout_y,
-         class Accessor_y>
-  requires (Layout_A::template mapping<std::experimental::extents<numRows_A, numCols_A>>::is_always_unique())
+         class Accessor_y,
+         /* requires */ (Layout_A::template mapping<std::experimental::extents<numRows_A, numCols_A>>::is_always_unique())
+)
 void symmetric_matrix_vector_product(
   std::experimental::linalg::impl::inline_exec_t&& /* exec */,
   std::experimental::mdspan<ElementType_A, std::experimental::extents<numRows_A, numCols_A>, Layout_A, Accessor_A> A,
@@ -491,7 +499,8 @@ void symmetric_matrix_vector_product(
   }
 }
 
-template<class ElementType_A,
+MDSPAN_TEMPLATE_REQUIRES(
+         class ElementType_A,
          extents<>::size_type numRows_A,
          extents<>::size_type numCols_A,
          class Layout_A,
@@ -504,8 +513,9 @@ template<class ElementType_A,
          class ElementType_y,
          extents<>::size_type ext_y,
          class Layout_y,
-         class Accessor_y>
-  requires (Layout_A::template mapping<std::experimental::extents<numRows_A, numCols_A>>::is_always_unique())
+         class Accessor_y,
+         /* requires */ (Layout_A::template mapping<std::experimental::extents<numRows_A, numCols_A>>::is_always_unique())
+)
 void symmetric_matrix_vector_product(
   std::experimental::mdspan<ElementType_A, std::experimental::extents<numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t,
@@ -518,7 +528,8 @@ void symmetric_matrix_vector_product(
 
 // Updating symmetric matrix-vector product: z := y + A * x
 
-template<class ElementType_A,
+MDSPAN_TEMPLATE_REQUIRES(
+         class ElementType_A,
          extents<>::size_type numRows_A,
          extents<>::size_type numCols_A,
          class Layout_A,
@@ -535,8 +546,9 @@ template<class ElementType_A,
          class ElementType_z,
          extents<>::size_type ext_z,
          class Layout_z,
-         class Accessor_z>
-  requires (Layout_A::template mapping<std::experimental::extents<numRows_A, numCols_A>>::is_always_unique())
+         class Accessor_z,
+         /* requires */ (Layout_A::template mapping<std::experimental::extents<numRows_A, numCols_A>>::is_always_unique())
+)
 void symmetric_matrix_vector_product(
   std::experimental::linalg::impl::inline_exec_t&& /* exec */,
   std::experimental::mdspan<ElementType_A, std::experimental::extents<numRows_A, numCols_A>, Layout_A, Accessor_A> A,
@@ -608,7 +620,8 @@ void symmetric_matrix_vector_product(
   }
 }
 
-template<class ElementType_A,
+MDSPAN_TEMPLATE_REQUIRES(
+         class ElementType_A,
          extents<>::size_type numRows_A,
          extents<>::size_type numCols_A,
          class Layout_A,
@@ -625,8 +638,9 @@ template<class ElementType_A,
          class ElementType_z,
          extents<>::size_type ext_z,
          class Layout_z,
-         class Accessor_z>
-  requires (Layout_A::template mapping<std::experimental::extents<numRows_A, numCols_A>>::is_always_unique())
+         class Accessor_z,
+         /* requires */ (Layout_A::template mapping<std::experimental::extents<numRows_A, numCols_A>>::is_always_unique())
+)
 void symmetric_matrix_vector_product(
   std::experimental::mdspan<ElementType_A, std::experimental::extents<numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t,
@@ -641,7 +655,8 @@ void symmetric_matrix_vector_product(
 
 // Overwriting Hermitian matrix-vector product: y := A * x
 
-template<class ElementType_A,
+MDSPAN_TEMPLATE_REQUIRES(
+         class ElementType_A,
          extents<>::size_type numRows_A,
          extents<>::size_type numCols_A,
          class Layout_A,
@@ -654,8 +669,9 @@ template<class ElementType_A,
          class ElementType_y,
          extents<>::size_type ext_y,
          class Layout_y,
-         class Accessor_y>
-  requires (Layout_A::template mapping<std::experimental::extents<numRows_A, numCols_A>>::is_always_unique())
+         class Accessor_y,
+         /* requires */ (Layout_A::template mapping<std::experimental::extents<numRows_A, numCols_A>>::is_always_unique())
+)
 void hermitian_matrix_vector_product(
   std::experimental::linalg::impl::inline_exec_t&& /* exec */,
   std::experimental::mdspan<ElementType_A, std::experimental::extents<numRows_A, numCols_A>, Layout_A, Accessor_A> A,
@@ -689,7 +705,8 @@ void hermitian_matrix_vector_product(
   }
 }
 
-template<class ExecutionPolicy,
+MDSPAN_TEMPLATE_REQUIRES(
+         class ExecutionPolicy,
          class ElementType_A,
          extents<>::size_type numRows_A,
          extents<>::size_type numCols_A,
@@ -703,8 +720,9 @@ template<class ExecutionPolicy,
          class ElementType_y,
          extents<>::size_type ext_y,
          class Layout_y,
-         class Accessor_y>
-  requires (Layout_A::template mapping<std::experimental::extents<numRows_A, numCols_A>>::is_always_unique())
+         class Accessor_y,
+         /* requires */ (Layout_A::template mapping<std::experimental::extents<numRows_A, numCols_A>>::is_always_unique())
+)
 void hermitian_matrix_vector_product(
   ExecutionPolicy&& exec,
   std::experimental::mdspan<ElementType_A, std::experimental::extents<numRows_A, numCols_A>, Layout_A, Accessor_A> A,
@@ -722,7 +740,8 @@ void hermitian_matrix_vector_product(
   }
 }
 
-template<class ElementType_A,
+MDSPAN_TEMPLATE_REQUIRES(
+         class ElementType_A,
          extents<>::size_type numRows_A,
          extents<>::size_type numCols_A,
          class Layout_A,
@@ -735,8 +754,9 @@ template<class ElementType_A,
          class ElementType_y,
          extents<>::size_type ext_y,
          class Layout_y,
-         class Accessor_y>
-  requires (Layout_A::template mapping<std::experimental::extents<numRows_A, numCols_A>>::is_always_unique())
+         class Accessor_y,
+         /* requires */ (Layout_A::template mapping<std::experimental::extents<numRows_A, numCols_A>>::is_always_unique())
+)
 void hermitian_matrix_vector_product(
   std::experimental::mdspan<ElementType_A, std::experimental::extents<numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t,
@@ -749,7 +769,8 @@ void hermitian_matrix_vector_product(
 
 // Updating Hermitian matrix-vector product: z := y + A * x
 
-template<class ElementType_A,
+MDSPAN_TEMPLATE_REQUIRES(
+         class ElementType_A,
          extents<>::size_type numRows_A,
          extents<>::size_type numCols_A,
          class Layout_A,
@@ -766,8 +787,9 @@ template<class ElementType_A,
          class ElementType_z,
          extents<>::size_type ext_z,
          class Layout_z,
-         class Accessor_z>
-  requires (Layout_A::template mapping<std::experimental::extents<numRows_A, numCols_A>>::is_always_unique())
+         class Accessor_z,
+         /* requires */ (Layout_A::template mapping<std::experimental::extents<numRows_A, numCols_A>>::is_always_unique())
+)
 void hermitian_matrix_vector_product(
   std::experimental::linalg::impl::inline_exec_t&& /* exec */,
   std::experimental::mdspan<ElementType_A, std::experimental::extents<numRows_A, numCols_A>, Layout_A, Accessor_A> A,
@@ -839,7 +861,8 @@ void hermitian_matrix_vector_product(
   }
 }
 
-template<class ElementType_A,
+MDSPAN_TEMPLATE_REQUIRES(
+         class ElementType_A,
          extents<>::size_type numRows_A,
          extents<>::size_type numCols_A,
          class Layout_A,
@@ -856,8 +879,9 @@ template<class ElementType_A,
          class ElementType_z,
          extents<>::size_type ext_z,
          class Layout_z,
-         class Accessor_z>
-  requires (Layout_A::template mapping<std::experimental::extents<numRows_A, numCols_A>>::is_always_unique())
+         class Accessor_z,
+         /* requires */ (Layout_A::template mapping<std::experimental::extents<numRows_A, numCols_A>>::is_always_unique())
+)
 void hermitian_matrix_vector_product(
   std::experimental::mdspan<ElementType_A, std::experimental::extents<numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t,
@@ -871,7 +895,8 @@ void hermitian_matrix_vector_product(
 
 // Overwriting triangular matrix-vector product: y := A * x
 
-template<class ElementType_A,
+MDSPAN_TEMPLATE_REQUIRES(
+         class ElementType_A,
          extents<>::size_type numRows_A,
          extents<>::size_type numCols_A,
          class Layout_A,
@@ -885,8 +910,9 @@ template<class ElementType_A,
          class ElementType_y,
          extents<>::size_type ext_y,
          class Layout_y,
-         class Accessor_y>
-  requires (Layout_A::template mapping<std::experimental::extents<numRows_A, numCols_A>>::is_always_unique())
+         class Accessor_y,
+         /* requires */ (Layout_A::template mapping<std::experimental::extents<numRows_A, numCols_A>>::is_always_unique())
+)
 void triangular_matrix_vector_product(
   std::experimental::linalg::impl::inline_exec_t&& /* exec */,
   std::experimental::mdspan<ElementType_A, std::experimental::extents<numRows_A, numCols_A>, Layout_A, Accessor_A> A,
@@ -967,7 +993,8 @@ void triangular_matrix_vector_product(
   }
 }
 
-template<class ElementType_A,
+MDSPAN_TEMPLATE_REQUIRES(
+         class ElementType_A,
          extents<>::size_type numRows_A,
          extents<>::size_type numCols_A,
          class Layout_A,
@@ -981,8 +1008,9 @@ template<class ElementType_A,
          class ElementType_y,
          extents<>::size_type ext_y,
          class Layout_y,
-         class Accessor_y>
-  requires (Layout_A::template mapping<std::experimental::extents<numRows_A, numCols_A>>::is_always_unique())
+         class Accessor_y,
+         /* requires */ (Layout_A::template mapping<std::experimental::extents<numRows_A, numCols_A>>::is_always_unique())
+)
 void triangular_matrix_vector_product(
   std::experimental::mdspan<ElementType_A, std::experimental::extents<numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t,
@@ -996,7 +1024,8 @@ void triangular_matrix_vector_product(
 
 // Updating triangular matrix-vector product: z := y + A * x
 
-template<class ElementType_A,
+MDSPAN_TEMPLATE_REQUIRES(
+         class ElementType_A,
          extents<>::size_type numRows_A,
          extents<>::size_type numCols_A,
          class Layout_A,
@@ -1014,8 +1043,9 @@ template<class ElementType_A,
          class ElementType_z,
          extents<>::size_type ext_z,
          class Layout_z,
-         class Accessor_z>
-  requires (Layout_A::template mapping<std::experimental::extents<numRows_A, numCols_A>>::is_always_unique())
+         class Accessor_z,
+         /* requires */ (Layout_A::template mapping<std::experimental::extents<numRows_A, numCols_A>>::is_always_unique())
+)
 void triangular_matrix_vector_product(
   std::experimental::linalg::impl::inline_exec_t&& /* exec */,
   std::experimental::mdspan<ElementType_A, std::experimental::extents<numRows_A, numCols_A>, Layout_A, Accessor_A> A,
@@ -1098,7 +1128,8 @@ void triangular_matrix_vector_product(
   }
 }
 
-template<class ElementType_A,
+MDSPAN_TEMPLATE_REQUIRES(
+         class ElementType_A,
          extents<>::size_type numRows_A,
          extents<>::size_type numCols_A,
          class Layout_A,
@@ -1116,8 +1147,9 @@ template<class ElementType_A,
          class ElementType_z,
          extents<>::size_type ext_z,
          class Layout_z,
-         class Accessor_z>
-  requires (Layout_A::template mapping<std::experimental::extents<numRows_A, numCols_A>>::is_always_unique())
+         class Accessor_z,
+         /* requires */ (Layout_A::template mapping<std::experimental::extents<numRows_A, numCols_A>>::is_always_unique())
+)
 void triangular_matrix_vector_product(
   std::experimental::mdspan<ElementType_A, std::experimental::extents<numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t,


### PR DESCRIPTION
* Replace `requires` with the mdspan macro `MDSPAN_TEMPLATE_REQUIRES`, which
  uses `enable_if_t` when C++20 is not enabled
* Replace `template<std::floating_point T>` with a `requires`/`enable_if_t`
  (via above mdspan macro)