### PR TITLE
kokkos: change tolerace-based comparison to diff and add relative difference

### DIFF
--- a/tests/kokkos-based/helpers.hpp
+++ b/tests/kokkos-based/helpers.hpp
@@ -140,14 +140,16 @@ auto scalar_ref_diff(const T &v1, const T &v2) {
 
 // no-tolerance (exact) comparison
 template <typename ElementType1,
+          std::size_t Extent1,
           typename LayoutPolicy1,
           typename AccessorPolicy1,
           typename ElementType2,
+          std::size_t Extent2,
           typename LayoutPolicy2,
           typename AccessorPolicy2>
 bool is_same_vector(
-    mdspan<ElementType1, extents<dynamic_extent>, LayoutPolicy1, AccessorPolicy1> v1,
-    mdspan<ElementType2, extents<dynamic_extent>, LayoutPolicy2, AccessorPolicy2> v2)
+    mdspan<ElementType1, extents<Extent1>, LayoutPolicy1, AccessorPolicy1> v1,
+    mdspan<ElementType2, extents<Extent2>, LayoutPolicy2, AccessorPolicy2> v2)
 {
   const auto size = v1.extent(0);
   if (size != v2.extent(0))
@@ -166,23 +168,25 @@ bool is_same_vector(
 }
 
 template <typename ElementType1,
+          std::size_t Extent,
           typename LayoutPolicy,
           typename AccessorPolicy,
           typename ElementType2>
 bool is_same_vector(
-    mdspan<ElementType1, extents<dynamic_extent>, LayoutPolicy, AccessorPolicy> v1,
+    mdspan<ElementType1, extents<Extent>, LayoutPolicy, AccessorPolicy> v1,
     const std::vector<ElementType2> &v2)
 {
   return is_same_vector(v1, make_mdspan(v2));
 }
 
 template <typename ElementType1,
+          std::size_t Extent,
           typename LayoutPolicy,
           typename AccessorPolicy,
           typename ElementType2>
 bool is_same_vector(
     const std::vector<ElementType1> &v1,
-    mdspan<ElementType2, extents<dynamic_extent>, LayoutPolicy, AccessorPolicy> v2)
+    mdspan<ElementType2, extents<Extent>, LayoutPolicy, AccessorPolicy> v2)
 {
   return is_same_vector(v2, v1);
 }
@@ -196,14 +200,16 @@ bool is_same_vector(
 }
 
 template <typename ElementType1,
+          std::size_t Extent1,
           typename LayoutPolicy1,
           typename AccessorPolicy1,
           typename ElementType2,
+          std::size_t Extent2,
           typename LayoutPolicy2,
           typename AccessorPolicy2>
 auto vector_abs_diff(
-    mdspan<ElementType1, extents<dynamic_extent>, LayoutPolicy1, AccessorPolicy1> v1,
-    mdspan<ElementType2, extents<dynamic_extent>, LayoutPolicy2, AccessorPolicy2> v2)
+    mdspan<ElementType1, extents<Extent1>, LayoutPolicy1, AccessorPolicy1> v1,
+    mdspan<ElementType2, extents<Extent2>, LayoutPolicy2, AccessorPolicy2> v2)
 {
   using RetType = decltype(scalar_abs_diff(v1[0], v2[0])); // will be same for views
   const auto size = v1.extent(0);
@@ -223,23 +229,25 @@ auto vector_abs_diff(
 }
 
 template <typename ElementType1,
+          std::size_t Extent,
           typename LayoutPolicy,
           typename AccessorPolicy,
           typename ElementType2>
 auto vector_abs_diff(
-    mdspan<ElementType1, extents<dynamic_extent>, LayoutPolicy, AccessorPolicy> v1,
+    mdspan<ElementType1, extents<Extent>, LayoutPolicy, AccessorPolicy> v1,
     const std::vector<ElementType2> &v2)
 {
   return vector_abs_diff(v1, make_mdspan(v2));
 }
 
 template <typename ElementType1,
+          std::size_t Extent,
           typename LayoutPolicy,
           typename AccessorPolicy,
           typename ElementType2>
 auto vector_abs_diff(
     const std::vector<ElementType1> &v1,
-    mdspan<ElementType2, extents<dynamic_extent>, LayoutPolicy, AccessorPolicy> v2)
+    mdspan<ElementType2, extents<Extent>, LayoutPolicy, AccessorPolicy> v2)
 {
   return vector_abs_diff(v2, v1);
 }
