### PR TITLE
[ready] kokkos impl `{symmetric,hermitian}_matrix_rank_k_update`

### DIFF
--- a/tests/kokkos-based/hermitian_matrix_rank_k_update_kokkos.cpp
+++ b/tests/kokkos-based/hermitian_matrix_rank_k_update_kokkos.cpp
@@ -1,0 +1,104 @@
+ /*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2019) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include "gtest_fixtures.hpp"
+#include "helpers.hpp"
+
+namespace{
+
+using namespace kokkostesting;
+
+template<class AlphaType, class A_t, class C_t, class Triangle>
+void hermitian_matrix_rank_k_update_gold_solution(AlphaType alpha,
+    const A_t &A, C_t &C, Triangle /* t */)
+{
+  using std::experimental::linalg::impl::conj_if_needed;
+  using size_type = std::experimental::extents<>::size_type;
+  constexpr bool low = std::is_same_v<Triangle, std::experimental::linalg::lower_triangle_t>;
+  const auto C_ext = C.extent(0);
+  const auto A_ext1 = A.extent(1);
+  for (size_type j = 0; j < C_ext; ++j) {
+    const size_type i1 = low ? C_ext : j + 1;
+    for (size_type i = low ? j : 0; i < i1; ++i) {
+      for (size_type k = 0; k < A_ext1; ++k) {
+        C(i, j) += alpha * A(i, k) * conj_if_needed(A(j, k));
+      }
+    }
+  }
+}
+
+template<class A_t, class C_t, class Triangle>
+void test_kokkos_hermitian_matrix_rank_k_update_impl(const A_t A, C_t C, Triangle t)
+{
+  const auto alpha = static_cast<A_t::element_type>(2.0); // check if alpha is applied
+  const auto get_gold = [&](auto C_gold) {
+      hermitian_matrix_rank_k_update_gold_solution(alpha, A, C_gold, t);
+    };
+  const auto compute = [&]() {
+      std::experimental::linalg::hermitian_matrix_rank_k_update(
+        KokkosKernelsSTD::kokkos_exec<>(), alpha, A, C, t);
+    };
+  const auto tol = tolerance<typename C_t::value_type>(1e-20, 1e-10f);
+  test_op_CA(A, C, tol, get_gold, compute);
+}
+
+} // anonymous namespace
+
+#define DEFINE_TESTS(blas_val_type)                                          \
+TEST_F(blas2_signed_##blas_val_type##_fixture,                               \
+       kokkos_hermitian_matrix_rank_k_update) {                              \
+  using val_t = typename blas2_signed_##blas_val_type##_fixture::value_type; \
+  run_checked_tests<val_t>("kokkos_", "hermitian_matrix_rank_k_update", "",  \
+                           #blas_val_type, [&]() {                           \
+                                                                             \
+    test_kokkos_hermitian_matrix_rank_k_update_impl(A_sym_e0, A_hem_e0,      \
+                            std::experimental::linalg::lower_triangle);      \
+    test_kokkos_hermitian_matrix_rank_k_update_impl(A_sym_e0, A_hem_e0,      \
+                            std::experimental::linalg::upper_triangle);      \
+                                                                             \
+  });                                                                        \
+}
+
+DEFINE_TESTS(double)
+DEFINE_TESTS(float)
+DEFINE_TESTS(complex_double)

