### PR TITLE
[ready] Refactor shared utilities in Kokkos implementation

### DIFF
--- a/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas1_add_kk.hpp
+++ b/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas1_add_kk.hpp
@@ -3,19 +3,11 @@
 #define LINALG_TPLIMPLEMENTATIONS_INCLUDE_EXPERIMENTAL___P1673_BITS_KOKKOSKERNELS_ADD_HPP_
 
 #include "signal_kokkos_impl_called.hpp"
+#include "static_extent_match.hpp"
 
 namespace KokkosKernelsSTD {
 
 namespace add_impl{
-
-template <class size_type>
-KOKKOS_INLINE_FUNCTION
-constexpr bool static_extent_match(size_type extent1, size_type extent2)
-{
-  return extent1 == std::experimental::dynamic_extent ||
-         extent2 == std::experimental::dynamic_extent ||
-         extent1 == extent2;
-}
 
 template <class F, class T, T... Is>
 void repeat_impl(F&& f, std::integer_sequence<T, Is...>){
@@ -80,9 +72,9 @@ void add(kokkos_exec<ExeSpace>,
   // P1673 mandates
   add_impl::repeat<x.rank()>
     ([=](int r){
-      add_impl::static_extent_match(x.static_extent(r), z.static_extent(r));
-      add_impl::static_extent_match(y.static_extent(r), z.static_extent(r));
-      add_impl::static_extent_match(x.static_extent(r), y.static_extent(r));
+      Impl::static_extent_match(x.static_extent(r), z.static_extent(r));
+      Impl::static_extent_match(y.static_extent(r), z.static_extent(r));
+      Impl::static_extent_match(x.static_extent(r), y.static_extent(r));
     });
 
   Impl::signal_kokkos_impl_called("add");

--- a/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas1_dot_kk.hpp
+++ b/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas1_dot_kk.hpp
@@ -5,21 +5,9 @@
 // keeping this in mind: https://github.com/kokkos/stdBLAS/issues/122
 
 #include "signal_kokkos_impl_called.hpp"
+#include "static_extent_match.hpp"
 
 namespace KokkosKernelsSTD {
-
-namespace dot_impl {
-
-template <class size_type>
-KOKKOS_INLINE_FUNCTION
-constexpr bool static_extent_match(size_type extent1, size_type extent2)
-{
-  return extent1 == std::experimental::dynamic_extent ||
-         extent2 == std::experimental::dynamic_extent ||
-         extent1 == extent2;
-}
-
-} // namespace dot_impl
 
 template<class ExeSpace,
 	 class ElementType_x,
@@ -50,7 +38,7 @@ Scalar dot(kokkos_exec<ExeSpace> /*kexe*/,
   }
 
   // P1673 mandates
-  static_assert(dot_impl::static_extent_match(x.static_extent(0), y.static_extent(0)));
+  static_assert(Impl::static_extent_match(x.static_extent(0), y.static_extent(0)));
 
   Impl::signal_kokkos_impl_called("dot");
 
@@ -110,7 +98,7 @@ Scalar dot(kokkos_exec<ExeSpace>,
   }
 
   // P1673 mandates
-  static_assert(dot_impl::static_extent_match(x.static_extent(0), y.static_extent(0)));
+  static_assert(Impl::static_extent_match(x.static_extent(0), y.static_extent(0)));
 
   Impl::signal_kokkos_impl_called("dot");
 

--- a/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas1_swap_elements_kk.hpp
+++ b/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas1_swap_elements_kk.hpp
@@ -4,6 +4,7 @@
 
 #include <utility>
 #include "signal_kokkos_impl_called.hpp"
+#include "static_extent_match.hpp"
 
 namespace KokkosKernelsSTD {
 
@@ -27,14 +28,6 @@ void repeat_impl(F&& f, std::integer_sequence<T, Is...>){
 template <int N, class F>
 void repeat(F&& f){
   repeat_impl(f, std::make_integer_sequence<int, N>{});
-}
-
-template <class size_type>
-constexpr bool static_extent_match(size_type extent1, size_type extent2)
-{
-  return extent1 == std::experimental::dynamic_extent ||
-         extent2 == std::experimental::dynamic_extent ||
-         extent1 == extent2;
 }
 
 } // end namespace swap_impl
@@ -80,7 +73,7 @@ void swap_elements(kokkos_exec<ExeSpace> /*kexe*/,
   // P1673 mandates
   swap_impl::repeat<x.rank()>
     ([=](int r){
-      swap_impl::static_extent_match(x.static_extent(r), y.static_extent(r));
+      Impl::static_extent_match(x.static_extent(r), y.static_extent(r));
     });
 
   Impl::signal_kokkos_impl_called("swap_elements");

--- a/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas2_gemv_kk.hpp
+++ b/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas2_gemv_kk.hpp
@@ -3,6 +3,7 @@
 #define LINALG_TPLIMPLEMENTATIONS_INCLUDE_EXPERIMENTAL___P1673_BITS_KOKKOSKERNELS_GEMV_HPP_
 
 #include "signal_kokkos_impl_called.hpp"
+#include "static_extent_match.hpp"
 
 namespace KokkosKernelsSTD {
 
@@ -19,13 +20,6 @@ auto get_scaling_factor(std::experimental::linalg::accessor_scaled<Accessor,S> a
   return T(a.scale_factor());
 }
 
-template <class size_type>
-constexpr bool static_extent_match(size_type extent1, size_type extent2)
-{
-  return extent1 == std::experimental::dynamic_extent ||
-         extent2 == std::experimental::dynamic_extent ||
-         extent1 == extent2;
-}
 } //end anon namespace
 
 //
@@ -75,8 +69,8 @@ void matrix_vector_product(kokkos_exec<ExeSpace> /*kexe*/,
   }
 
   // mandates
-  gemv_impl::static_extent_match(A.static_extent(1), x.static_extent(0));
-  gemv_impl::static_extent_match(A.static_extent(0), y.static_extent(0));
+  Impl::static_extent_match(A.static_extent(1), x.static_extent(0));
+  Impl::static_extent_match(A.static_extent(0), y.static_extent(0));
 
   Impl::signal_kokkos_impl_called("overwriting_matrix_vector_product");
 
@@ -149,9 +143,9 @@ void matrix_vector_product(kokkos_exec<ExeSpace> /*kexe*/,
   }
 
   // mandates
-  gemv_impl::static_extent_match(A.static_extent(1), x.static_extent(0));
-  gemv_impl::static_extent_match(A.static_extent(0), y.static_extent(0));
-  gemv_impl::static_extent_match(y.static_extent(0), z.static_extent(0));
+  Impl::static_extent_match(A.static_extent(1), x.static_extent(0));
+  Impl::static_extent_match(A.static_extent(0), y.static_extent(0));
+  Impl::static_extent_match(y.static_extent(0), z.static_extent(0));
 
   Impl::signal_kokkos_impl_called("updating_matrix_vector_product");
 

--- a/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas2_matrix_rank_1_update.hpp
+++ b/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas2_matrix_rank_1_update.hpp
@@ -46,6 +46,7 @@
 
 #include <complex>
 #include "signal_kokkos_impl_called.hpp"
+#include "static_extent_match.hpp"
 
 namespace KokkosKernelsSTD {
 
@@ -143,15 +144,6 @@ struct triangle_layout_match<
 
 template <typename Layout, typename Triangle>
 inline constexpr bool triangle_layout_match_v = triangle_layout_match<Layout, Triangle>::value;
-
-template <class size_type>
-KOKKOS_INLINE_FUNCTION
-constexpr bool static_extent_match(size_type extent1, size_type extent2)
-{
-  return extent1 == std::experimental::dynamic_extent ||
-         extent2 == std::experimental::dynamic_extent ||
-         extent1 == extent2;
-}
 
 } // namespace Impl
 

--- a/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas2_matrix_rank_1_update.hpp
+++ b/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas2_matrix_rank_1_update.hpp
@@ -47,6 +47,7 @@
 #include <complex>
 #include "signal_kokkos_impl_called.hpp"
 #include "static_extent_match.hpp"
+#include "triangle.hpp"
 
 namespace KokkosKernelsSTD {
 
@@ -110,40 +111,6 @@ private:
   size_t ext0;
   size_t ext1;
 };
-
-// Note: phrase it simply and the same as in specification ("has unique layout")
-template <typename Layout,
-          std::experimental::extents<>::size_type numRows,
-          std::experimental::extents<>::size_type numCols>
-
-inline constexpr bool is_unique_layout_v = Layout::template mapping<
-    std::experimental::extents<numRows, numCols> >::is_always_unique();
-
-template <typename Layout>
-struct is_layout_blas_packed: public std::false_type {};
-
-template <typename Triangle, typename StorageOrder>
-struct is_layout_blas_packed<
-  std::experimental::linalg::layout_blas_packed<Triangle, StorageOrder>>:
-    public std::true_type {};
-
-template <typename Layout>
-inline constexpr bool is_layout_blas_packed_v = is_layout_blas_packed<Layout>::value;
-
-// Note: will only signal failure for layout_blas_packed with different triangle
-template <typename Layout, typename Triangle>
-struct triangle_layout_match: public std::true_type {};
-
-template <typename StorageOrder, typename Triangle1, typename Triangle2>
-struct triangle_layout_match<
-  std::experimental::linalg::layout_blas_packed<Triangle1, StorageOrder>,
-  Triangle2>
-{
-  static constexpr bool value = std::is_same_v<Triangle1, Triangle2>;
-};
-
-template <typename Layout, typename Triangle>
-inline constexpr bool triangle_layout_match_v = triangle_layout_match<Layout, Triangle>::value;
 
 } // namespace Impl
 

--- a/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas2_matrix_rank_2_update.hpp
+++ b/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas2_matrix_rank_2_update.hpp
@@ -47,6 +47,7 @@
 #include <complex>
 #include "signal_kokkos_impl_called.hpp"
 #include "static_extent_match.hpp"
+#include "triangle.hpp"
 
 namespace KokkosKernelsSTD {
 
@@ -111,41 +112,6 @@ private:
   size_t ext1;
 };
 
-// Note: phrase it simply and the same as in specification ("has unique layout")
-template <typename Layout,
-          std::experimental::extents<>::size_type numRows,
-          std::experimental::extents<>::size_type numCols>
-
-inline constexpr bool is_unique_layout_v = Layout::template mapping<
-    std::experimental::extents<numRows, numCols> >::is_always_unique();
-
-template <typename Layout>
-struct is_layout_blas_packed: public std::false_type {};
-
-template <typename Triangle, typename StorageOrder>
-struct is_layout_blas_packed<
-  std::experimental::linalg::layout_blas_packed<Triangle, StorageOrder>>:
-    public std::true_type {};
-
-template <typename Layout>
-inline constexpr bool is_layout_blas_packed_v = is_layout_blas_packed<Layout>::value;
-
-// Note: will only signal failure for layout_blas_packed with different triangle
-template <typename Layout, typename Triangle>
-struct triangle_layout_match: public std::true_type {};
-
-template <typename StorageOrder, typename Triangle1, typename Triangle2>
-struct triangle_layout_match<
-  std::experimental::linalg::layout_blas_packed<Triangle1, StorageOrder>,
-  Triangle2>
-{
-  static constexpr bool value = std::is_same_v<Triangle1, Triangle2>;
-};
-
-template <typename Layout, typename Triangle>
-inline constexpr bool triangle_layout_match_v = triangle_layout_match<Layout, Triangle>::value;
-
-
 } // namespace mtxr2update_impl
 
 // Rank-2 update of a symmetric matrix
@@ -163,8 +129,8 @@ template<class ExecSpace,
          std::experimental::extents<>::size_type numCols_A,
          class Layout_A,
          class Triangle>
-  requires (mtxr2update_impl::is_unique_layout_v<Layout_A, numRows_A, numCols_A>
-            or mtxr2update_impl::is_layout_blas_packed_v<Layout_A>)
+  requires (Impl::is_unique_layout_v<Layout_A, numRows_A, numCols_A>
+            or Impl::is_layout_blas_packed_v<Layout_A>)
 void symmetric_matrix_rank_2_update(kokkos_exec<ExecSpace> &&exec,
   std::experimental::mdspan<ElementType_x, std::experimental::extents<ext_x>, Layout_x,
     std::experimental::default_accessor<ElementType_x>> x,
@@ -178,7 +144,7 @@ void symmetric_matrix_rank_2_update(kokkos_exec<ExecSpace> &&exec,
   static_assert(A.rank() == 2);
   static_assert(x.rank() == 1);
   static_assert(y.rank() == 1);
-  static_assert(mtxr2update_impl::triangle_layout_match_v<Layout_A, Triangle>);
+  static_assert(Impl::triangle_layout_match_v<Layout_A, Triangle>);
 
   // P1673 mandates
   static_assert(Impl::static_extent_match(A.static_extent(0), A.static_extent(1)));
@@ -224,8 +190,8 @@ template<class ExecSpace,
          std::experimental::extents<>::size_type numCols_A,
          class Layout_A,
          class Triangle>
-  requires (mtxr2update_impl::is_unique_layout_v<Layout_A, numRows_A, numCols_A>
-            or mtxr2update_impl::is_layout_blas_packed_v<Layout_A>)
+  requires (Impl::is_unique_layout_v<Layout_A, numRows_A, numCols_A>
+            or Impl::is_layout_blas_packed_v<Layout_A>)
 void hermitian_matrix_rank_2_update(kokkos_exec<ExecSpace> &&exec,
   std::experimental::mdspan<ElementType_x, std::experimental::extents<ext_x>, Layout_x,
     std::experimental::default_accessor<ElementType_x>> x,
@@ -239,7 +205,7 @@ void hermitian_matrix_rank_2_update(kokkos_exec<ExecSpace> &&exec,
   static_assert(A.rank() == 2);
   static_assert(x.rank() == 1);
   static_assert(y.rank() == 1);
-  static_assert(mtxr2update_impl::triangle_layout_match_v<Layout_A, Triangle>);
+  static_assert(Impl::triangle_layout_match_v<Layout_A, Triangle>);
 
   // P1673 mandates
   static_assert(Impl::static_extent_match(A.static_extent(0), A.static_extent(1)));

--- a/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas2_matrix_rank_2_update.hpp
+++ b/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas2_matrix_rank_2_update.hpp
@@ -46,6 +46,7 @@
 
 #include <complex>
 #include "signal_kokkos_impl_called.hpp"
+#include "static_extent_match.hpp"
 
 namespace KokkosKernelsSTD {
 
@@ -145,15 +146,6 @@ template <typename Layout, typename Triangle>
 inline constexpr bool triangle_layout_match_v = triangle_layout_match<Layout, Triangle>::value;
 
 
-template <class size_type>
-KOKKOS_INLINE_FUNCTION
-constexpr bool static_extent_match(size_type extent1, size_type extent2)
-{
-  return extent1 == std::experimental::dynamic_extent ||
-         extent2 == std::experimental::dynamic_extent ||
-         extent1 == extent2;
-}
-
 } // namespace mtxr2update_impl
 
 // Rank-2 update of a symmetric matrix
@@ -189,9 +181,9 @@ void symmetric_matrix_rank_2_update(kokkos_exec<ExecSpace> &&exec,
   static_assert(mtxr2update_impl::triangle_layout_match_v<Layout_A, Triangle>);
 
   // P1673 mandates
-  static_assert(mtxr2update_impl::static_extent_match(A.static_extent(0), A.static_extent(1)));
-  static_assert(mtxr2update_impl::static_extent_match(A.static_extent(0), x.static_extent(0)));
-  static_assert(mtxr2update_impl::static_extent_match(A.static_extent(0), y.static_extent(0)));
+  static_assert(Impl::static_extent_match(A.static_extent(0), A.static_extent(1)));
+  static_assert(Impl::static_extent_match(A.static_extent(0), x.static_extent(0)));
+  static_assert(Impl::static_extent_match(A.static_extent(0), y.static_extent(0)));
 
   // P1673 preconditions
   if ( A.extent(0) != A.extent(1) ){
@@ -250,9 +242,9 @@ void hermitian_matrix_rank_2_update(kokkos_exec<ExecSpace> &&exec,
   static_assert(mtxr2update_impl::triangle_layout_match_v<Layout_A, Triangle>);
 
   // P1673 mandates
-  static_assert(mtxr2update_impl::static_extent_match(A.static_extent(0), A.static_extent(1)));
-  static_assert(mtxr2update_impl::static_extent_match(A.static_extent(0), x.static_extent(0)));
-  static_assert(mtxr2update_impl::static_extent_match(A.static_extent(0), y.static_extent(0)));
+  static_assert(Impl::static_extent_match(A.static_extent(0), A.static_extent(1)));
+  static_assert(Impl::static_extent_match(A.static_extent(0), x.static_extent(0)));
+  static_assert(Impl::static_extent_match(A.static_extent(0), y.static_extent(0)));
 
   // P1673 preconditions
   if ( A.extent(0) != A.extent(1) ){

--- a/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas2_symv_kk.hpp
+++ b/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas2_symv_kk.hpp
@@ -3,18 +3,9 @@
 #define LINALG_TPLIMPLEMENTATIONS_INCLUDE_EXPERIMENTAL___P1673_BITS_KOKKOSKERNELS_SYMV_HPP_
 
 #include "signal_kokkos_impl_called.hpp"
+#include "static_extent_match.hpp"
 
 namespace KokkosKernelsSTD {
-
-namespace symv_impl{
-template <class size_type>
-constexpr bool static_extent_match(size_type extent1, size_type extent2)
-{
-  return extent1 == std::experimental::dynamic_extent ||
-         extent2 == std::experimental::dynamic_extent ||
-         extent1 == extent2;
-}
-} // end namespace symv_impl
 
 //
 // overwriting symmetric gemv: y = Ax
@@ -66,9 +57,9 @@ void symmetric_matrix_vector_product(kokkos_exec<ExeSpace> /*kexe*/,
     throw std::runtime_error("KokkosBlas: matrix_vector_product: A.extent(0) != y.extent(0) ");
   }
 
-  symv_impl::static_extent_match(A.static_extent(0), A.static_extent(1));
-  symv_impl::static_extent_match(A.static_extent(1), x.static_extent(0));
-  symv_impl::static_extent_match(A.static_extent(0), x.static_extent(0));
+  Impl::static_extent_match(A.static_extent(0), A.static_extent(1));
+  Impl::static_extent_match(A.static_extent(1), x.static_extent(0));
+  Impl::static_extent_match(A.static_extent(0), x.static_extent(0));
 
   auto A_view = Impl::mdspan_to_view(A);
   auto x_view = Impl::mdspan_to_view(x);
@@ -188,10 +179,10 @@ void symmetric_matrix_vector_product(kokkos_exec<ExeSpace> /*kexe*/,
     throw std::runtime_error("KokkosBlas: matrix_vector_product: A.extent(0) != z.extent(0) ");
   }
 
-  symv_impl::static_extent_match(A.static_extent(0), A.static_extent(1));
-  symv_impl::static_extent_match(A.static_extent(1), x.static_extent(0));
-  symv_impl::static_extent_match(A.static_extent(0), x.static_extent(0));
-  symv_impl::static_extent_match(y.static_extent(0), z.static_extent(0));
+  Impl::static_extent_match(A.static_extent(0), A.static_extent(1));
+  Impl::static_extent_match(A.static_extent(1), x.static_extent(0));
+  Impl::static_extent_match(A.static_extent(0), x.static_extent(0));
+  Impl::static_extent_match(y.static_extent(0), z.static_extent(0));
 
   auto A_view = Impl::mdspan_to_view(A);
   auto x_view = Impl::mdspan_to_view(x);

--- a/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas2_triangular_mat_vec_product.hpp
+++ b/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas2_triangular_mat_vec_product.hpp
@@ -3,17 +3,10 @@
 #define LINALG_TPLIMPLEMENTATIONS_INCLUDE_EXPERIMENTAL___P1673_BITS_KOKKOSKERNELS_TRIANG_MATVEC_HPP_
 
 #include "signal_kokkos_impl_called.hpp"
+#include "static_extent_match.hpp"
 
 namespace KokkosKernelsSTD {
 
-namespace trmv_impl{
-template <class size_type>
-constexpr bool static_extent_match(size_type extent1, size_type extent2)
-{
-  return extent1 == std::experimental::dynamic_extent ||
-         extent2 == std::experimental::dynamic_extent ||
-         extent1 == extent2;
-}
 } //end trmv_impl namespace
 
 //
@@ -67,9 +60,9 @@ void triangular_matrix_vector_product(kokkos_exec<ExeSpace> /*kexe*/,
     throw std::runtime_error("KokkosBlas: triangular_matrix_vector_product: A.extent(0) != y.extent(0) ");
   }
 
-  trmv_impl::static_extent_match(A.static_extent(1), A.static_extent(0));
-  trmv_impl::static_extent_match(A.static_extent(0), y.static_extent(0));
-  trmv_impl::static_extent_match(A.static_extent(1), x.static_extent(0));
+  Impl::static_extent_match(A.static_extent(1), A.static_extent(0));
+  Impl::static_extent_match(A.static_extent(0), y.static_extent(0));
+  Impl::static_extent_match(A.static_extent(1), x.static_extent(0));
 
   auto A_view = Impl::mdspan_to_view(A);
   auto x_view = Impl::mdspan_to_view(x);
@@ -195,10 +188,10 @@ void triangular_matrix_vector_product(kokkos_exec<ExeSpace> /*kexe*/,
     throw std::runtime_error("KokkosBlas: triangular_matrix_vector_product: A.extent(0) != z.extent(0) ");
   }
 
-  trmv_impl::static_extent_match(A.static_extent(1), A.static_extent(0));
-  trmv_impl::static_extent_match(A.static_extent(0), y.static_extent(0));
-  trmv_impl::static_extent_match(A.static_extent(1), x.static_extent(0));
-  trmv_impl::static_extent_match(y.static_extent(0), z.static_extent(0));
+  Impl::static_extent_match(A.static_extent(1), A.static_extent(0));
+  Impl::static_extent_match(A.static_extent(0), y.static_extent(0));
+  Impl::static_extent_match(A.static_extent(1), x.static_extent(0));
+  Impl::static_extent_match(y.static_extent(0), z.static_extent(0));
 
   auto A_view = Impl::mdspan_to_view(A);
   auto x_view = Impl::mdspan_to_view(x);

--- a/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas3_overwriting_gemm_kk.hpp
+++ b/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas3_overwriting_gemm_kk.hpp
@@ -3,18 +3,9 @@
 #define LINALG_TPLIMPLEMENTATIONS_INCLUDE_EXPERIMENTAL___P1673_BITS_KOKKOSKERNELS_OVERWRITING_GEMM_HPP_
 
 #include "signal_kokkos_impl_called.hpp"
+#include "static_extent_match.hpp"
 
 namespace KokkosKernelsSTD {
-
-namespace ov_gemm_impl{
-template <class size_type>
-constexpr bool static_extent_match(size_type extent1, size_type extent2)
-{
-  return extent1 == std::experimental::dynamic_extent ||
-         extent2 == std::experimental::dynamic_extent ||
-         extent1 == extent2;
-}
-} //end ov_gemm_impl namespace
 
 //
 // overwriting gemm: C = alpha*A*B
@@ -66,9 +57,9 @@ void matrix_product(
   }
 
   // mandates
-  ov_gemm_impl::static_extent_match(A.static_extent(1), B.static_extent(0));
-  ov_gemm_impl::static_extent_match(A.static_extent(0), C.static_extent(0));
-  ov_gemm_impl::static_extent_match(B.static_extent(1), C.static_extent(1));
+  Impl::static_extent_match(A.static_extent(1), B.static_extent(0));
+  Impl::static_extent_match(A.static_extent(0), C.static_extent(0));
+  Impl::static_extent_match(B.static_extent(1), C.static_extent(1));
 
   auto A_view = Impl::mdspan_to_view(A);
   auto B_view = Impl::mdspan_to_view(B);
@@ -149,9 +140,9 @@ void matrix_product(
   }
 
   // mandates
-  ov_gemm_impl::static_extent_match(AT.static_extent(1), B.static_extent(0));
-  ov_gemm_impl::static_extent_match(AT.static_extent(0), C.static_extent(0));
-  ov_gemm_impl::static_extent_match(B.static_extent(1), C.static_extent(1));
+  Impl::static_extent_match(AT.static_extent(1), B.static_extent(0));
+  Impl::static_extent_match(AT.static_extent(0), C.static_extent(0));
+  Impl::static_extent_match(B.static_extent(1), C.static_extent(1));
 
   // note that the conversion to view does NOT carry the transpose
   auto A_view = Impl::mdspan_to_view(AT);
@@ -235,9 +226,9 @@ void matrix_product(
   }
 
   // mandates
-  ov_gemm_impl::static_extent_match(A.static_extent(1),  BT.static_extent(0));
-  ov_gemm_impl::static_extent_match(A.static_extent(0),  C.static_extent(0));
-  ov_gemm_impl::static_extent_match(BT.static_extent(1), C.static_extent(1));
+  Impl::static_extent_match(A.static_extent(1),  BT.static_extent(0));
+  Impl::static_extent_match(A.static_extent(0),  C.static_extent(0));
+  Impl::static_extent_match(BT.static_extent(1), C.static_extent(1));
 
   // note that the conversion to view does NOT carry the transpose
   auto A_view = Impl::mdspan_to_view(A);

--- a/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/parallel_matrix.hpp
+++ b/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/parallel_matrix.hpp
@@ -1,0 +1,111 @@
+ /*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2019) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef LINALG_TPLIMPLEMENTATIONS_INCLUDE_EXPERIMENTAL___P1673_BITS_KOKKOSKERNELS_PARALLEL_MATRIX_HPP_
+#define LINALG_TPLIMPLEMENTATIONS_INCLUDE_EXPERIMENTAL___P1673_BITS_KOKKOSKERNELS_PARALLEL_MATRIX_HPP_
+
+namespace KokkosKernelsSTD {
+namespace Impl {
+
+// manages parallel execution of independent action
+// called like action(i, j) for each matrix element A(i, j)
+template <typename ExecSpace, typename MatrixType>
+class ParallelMatrixVisitor {
+public:
+  KOKKOS_INLINE_FUNCTION ParallelMatrixVisitor(ExecSpace &&exec_in, MatrixType A_in):
+    exec(exec_in), A(A_in), ext0(A.extent(0)), ext1(A.extent(1))
+  {}
+
+  template <typename ActionType>
+  KOKKOS_INLINE_FUNCTION
+  void for_each_matrix_element(ActionType action) {
+    if (ext0 > ext1) { // parallel rows
+      Kokkos::parallel_for(Kokkos::RangePolicy(exec, 0, ext0),
+        KOKKOS_LAMBDA(const auto i) {
+          using idx_type = std::remove_const_t<decltype(i)>;
+          for (idx_type j = 0; j < ext1; ++j) {
+            action(i, j);
+          }
+        });
+    } else { // parallel columns
+      Kokkos::parallel_for(Kokkos::RangePolicy(exec, 0, ext1),
+        KOKKOS_LAMBDA(const auto j) {
+          using idx_type = std::remove_const_t<decltype(j)>;
+          for (idx_type i = 0; i < ext0; ++i) {
+            action(i, j);
+          }
+        });
+    }
+    exec.fence();
+  }
+
+  template <typename ActionType>
+  void for_each_triangle_matrix_element(std::experimental::linalg::upper_triangle_t t, ActionType action) {
+    Kokkos::parallel_for(Kokkos::RangePolicy(exec, 0, ext1),
+      KOKKOS_LAMBDA(const auto j) {
+        using idx_type = std::remove_const_t<decltype(j)>;
+        for (idx_type i = 0; i <= j; ++i) {
+          action(i, j);
+        }
+      });
+    exec.fence();
+  }
+
+  template <typename ActionType>
+  void for_each_triangle_matrix_element(std::experimental::linalg::lower_triangle_t t, ActionType action) {
+    for_each_triangle_matrix_element(std::experimental::linalg::upper_triangle,
+        [action](const auto i, const auto j) {
+          action(j, i);
+      });
+  }
+
+private:
+  ExecSpace exec;
+  MatrixType A;
+  size_t ext0;
+  size_t ext1;
+};
+
+} // namespace Impl
+} // namespace KokkosKernelsSTD
+#endif

--- a/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/static_extent_match.hpp
+++ b/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/static_extent_match.hpp
@@ -1,0 +1,60 @@
+ /*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2019) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef LINALG_TPLIMPLEMENTATIONS_INCLUDE_EXPERIMENTAL___P1673_BITS_KOKKOSKERNELS_STATICEXTMATCH_HPP_
+#define LINALG_TPLIMPLEMENTATIONS_INCLUDE_EXPERIMENTAL___P1673_BITS_KOKKOSKERNELS_STATICEXTMATCH_HPP_
+
+namespace KokkosKernelsSTD {
+namespace Impl {
+
+template <class size_type>
+constexpr bool static_extent_match(size_type extent1, size_type extent2)
+{
+  return extent1 == std::experimental::dynamic_extent ||
+         extent2 == std::experimental::dynamic_extent ||
+         extent1 == extent2;
+}
+
+} // namespace Impl
+} // namespace KokkosKernelsSTD
+#endif

--- a/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/triangle.hpp
+++ b/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/triangle.hpp
@@ -1,0 +1,85 @@
+ /*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2019) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef LINALG_TPLIMPLEMENTATIONS_INCLUDE_EXPERIMENTAL___P1673_BITS_KOKKOSKERNELS_TRIANGLE_UTILS_HPP_
+#define LINALG_TPLIMPLEMENTATIONS_INCLUDE_EXPERIMENTAL___P1673_BITS_KOKKOSKERNELS_TRIANGLE_UTILS_HPP_
+
+namespace KokkosKernelsSTD {
+namespace Impl {
+
+// Note: phrase it simply and the same as in specification ("has unique layout")
+template <typename Layout,
+          std::experimental::extents<>::size_type numRows,
+          std::experimental::extents<>::size_type numCols>
+constexpr bool is_unique_layout_v = Layout::template mapping<
+    std::experimental::extents<numRows, numCols> >::is_always_unique();
+
+template <typename Layout>
+struct is_layout_blas_packed: public std::false_type {};
+
+template <typename Triangle, typename StorageOrder>
+struct is_layout_blas_packed<
+  std::experimental::linalg::layout_blas_packed<Triangle, StorageOrder>>:
+    public std::true_type {};
+
+template <typename Layout>
+constexpr bool is_layout_blas_packed_v = is_layout_blas_packed<Layout>::value;
+
+// Note: will only signal failure for layout_blas_packed with different triangle
+template <typename Layout, typename Triangle>
+struct triangle_layout_match: public std::true_type {};
+
+template <typename StorageOrder, typename Triangle1, typename Triangle2>
+struct triangle_layout_match<
+  std::experimental::linalg::layout_blas_packed<Triangle1, StorageOrder>,
+  Triangle2>
+{
+  static constexpr bool value = std::is_same_v<Triangle1, Triangle2>;
+};
+
+template <typename Layout, typename Triangle>
+constexpr bool triangle_layout_match_v = triangle_layout_match<Layout, Triangle>::value;
+
+} // namespace Impl
+} // namespace KokkosKernelsSTD
+#endif


### PR DESCRIPTION
Inspired by #179 for #173, let's consider refactoring of utilities shared by Kokkos algorithm implementations into respective separate headers:
* _triangle.hpp_: various checks and utilities related to triangular matrix handling, including KK tag mappers;
* _static_extent_match.hpp_: for `ParallelMatrixVisitor` (2D `parallel_for` iterating over whole matrix or selected triangle);
* _parallel_matrix.hpp_: `static_extent_match()`;