@@ -253,14 +261,16 @@ auto vector_abs_diff(
 }
 
 template <typename ElementType1,
+          std::size_t Extent1,
           typename LayoutPolicy1,
           typename AccessorPolicy1,
           typename ElementType2,
+          std::size_t Extent2,
           typename LayoutPolicy2,
           typename AccessorPolicy2>
 auto vector_rel_diff(
-    mdspan<ElementType1, extents<dynamic_extent>, LayoutPolicy1, AccessorPolicy1> v1,
-    mdspan<ElementType2, extents<dynamic_extent>, LayoutPolicy2, AccessorPolicy2> v2)
+    mdspan<ElementType1, extents<Extent1>, LayoutPolicy1, AccessorPolicy1> v1,
+    mdspan<ElementType2, extents<Extent2>, LayoutPolicy2, AccessorPolicy2> v2)
 {
   using RetType = decltype(scalar_abs_diff(v1[0], v2[0]));
   const auto size = v1.extent(0);
@@ -286,23 +296,25 @@ auto vector_rel_diff(
 }
 
 template <typename ElementType1,
+          std::size_t Extent1,
           typename LayoutPolicy,
           typename AccessorPolicy,
           typename ElementType2>
 auto vector_rel_diff(
-    mdspan<ElementType1, extents<dynamic_extent>, LayoutPolicy, AccessorPolicy> v1,
+    mdspan<ElementType1, extents<Extent1>, LayoutPolicy, AccessorPolicy> v1,
     const std::vector<ElementType2> &v2)
 {
   return vector_rel_diff(v1, make_mdspan(v2));
 }
 
 template <typename ElementType1,
+          std::size_t Extent,
           typename LayoutPolicy,
           typename AccessorPolicy,
           typename ElementType2>
 auto vector_rel_diff(
     const std::vector<ElementType1> &v1,
-    mdspan<ElementType2, extents<dynamic_extent>, LayoutPolicy, AccessorPolicy> v2)
+    mdspan<ElementType2, extents<Extent>, LayoutPolicy, AccessorPolicy> v2)
 {
   return vector_rel_diff(v2, v1);
 }
@@ -317,14 +329,18 @@ auto vector_rel_diff(
 
 // no-tolerance (exact) comparison
 template <typename ElementType1,
+          std::size_t Extent10,
+          std::size_t Extent11,
           typename LayoutPolicy1,
           typename AccessorPolicy1,
           typename ElementType2,
+          std::size_t Extent20,
+          std::size_t Extent21,
           typename LayoutPolicy2,
           typename AccessorPolicy2>
 bool is_same_matrix(
-    mdspan<ElementType1, extents<dynamic_extent, dynamic_extent>, LayoutPolicy1, AccessorPolicy1> A,
-    mdspan<ElementType2, extents<dynamic_extent, dynamic_extent>, LayoutPolicy2, AccessorPolicy2> B)
+    mdspan<ElementType1, extents<Extent10, Extent11>, LayoutPolicy1, AccessorPolicy1> A,
+    mdspan<ElementType2, extents<Extent20, Extent21>, LayoutPolicy2, AccessorPolicy2> B)
 {
   const auto ext0 = A.extent(0);
   const auto ext1 = A.extent(1);
@@ -347,32 +363,41 @@ bool is_same_matrix(
 }
 
 template <typename ElementType,
+          std::size_t Extent0,
+          std::size_t Extent1,
           typename LayoutPolicy1,
           typename AccessorPolicy1>
 bool is_same_matrix(
-    mdspan<ElementType, extents<dynamic_extent, dynamic_extent>, LayoutPolicy1, AccessorPolicy1> A,
+    mdspan<ElementType, extents<Extent0, Extent1>, LayoutPolicy1, AccessorPolicy1> A,
     const std::vector<ElementType> &B)
 {
   return is_same_matrix(A, make_mdspan(B.data(), A.extent(0), A.extent(1)));
 }
 
 template <typename ElementType,
+          std::size_t Extent0,
+          std::size_t Extent1,
           typename LayoutPolicy1,
           typename AccessorPolicy1>
 bool is_same_matrix(const std::vector<ElementType> &A,
-    mdspan<ElementType, extents<dynamic_extent, dynamic_extent>, LayoutPolicy1, AccessorPolicy1> B)
+    mdspan<ElementType, extents<Extent0, Extent1>, LayoutPolicy1, AccessorPolicy1> B)
 {
   return is_same_matrix(make_mdspan(A.data(), B.extent(0), B.extent(1)), B);
 }
 