--- a/tests/kokkos-based/symmetric_matrix_rank_k_update_kokkos.cpp
+++ b/tests/kokkos-based/symmetric_matrix_rank_k_update_kokkos.cpp
@@ -1,0 +1,103 @@
+ /*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2019) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include "gtest_fixtures.hpp"
+#include "helpers.hpp"
+
+namespace{
+
+using namespace kokkostesting;
+
+template<class AlphaType, class A_t, class C_t, class Triangle>
+void symmetric_matrix_rank_k_update_gold_solution(AlphaType alpha,
+    const A_t &A, C_t &C, Triangle /* t */)
+{
+  using size_type = std::experimental::extents<>::size_type;
+  constexpr bool low = std::is_same_v<Triangle, std::experimental::linalg::lower_triangle_t>;
+  const auto C_ext = C.extent(0);
+  const auto A_ext1 = A.extent(1);
+  for (size_type j = 0; j < C_ext; ++j) {
+    const size_type i1 = low ? C_ext : j + 1;
+    for (size_type i = low ? j : 0; i < i1; ++i) {
+      for (size_type k = 0; k < A_ext1; ++k) {
+        C(i, j) += alpha * A(i, k) * A(j, k);
+      }
+    }
+  }
+}
+
+template<class A_t, class C_t, class Triangle>
+void test_kokkos_symmetric_matrix_rank_k_update_impl(const A_t A, C_t C, Triangle t)
+{
+  const auto alpha = static_cast<A_t::element_type>(2.0); // check if alpha is applied
+  const auto get_gold = [&](auto C_gold) {
+      symmetric_matrix_rank_k_update_gold_solution(alpha, A, C_gold, t);
+    };
+  const auto compute = [&]() {
+      std::experimental::linalg::symmetric_matrix_rank_k_update(
+        KokkosKernelsSTD::kokkos_exec<>(), alpha, A, C, t);
+    };
+  const auto tol = tolerance<typename C_t::value_type>(1e-20, 1e-10f);
+  test_op_CA(A, C, tol, get_gold, compute);
+}
+
+} // anonymous namespace
+
+#define DEFINE_TESTS(blas_val_type)                                          \
+TEST_F(blas2_signed_##blas_val_type##_fixture,                               \
+       kokkos_symmetric_matrix_rank_k_update) {                              \
+  using val_t = typename blas2_signed_##blas_val_type##_fixture::value_type; \
+  run_checked_tests<val_t>("kokkos_", "symmetric_matrix_rank_k_update", "",  \
+                           #blas_val_type, [&]() {                           \
+                                                                             \
+    test_kokkos_symmetric_matrix_rank_k_update_impl(A_sym_e0, A_hem_e0,      \
+                            std::experimental::linalg::lower_triangle);      \
+    test_kokkos_symmetric_matrix_rank_k_update_impl(A_sym_e0, A_hem_e0,      \
+                            std::experimental::linalg::upper_triangle);      \
+                                                                             \
+  });                                                                        \
+}
+
+DEFINE_TESTS(double)
+DEFINE_TESTS(float)
+DEFINE_TESTS(complex_double)