-template <typename ElementType,
+template <typename ElementType1,
+          std::size_t Extent10,
+          std::size_t Extent11,
           typename LayoutPolicy1,
           typename AccessorPolicy1,
+          typename ElementType2,
+          std::size_t Extent20,
+          std::size_t Extent21,
           typename LayoutPolicy2,
           typename AccessorPolicy2>
 auto matrix_abs_diff(
-    mdspan<ElementType, extents<dynamic_extent, dynamic_extent>, LayoutPolicy1, AccessorPolicy1> A,
-    mdspan<ElementType, extents<dynamic_extent, dynamic_extent>, LayoutPolicy2, AccessorPolicy2> B)
+    mdspan<ElementType1, extents<Extent10, Extent11>, LayoutPolicy1, AccessorPolicy1> A,
+    mdspan<ElementType2, extents<Extent20, Extent21>, LayoutPolicy2, AccessorPolicy2> B)
 {
   const auto ext0 = A.extent(0);
   const auto ext1 = A.extent(1);
@@ -386,13 +411,17 @@ auto matrix_abs_diff(
 }
 
 template <typename ElementType,
+          std::size_t Extent10,
+          std::size_t Extent11,
           typename LayoutPolicy1,
           typename AccessorPolicy1,
+          std::size_t Extent20,
+          std::size_t Extent21,
           typename LayoutPolicy2,
           typename AccessorPolicy2>
 auto matrix_rel_diff(
-    mdspan<ElementType, extents<dynamic_extent, dynamic_extent>, LayoutPolicy1, AccessorPolicy1> A,
-    mdspan<ElementType, extents<dynamic_extent, dynamic_extent>, LayoutPolicy2, AccessorPolicy2> B)
+    mdspan<ElementType, extents<Extent10, Extent11>, LayoutPolicy1, AccessorPolicy1> A,
+    mdspan<ElementType, extents<Extent20, Extent21>, LayoutPolicy2, AccessorPolicy2> B)
 {
   const auto ext0 = A.extent(0);
   const auto ext1 = A.extent(1);

--- a/tests/kokkos-based/helpers.hpp
+++ b/tests/kokkos-based/helpers.hpp
@@ -129,15 +129,6 @@ T scalar_abs_diff(const Kokkos::complex<T> &v1, const Kokkos::complex<T> &v2) {
   return dr > di ? dr : di; // can't use std::max on GPU
 }
 
-#if 0
-template <typename T>
-KOKKOS_INLINE_FUNCTION
-auto scalar_ref_diff(const T &v1, const T &v2) {
-  const auto v1_abs = scalar_abs_diff(v1, static_cast<T>(0));
-  return scalar_abs_diff(v1, v2) / v1_abs;
-}
-#endif
-
 // no-tolerance (exact) comparison
 template <typename ElementType1,
           std::size_t Extent1,

--- a/tests/kokkos-based/helpers.hpp
+++ b/tests/kokkos-based/helpers.hpp
@@ -242,15 +242,15 @@ auto vector_abs_diff(
     mdspan<ElementType1, extents<Extent1>, LayoutPolicy1, AccessorPolicy1> v1,
     mdspan<ElementType2, extents<Extent2>, LayoutPolicy2, AccessorPolicy2> v2)
 {
-  using RetType = decltype(std::abs(v1[0] - v2[0])); // will be same for views
+  const auto v1_view = KokkosKernelsSTD::Impl::mdspan_to_view(v1);
+  const auto v2_view = KokkosKernelsSTD::Impl::mdspan_to_view(v2);
+  using RetType = decltype(Kokkos::abs(v1_view[0] - v2_view[0]));
   const auto size = v1.extent(0);
   if (size != v2.extent(0)) {
     throw std::runtime_error("Compared vectors have different sizes");
   } else if (size == 0) {
     return static_cast<RetType>(0); // no difference
   }
-  const auto v1_view = KokkosKernelsSTD::Impl::mdspan_to_view(v1);
-  const auto v2_view = KokkosKernelsSTD::Impl::mdspan_to_view(v2);
   RetType difference;
   const auto red = Kokkos::Max<RetType>(difference);
   Kokkos::parallel_reduce(size,
@@ -423,7 +423,9 @@ auto matrix_abs_diff(
     mdspan<ElementType1, extents<Extent10, Extent11>, LayoutPolicy1, AccessorPolicy1> A,
     mdspan<ElementType2, extents<Extent20, Extent21>, LayoutPolicy2, AccessorPolicy2> B)
 {
-  using RetType = decltype(std::abs(A(0, 0) - B(0, 0))); // will be same for views
+  const auto A_view = KokkosKernelsSTD::Impl::mdspan_to_view(A);
+  const auto B_view = KokkosKernelsSTD::Impl::mdspan_to_view(B);
+  using RetType = decltype(Kokkos::abs(A_view(0, 0) - B_view(0, 0)));
   const auto ext0 = A.extent(0);
   const auto ext1 = A.extent(1);
   if (B.extent(0) != ext0 or B.extent(1) != ext1) {
@@ -431,8 +433,6 @@ auto matrix_abs_diff(
   } else if (ext0 == 0 or ext1 == 0) {
     return static_cast<RetType>(0); // both empty -> no difference
   }
-  const auto A_view = KokkosKernelsSTD::Impl::mdspan_to_view(A);
-  const auto B_view = KokkosKernelsSTD::Impl::mdspan_to_view(B);
   RetType difference;
   const auto red = Kokkos::Max<RetType>(difference);
   Kokkos::parallel_reduce(ext0,

--- a/tests/kokkos-based/helpers.hpp
+++ b/tests/kokkos-based/helpers.hpp
@@ -171,14 +171,14 @@ RealType abs2rel_diff(RealType abs_diff, RealType norm1, RealType norm2)
 template <typename RealValue>
 KOKKOS_INLINE_FUNCTION
 RealValue scalar_abs_diff(RealValue v1, RealValue v2) {
-  return std::abs(v2 - v1);
+  return Kokkos::abs(v2 - v1);
 }
 
 template <typename T>
 T scalar_abs_diff(const std::complex<T> &v1, const std::complex<T> &v2) {
   const auto dr = scalar_abs_diff(v1.real(), v2.real());
   const auto di = scalar_abs_diff(v1.imag(), v2.imag());
-  return std::max(dr, di);
+  return di > dr ? di : dr;
 }
 
 template <typename T>
@@ -186,7 +186,7 @@ KOKKOS_INLINE_FUNCTION
 T scalar_abs_diff(const Kokkos::complex<T> &v1, const Kokkos::complex<T> &v2) {
   const auto dr = scalar_abs_diff(v1.real(), v2.real());
   const auto di = scalar_abs_diff(v1.imag(), v2.imag());
-  return dr > di ? dr : di; // can't use std::max on GPU
+  return di > dr ? di : dr;
 }
 
 // no-tolerance (exact) comparison

--- a/tests/kokkos-based/helpers.hpp
+++ b/tests/kokkos-based/helpers.hpp
@@ -154,7 +154,7 @@ bool is_same_vector(
     return false;
   const auto v1_view = KokkosKernelsSTD::Impl::mdspan_to_view(v1);
   const auto v2_view = KokkosKernelsSTD::Impl::mdspan_to_view(v2);
-  // Note: reducint to `int` because Kokkos can complain on `bool` not being 
+  // Note: reducint to `int` because Kokkos can complain on `bool` not being
   //       aligned with int32 and deny it for parallel_reduce()
   using diff_type = int;
   diff_type is_different = false;
@@ -332,7 +332,7 @@ bool is_same_matrix(
     return false;
   const auto A_view = KokkosKernelsSTD::Impl::mdspan_to_view(A);
   const auto B_view = KokkosKernelsSTD::Impl::mdspan_to_view(B);
-  // Note: reducint to `int` because Kokkos can complain on `bool` not being 
+  // Note: reducint to `int` because Kokkos can complain on `bool` not being
   //       aligned with int32 and deny it for parallel_reduce()
   using diff_type = int;
   diff_type is_different = false;

--- a/tests/kokkos-based/helpers.hpp
+++ b/tests/kokkos-based/helpers.hpp
@@ -154,7 +154,7 @@ bool is_same_vector(
     return false;
   const auto v1_view = KokkosKernelsSTD::Impl::mdspan_to_view(v1);
   const auto v2_view = KokkosKernelsSTD::Impl::mdspan_to_view(v2);
-  // Note: reducint to `int` because Kokkos can complain on `bool` not being
+  // Note: reducing to `int` because Kokkos can complain on `bool` not being
   //       aligned with int32 and deny it for parallel_reduce()
   using diff_type = int;
   diff_type is_different = false;
@@ -332,7 +332,7 @@ bool is_same_matrix(
     return false;
   const auto A_view = KokkosKernelsSTD::Impl::mdspan_to_view(A);
   const auto B_view = KokkosKernelsSTD::Impl::mdspan_to_view(B);
-  // Note: reducint to `int` because Kokkos can complain on `bool` not being
+  // Note: reducing to `int` because Kokkos can complain on `bool` not being
   //       aligned with int32 and deny it for parallel_reduce()
   using diff_type = int;
   diff_type is_different = false;

--- a/tests/kokkos-based/helpers.hpp
+++ b/tests/kokkos-based/helpers.hpp
@@ -204,8 +204,9 @@ auto vector_abs_diff(
 {
   using RetType = decltype(scalar_abs_diff(v1[0], v2[0])); // will be same for views
   const auto size = v1.extent(0);
-  if (size != v2.extent(0))
-    return std::numeric_limits<RetType>::max(); // very, very different
+  if (size != v2.extent(0)) {
+    throw std::runtime_error("Compared vectors have different sizes");
+  }
   const auto v1_view = KokkosKernelsSTD::Impl::mdspan_to_view(v1);
   const auto v2_view = KokkosKernelsSTD::Impl::mdspan_to_view(v2);
   RetType diff = static_cast<RetType>(0);
@@ -265,9 +266,9 @@ auto vector_rel_diff(
 {
   using RetType = decltype(scalar_abs_diff(v1[0], v2[0]));
   const auto size = v1.extent(0);
-  if (size != v2.extent(0))
-    return std::numeric_limits<RetType>::max(); // very, very different
-
+  if (size != v2.extent(0)) {
+    throw std::runtime_error("Compared vectors have different sizes");
+  }
   constexpr auto zero1 = static_cast<ElementType1>(0);
   constexpr auto zero2 = static_cast<ElementType2>(0);
   RetType abs_diff = vector_abs_diff(v1, v2);
@@ -394,7 +395,7 @@ auto matrix_abs_diff(
   const auto ext1 = A.extent(1);
   using RetType = decltype(scalar_abs_diff(A(0, 0), B(0, 0)));
   if (B.extent(0) != ext0 or B.extent(1) != ext1) {
-    return std::numeric_limits<RetType>::max(); // very, very different
+    throw std::runtime_error("Compared matrices have different sizes");
   }
   return vector_abs_diff(
       make_mdspan(A.data(), ext0 * ext1),
@@ -418,7 +419,7 @@ auto matrix_rel_diff(
   const auto ext1 = A.extent(1);
   using RetType = decltype(scalar_abs_diff(A(0, 0), B(0, 0)));
   if (B.extent(0) != ext0 or B.extent(1) != ext1) {
-    return std::numeric_limits<RetType>::max(); // very, very different
+    throw std::runtime_error("Compared matrices have different sizes");
   }
   return vector_rel_diff(
       make_mdspan(A.data(), ext0 * ext1),

--- a/tests/kokkos-based/hermitian_matrix_rank1_update_kokkos.cpp
+++ b/tests/kokkos-based/hermitian_matrix_rank1_update_kokkos.cpp
@@ -72,7 +72,7 @@ void test_kokkos_hermitian_matrix_rank1_update_impl(const x_t &x, A_t &A, Triang
       std::experimental::linalg::hermitian_matrix_rank_1_update(
         KokkosKernelsSTD::kokkos_exec<>(), x, A, t);
     };
-  const auto tol = tolerance<typename x_t::value_type>(1e-9, 1e-2f);
+  const auto tol = tolerance<typename x_t::value_type>(1e-20, 1e-10f);
   test_op_Ax(x, A, tol, get_gold, compute);
 }
 

--- a/tests/kokkos-based/hermitian_matrix_rank2_update_kokkos.cpp
+++ b/tests/kokkos-based/hermitian_matrix_rank2_update_kokkos.cpp
@@ -73,7 +73,7 @@ void test_kokkos_hermitian_matrix_rank2_update_impl(const x_t &x, const y_t &y, 
       std::experimental::linalg::hermitian_matrix_rank_2_update(
         KokkosKernelsSTD::kokkos_exec<>(), x, y, A, t);
     };
-  const auto tol = tolerance<typename x_t::value_type>(1e-9, 1e-2f);
+  const auto tol = tolerance<typename x_t::value_type>(1e-20, 1e-10f);
   test_op_Axy(x, y, A, tol, get_gold, compute);
 }
 

--- a/tests/kokkos-based/matrix_rank1_update_kokkos.cpp
+++ b/tests/kokkos-based/matrix_rank1_update_kokkos.cpp
@@ -69,7 +69,7 @@ void test_kokkos_matrix_rank1_update_impl(const x_t &x, const y_t &y, A_t &A)
       std::experimental::linalg::matrix_rank_1_update(
           KokkosKernelsSTD::kokkos_exec<>(), x, y, A);
     };
-  const auto tol = tolerance<typename x_t::value_type>(1e-9, 1e-2f);
+  const auto tol = tolerance<typename x_t::value_type>(1e-20, 1e-10f);
   test_op_Axy(x, y, A, tol, get_gold, compute);
 }
 
@@ -84,7 +84,7 @@ void test_kokkos_matrix_rank1_update_conj_impl(const x_t &x, const y_t &y, A_t &
       std::experimental::linalg::matrix_rank_1_update_c(
           KokkosKernelsSTD::kokkos_exec<>(), x, y, A);
     };
-  const auto tol = tolerance<typename x_t::value_type>(1e-9, 1e-2f);
+  const auto tol = tolerance<typename x_t::value_type>(1e-20, 1e-10f);
   test_op_Axy(x, y, A, tol, get_gold, compute);
 }
 

--- a/tests/kokkos-based/symmetric_matrix_rank1_update_kokkos.cpp
+++ b/tests/kokkos-based/symmetric_matrix_rank1_update_kokkos.cpp
@@ -71,7 +71,7 @@ void test_kokkos_symmetric_matrix_rank1_update_impl(const x_t &x, A_t &A, Triang
       std::experimental::linalg::symmetric_matrix_rank_1_update(
         KokkosKernelsSTD::kokkos_exec<>(), x, A, t);
     };
-  const auto tol = tolerance<typename x_t::value_type>(1e-9, 1e-2f);
+  const auto tol = tolerance<typename x_t::value_type>(1e-20, 1e-10f);
   test_op_Ax(x, A, tol, get_gold, compute);
 }
 

--- a/tests/kokkos-based/symmetric_matrix_rank2_update_kokkos.cpp
+++ b/tests/kokkos-based/symmetric_matrix_rank2_update_kokkos.cpp
@@ -71,7 +71,7 @@ void test_kokkos_symmetric_matrix_rank2_update_impl(const x_t &x, const y_t &y, 
       std::experimental::linalg::symmetric_matrix_rank_2_update(
         KokkosKernelsSTD::kokkos_exec<>(), x, y, A, t);
     };
-  const auto tol = tolerance<typename x_t::value_type>(1e-9, 1e-2f);
+  const auto tol = tolerance<typename x_t::value_type>(1e-20, 1e-10f);
   test_op_Axy(x, y, A, tol, get_gold, compute);
 }
 


### PR DESCRIPTION
On this PR I'd like to propose:
* changing tolerance based `is_same_{vector,matrix}` comparison to `{vector,matrix}_abs_diff` difference calculation which can be used like `EXPECT_LE(matrix_abs_diff(A_gold, A), A_tolerance)` in tests and show compared numerical values on failure;
* adding new `{vector,matrix}_rel_diff` variant that computes _relative_ difference;
* revision of tolerance values in existing tests;