--- a/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas3_matrix_rank_2k_update.hpp
+++ b/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas3_matrix_rank_2k_update.hpp
@@ -76,7 +76,7 @@ void symmetric_matrix_rank_2k_update(kokkos_exec<ExecSpace> &&exec,
   Impl::ParallelMatrixVisitor v(ExecSpace(), C_view);
   v.for_each_triangle_matrix_element(t,
     KOKKOS_LAMBDA(const auto i, const auto j) {
-      auto &c = C_view(i, j);
+      decltype(auto) c = C_view(i, j);
       for (size_type k = 0; k < A_ext1; ++k) {
         c += A_view(i, k) * B_view(j, k) + B_view(i, k) * A_view(j, k);
       }
@@ -150,7 +150,7 @@ void hermitian_matrix_rank_2k_update(kokkos_exec<ExecSpace> &&exec,
   Impl::ParallelMatrixVisitor v(ExecSpace(), C_view);
   v.for_each_triangle_matrix_element(t,
     KOKKOS_LAMBDA(const auto i, const auto j) {
-      auto &c = C_view(i, j);
+      decltype(auto) c = C_view(i, j);
       for (size_type k = 0; k < A_ext1; ++k) {
         c += A_view(i, k) * conj_if_needed(B_view(j, k))
            + B_view(i, k) * conj_if_needed(A_view(j, k));

--- a/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas3_matrix_rank_k_update.hpp
+++ b/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas3_matrix_rank_k_update.hpp
@@ -61,7 +61,7 @@ void symmetric_matrix_rank_k_update(kokkos_exec<ExecSpace> &&exec,
   Impl::ParallelMatrixVisitor v(ExecSpace(), C_view);
   v.for_each_triangle_matrix_element(t,
     KOKKOS_LAMBDA(const auto i, const auto j) {
-      auto &c = C_view(i, j);
+      decltype(auto) c = C_view(i, j);
       for (size_type k = 0; k < A_ext1; ++k) {
         c += alpha * A_view(i, k) * A_view(j, k);
       }
@@ -121,7 +121,7 @@ void hermitian_matrix_rank_k_update(kokkos_exec<ExecSpace> &&exec,
   Impl::ParallelMatrixVisitor v(ExecSpace(), C_view);
   v.for_each_triangle_matrix_element(t,
     KOKKOS_LAMBDA(const auto i, const auto j) {
-      auto &c = C_view(i, j);
+      decltype(auto) c = C_view(i, j);
       for (size_type k = 0; k < A_ext1; ++k) {
         c += alpha * A_view(i, k) * conj_if_needed(A_view(j, k));
       }

--- a/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas3_matrix_rank_k_update.hpp
+++ b/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas3_matrix_rank_k_update.hpp
@@ -1,0 +1,132 @@
+
+#ifndef LINALG_TPLIMPLEMENTATIONS_INCLUDE_EXPERIMENTAL___P1673_BITS_KOKKOSKERNELS_MATRIX_RANK_k_UPDATE_HPP_
+#define LINALG_TPLIMPLEMENTATIONS_INCLUDE_EXPERIMENTAL___P1673_BITS_KOKKOSKERNELS_MATRIX_RANK_k_UPDATE_HPP_
+
+#include "signal_kokkos_impl_called.hpp"
+#include "static_extent_match.hpp"
+#include "triangle.hpp"
+#include "parallel_matrix.hpp"
+
+namespace KokkosKernelsSTD {
+
+// Rank-k update of a symmetric matrix with scaling factor alpha
+// performs BLAS xSYRK: C += alpha * A * trans(A)
+
+MDSPAN_TEMPLATE_REQUIRES(class ExecSpace,
+    class ScaleFactorType,
+    class ElementType_A,
+    std::experimental::extents<>::size_type numRows_A,
+    std::experimental::extents<>::size_type numCols_A,
+    class Layout_A,
+    class ElementType_C,
+    std::experimental::extents<>::size_type numRows_C,
+    std::experimental::extents<>::size_type numCols_C,
+    class Layout_C,
+    class Triangle,
+  /* requires */ (Impl::is_unique_layout_v<Layout_C, numRows_C, numCols_C>
+               or Impl::is_layout_blas_packed_v<Layout_C>))
+void symmetric_matrix_rank_k_update(kokkos_exec<ExecSpace> &&exec,
+  ScaleFactorType alpha,
+  std::experimental::mdspan<ElementType_A, std::experimental::extents<numRows_A, numCols_A>, Layout_A,
+    std::experimental::default_accessor<ElementType_A>> A,
+  std::experimental::mdspan<ElementType_C, std::experimental::extents<numRows_C, numCols_C>, Layout_C,
+    std::experimental::default_accessor<ElementType_C>> C,
+  Triangle t)
+{
+  // P1673 constraints (redundant to mdspan extents in the header)
+  static_assert(A.rank() == 2);
+  static_assert(C.rank() == 2);
+  static_assert(Impl::triangle_layout_match_v<Layout_C, Triangle>);
+
+  // P1673 mandates
+  static_assert(Impl::static_extent_match(A.static_extent(0), C.static_extent(0)));
+  static_assert(Impl::static_extent_match(C.static_extent(0), C.static_extent(1)));
+
+  // P1673 preconditions
+  if ( A.extent(0) != C.extent(0) ){
+    throw std::runtime_error("KokkosBlas: symmetric_matrix_rank_k_update: A.extent(0) != C.extent(0)");
+  }
+  if ( C.extent(0) != C.extent(1) ){
+    throw std::runtime_error("KokkosBlas: symmetric_matrix_rank_k_update: C.extent(0) != C.extent(1)");
+  }
+
+  Impl::signal_kokkos_impl_called("symmetric_matrix_rank_k_update");
+
+  // convert mdspans to views
+  const auto A_view = Impl::mdspan_to_view(A);
+  auto C_view = Impl::mdspan_to_view(C);
+
+  using size_type = std::experimental::extents<>::size_type;
+  const auto A_ext1 = A.extent(1);
+  Impl::ParallelMatrixVisitor v(ExecSpace(), C_view);
+  v.for_each_triangle_matrix_element(t,
+    KOKKOS_LAMBDA(const auto i, const auto j) {
+      auto &c = C_view(i, j);
+      for (size_type k = 0; k < A_ext1; ++k) {
+        c += alpha * A_view(i, k) * A_view(j, k);
+      }
+    });
+}
+
+// Rank-k update of a hermitian matrix with scaling factor alpha
+// performs BLAS xHERK: C += alpha * A * trans(A)
+
+MDSPAN_TEMPLATE_REQUIRES(class ExecSpace,
+    class ScaleFactorType,
+    class ElementType_A,
+    std::experimental::extents<>::size_type numRows_A,
+    std::experimental::extents<>::size_type numCols_A,
+    class Layout_A,
+    class ElementType_C,
+    std::experimental::extents<>::size_type numRows_C,
+    std::experimental::extents<>::size_type numCols_C,
+    class Layout_C,
+    class Triangle,
+  /* requires */ (Impl::is_unique_layout_v<Layout_C, numRows_C, numCols_C>
+               or Impl::is_layout_blas_packed_v<Layout_C>))
+void hermitian_matrix_rank_k_update(kokkos_exec<ExecSpace> &&exec,
+  ScaleFactorType alpha,
+  std::experimental::mdspan<ElementType_A, std::experimental::extents<numRows_A, numCols_A>, Layout_A,
+    std::experimental::default_accessor<ElementType_A>> A,
+  std::experimental::mdspan<ElementType_C, std::experimental::extents<numRows_C, numCols_C>, Layout_C,
+    std::experimental::default_accessor<ElementType_C>> C,
+  Triangle t)
+{
+  // P1673 constraints (redundant to mdspan extents in the header)
+  static_assert(A.rank() == 2);
+  static_assert(C.rank() == 2);
+  static_assert(Impl::triangle_layout_match_v<Layout_C, Triangle>);
+
+  // P1673 mandates
+  static_assert(Impl::static_extent_match(A.static_extent(0), C.static_extent(0)));
+  static_assert(Impl::static_extent_match(C.static_extent(0), C.static_extent(1)));
+
+  // P1673 preconditions
+  if ( A.extent(0) != C.extent(0) ){
+    throw std::runtime_error("KokkosBlas: hermitian_matrix_rank_k_update: A.extent(0) != C.extent(0)");
+  }
+  if ( C.extent(0) != C.extent(1) ){
+    throw std::runtime_error("KokkosBlas: hermitian_matrix_rank_k_update: C.extent(0) != C.extent(1)");
+  }
+
+  Impl::signal_kokkos_impl_called("hermitian_matrix_rank_k_update");
+
+  // convert mdspans to views
+  const auto A_view = Impl::mdspan_to_view(A);
+  auto C_view = Impl::mdspan_to_view(C);
+
+  using size_type = std::experimental::extents<>::size_type;
+  using std::experimental::linalg::impl::conj_if_needed;
+  const auto A_ext1 = A.extent(1);
+  Impl::ParallelMatrixVisitor v(ExecSpace(), C_view);
+  v.for_each_triangle_matrix_element(t,
+    KOKKOS_LAMBDA(const auto i, const auto j) {
+      auto &c = C_view(i, j);
+      for (size_type k = 0; k < A_ext1; ++k) {
+        c += alpha * A_view(i, k) * conj_if_needed(A_view(j, k));
+      }
+    });
+}
+
+} // namespace KokkosKernelsSTD
+#endif


### PR DESCRIPTION
This PR introduces Kokkos implementation and unit test for [`symmetric_matrix_rank_k_update()`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p1673r7.html#rank-k-symmetric-matrix-update-linalgalgblas3rank-ksyrk) and [`hermitian_matrix_rank_k_update()`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p1673r7.html#rank-k-hermitian-matrix-update-linalgalgblas3rank-kherk).