### PR TITLE
[ready] kokkos impl: `triangular_matrix_matrix_{left,right}_solve()`

### DIFF
--- a/tests/kokkos-based/triangular_matrix_matrix_left_solve.cpp
+++ b/tests/kokkos-based/triangular_matrix_matrix_left_solve.cpp
@@ -85,7 +85,8 @@ template<class A_t,
          class X_t,
          class Triangle,
          class DiagonalStorage>
-void test_triangular_matrix_matrix_left_solve_impl(A_t A, B_t B, X_t X0, Triangle t, DiagonalStorage d)
+void test_triangular_matrix_matrix_left_solve_impl(
+        A_t A, B_t B, X_t X0, Triangle t, DiagonalStorage d)
 {
   // copy x to leave original fixture intact
   auto x_data = create_stdvector_and_copy_rowwise(X0);
@@ -99,7 +100,7 @@ void test_triangular_matrix_matrix_left_solve_impl(A_t A, B_t B, X_t X0, Triangl
       std::experimental::linalg::triangular_matrix_matrix_left_solve(
         KokkosKernelsSTD::kokkos_exec<>(), A, t, d, B, X);
     };
-  const auto tol = tolerance<typename X_t::value_type>(1e-13, 1e-4f);
+  const auto tol = tolerance<typename X_t::value_type>(1e-12, 1e-4f);
   test_op_CAB(A, B, X, tol, get_gold, compute);
 }
 
@@ -112,10 +113,10 @@ TEST_F(blas2_signed_##blas_val_type##_fixture,                                  
   run_checked_tests<val_t>("kokkos_", "triangular_matrix_matrix_left_solve", "", \
                            #blas_val_type, [&]() {                               \
                                                                                  \
-    test_triangular_matrix_matrix_left_solve_impl(A_sym_e0, A_sym_e0, A_hem_e0,  \
+    test_triangular_matrix_matrix_left_solve_impl(A_sym_e0, A_e0e1, B_e0e1,      \
                          std::experimental::linalg::lower_triangle,              \
                          std::experimental::linalg::implicit_unit_diagonal);     \
-    test_triangular_matrix_matrix_left_solve_impl(A_sym_e0, A_sym_e0, A_hem_e0,  \
+    test_triangular_matrix_matrix_left_solve_impl(A_sym_e0, A_e0e1, B_e0e1,      \
                          std::experimental::linalg::upper_triangle,              \
                          std::experimental::linalg::explicit_diagonal);          \
                                                                                  \

--- a/tests/kokkos-based/triangular_matrix_matrix_left_solve.cpp
+++ b/tests/kokkos-based/triangular_matrix_matrix_left_solve.cpp
@@ -1,0 +1,127 @@
+ /*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2019) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include "gtest_fixtures.hpp"
+#include "helpers.hpp"
+
+namespace{
+
+using namespace kokkostesting;
+
+template<class A_t,
+         class X_t,
+         class Triangle,
+         class DiagonalStorage>
+void triangular_matrix_matrix_left_solve_gold_solution(
+        A_t A, Triangle t, DiagonalStorage d, X_t X)
+{
+  using size_type = typename std::experimental::extents<>::size_type;
+  constexpr bool lower_triangle = std::is_same_v<
+      Triangle, std::experimental::linalg::lower_triangle_t>;
+  constexpr bool explicit_diagonal = std::is_same_v<
+      DiagonalStorage, std::experimental::linalg::explicit_diagonal_t>;
+
+  const size_type A_ext = A.extent(0); // = A.extent(1)
+  const size_type num_vectors = X.extent(1);
+
+  for (size_type k = 0; k < num_vectors; ++k) {
+    for (size_type ii = 0; ii < A_ext; ++ii) {
+      const size_type i = lower_triangle ? A_ext - 1 - ii : ii;
+      // A(i, j) has lower triangle in i <= j
+      const size_type j0 = lower_triangle ? i + 1 : 0;
+      const size_type j1 = lower_triangle ? A_ext : i;
+      for (size_type j = j0; j < j1; ++j) {
+        X(i, k) -= A(i, j) * X(j, k);
+      }
+      if constexpr (explicit_diagonal) {
+        X(i, k) /= A(i, i);
+      }
+    }
+  }
+}
+
+template<class A_t,
+         class B_t,
+         class X_t,
+         class Triangle,
+         class DiagonalStorage>
+void test_triangular_matrix_matrix_left_solve_impl(A_t A, B_t B, X_t X0, Triangle t, DiagonalStorage d)
+{
+  // copy x to leave original fixture intact
+  auto x_data = create_stdvector_and_copy_rowwise(X0);
+  auto X = make_mdspan(x_data.data(), X0.extent(0), X0.extent(1));
+
+  const auto get_gold = [&](auto X_gold) {
+      std::experimental::linalg::copy(B, X_gold);
+      triangular_matrix_matrix_left_solve_gold_solution(A, t, d, X_gold);
+    };
+  const auto compute = [&]() {
+      std::experimental::linalg::triangular_matrix_matrix_left_solve(
+        KokkosKernelsSTD::kokkos_exec<>(), A, t, d, B, X);
+    };
+  const auto tol = tolerance<typename X_t::value_type>(1e-13, 1e-4f);
+  test_op_CAB(A, B, X, tol, get_gold, compute);
+}
+
+} // anonymous namespace
+
+#define DEFINE_TESTS(blas_val_type)                                              \
+TEST_F(blas2_signed_##blas_val_type##_fixture,                                   \
+       kokkos_triangular_matrix_matrix_left_solve) {                             \
+  using val_t = typename blas2_signed_##blas_val_type##_fixture::value_type;     \
+  run_checked_tests<val_t>("kokkos_", "triangular_matrix_matrix_left_solve", "", \
+                           #blas_val_type, [&]() {                               \
+                                                                                 \
+    test_triangular_matrix_matrix_left_solve_impl(A_sym_e0, A_sym_e0, A_hem_e0,  \
+                         std::experimental::linalg::lower_triangle,              \
+                         std::experimental::linalg::implicit_unit_diagonal);     \
+    test_triangular_matrix_matrix_left_solve_impl(A_sym_e0, A_sym_e0, A_hem_e0,  \
+                         std::experimental::linalg::upper_triangle,              \
+                         std::experimental::linalg::explicit_diagonal);          \
+                                                                                 \
+  });                                                                            \
+}
+
+DEFINE_TESTS(double)
+DEFINE_TESTS(float)
+DEFINE_TESTS(complex_double)

--- a/tests/kokkos-based/triangular_matrix_matrix_right_solve.cpp
+++ b/tests/kokkos-based/triangular_matrix_matrix_right_solve.cpp
@@ -1,0 +1,127 @@
+ /*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2019) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include "gtest_fixtures.hpp"
+#include "helpers.hpp"
+
+namespace{
+
+using namespace kokkostesting;
+
+template<class A_t,
+         class X_t,
+         class Triangle,
+         class DiagonalStorage>
+void triangular_matrix_matrix_right_solve_gold_solution(
+        A_t A, Triangle t, DiagonalStorage d, X_t X)
+{
+  using size_type = typename std::experimental::extents<>::size_type;
+  constexpr bool lower_triangle = std::is_same_v<
+      Triangle, std::experimental::linalg::lower_triangle_t>;
+  constexpr bool explicit_diagonal = std::is_same_v<
+      DiagonalStorage, std::experimental::linalg::explicit_diagonal_t>;
+
+  const size_type A_ext = A.extent(0); // = A.extent(1)
+  const size_type num_vectors = X.extent(0);
+
+  for (size_type i = 0; i < num_vectors; ++i) {
+    for (size_type kk = 0; kk < A_ext; ++kk) {
+      const size_type k = lower_triangle ? kk : A_ext - 1 - kk;
+      // A(j, k) has lower triangle in j <= k
+      const size_type j0 = lower_triangle ? 0 : k + 1;
+      const size_type j1 = lower_triangle ? k : A_ext;
+      for (size_type j = j0; j < j1; ++j) {
+        X(i, k) -= X(i, j) * A(j, k);
+      }
+      if constexpr (explicit_diagonal) {
+        X(i, k) /= A(k, k);
+      }
+    }
+  }
+}
+
+template<class A_t,
+         class B_t,
+         class X_t,
+         class Triangle,
+         class DiagonalStorage>
+void test_triangular_matrix_matrix_right_solve_impl(A_t A, B_t B, X_t X0, Triangle t, DiagonalStorage d)
+{
+  // copy x to leave original fixture intact
+  auto x_data = create_stdvector_and_copy_rowwise(X0);
+  auto X = make_mdspan(x_data.data(), X0.extent(0), X0.extent(1));
+
+  const auto get_gold = [&](auto X_gold) {
+      std::experimental::linalg::copy(B, X_gold);
+      triangular_matrix_matrix_right_solve_gold_solution(A, t, d, X_gold);
+    };
+  const auto compute = [&]() {
+      std::experimental::linalg::triangular_matrix_matrix_right_solve(
+        KokkosKernelsSTD::kokkos_exec<>(), A, t, d, B, X);
+    };
+  const auto tol = tolerance<typename X_t::value_type>(1e-13, 1e-4f);
+  test_op_CAB(A, B, X, tol, get_gold, compute);
+}
+
+} // anonymous namespace
+
+#define DEFINE_TESTS(blas_val_type)                                               \
+TEST_F(blas2_signed_##blas_val_type##_fixture,                                    \
+       kokkos_triangular_matrix_matrix_right_solve) {                             \
+  using val_t = typename blas2_signed_##blas_val_type##_fixture::value_type;      \
+  run_checked_tests<val_t>("kokkos_", "triangular_matrix_matrix_right_solve", "", \
+                           #blas_val_type, [&]() {                                \
+                                                                                  \
+    test_triangular_matrix_matrix_right_solve_impl(A_sym_e0, A_sym_e0, A_hem_e0,  \
+                         std::experimental::linalg::lower_triangle,               \
+                         std::experimental::linalg::implicit_unit_diagonal);      \
+    test_triangular_matrix_matrix_right_solve_impl(A_sym_e0, A_sym_e0, A_hem_e0,  \
+                         std::experimental::linalg::upper_triangle,               \
+                         std::experimental::linalg::explicit_diagonal);           \
+                                                                                  \
+  });                                                                             \
+}
+
+DEFINE_TESTS(double)
+DEFINE_TESTS(float)
+DEFINE_TESTS(complex_double)

--- a/tests/kokkos-based/triangular_matrix_matrix_right_solve.cpp
+++ b/tests/kokkos-based/triangular_matrix_matrix_right_solve.cpp
@@ -85,7 +85,8 @@ template<class A_t,
          class X_t,
          class Triangle,
          class DiagonalStorage>
-void test_triangular_matrix_matrix_right_solve_impl(A_t A, B_t B, X_t X0, Triangle t, DiagonalStorage d)
+void test_triangular_matrix_matrix_right_solve_impl(
+        A_t A, B_t B, X_t X0, Triangle t, DiagonalStorage d)
 {
   // copy x to leave original fixture intact
   auto x_data = create_stdvector_and_copy_rowwise(X0);
@@ -106,16 +107,16 @@ void test_triangular_matrix_matrix_right_solve_impl(A_t A, B_t B, X_t X0, Triang
 } // anonymous namespace
 
 #define DEFINE_TESTS(blas_val_type)                                               \
-TEST_F(blas2_signed_##blas_val_type##_fixture,                                    \
+TEST_F(blas3_signed_##blas_val_type##_fixture,                                    \
        kokkos_triangular_matrix_matrix_right_solve) {                             \
-  using val_t = typename blas2_signed_##blas_val_type##_fixture::value_type;      \
+  using val_t = typename blas3_signed_##blas_val_type##_fixture::value_type;      \
   run_checked_tests<val_t>("kokkos_", "triangular_matrix_matrix_right_solve", "", \
                            #blas_val_type, [&]() {                                \
                                                                                   \
-    test_triangular_matrix_matrix_right_solve_impl(A_sym_e0, A_sym_e0, A_hem_e0,  \
+    test_triangular_matrix_matrix_right_solve_impl(A_sym_e0, C_e2e0, C_e2e0,      \
                          std::experimental::linalg::lower_triangle,               \
                          std::experimental::linalg::implicit_unit_diagonal);      \
-    test_triangular_matrix_matrix_right_solve_impl(A_sym_e0, A_sym_e0, A_hem_e0,  \
+    test_triangular_matrix_matrix_right_solve_impl(A_sym_e0, C_e2e0, C_e2e0,      \
                          std::experimental::linalg::upper_triangle,               \
                          std::experimental::linalg::explicit_diagonal);           \
                                                                                   \

--- a/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas3_triangular_matrix_matrix_solve.hpp
+++ b/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas3_triangular_matrix_matrix_solve.hpp
@@ -1,0 +1,219 @@
+ /*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2019) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#ifndef LINALG_TPLIMPLEMENTATIONS_INCLUDE_EXPERIMENTAL___P1673_BITS_KOKKOSKERNELS_BLAS2_TRIANGULAR_MATRIX_MATRIX_SOLVE_HPP_
+#define LINALG_TPLIMPLEMENTATIONS_INCLUDE_EXPERIMENTAL___P1673_BITS_KOKKOSKERNELS_BLAS2_TRIANGULAR_MATRIX_MATRIX_SOLVE_HPP_
+
+#include "signal_kokkos_impl_called.hpp"
+#include "static_extent_match.hpp"
+#include "triangle.hpp"
+
+#include <KokkosBlas3_trsm.hpp>
+
+namespace KokkosKernelsSTD {
+
+namespace trimatmatsolve_impl {
+
+template <class Side,
+          class Triangle,
+          class DiagonalStorage,
+          class AViewType,
+          class XViewType>
+void trsm(Side /*s*/, Triangle /*t*/, DiagonalStorage /*d*/, AViewType A, XViewType X)
+{
+  const auto side = std::is_same_v<Side,
+      std::experimental::linalg::left_side_t> ? "L" : "R";
+  // KK and stdBLAS use REVERSED triangle definitions
+  const auto uplo = std::is_same_v<Triangle,
+      std::experimental::linalg::lower_triangle_t> ? "U" : "L";
+  const auto diag = std::is_same_v<DiagonalStorage,
+      std::experimental::linalg::explicit_diagonal_t> ? "N" : "U";
+
+  const auto alpha = static_cast<typename XViewType::non_const_value_type>(1.0);
+  const auto notranspose = "N";
+  KokkosBlas::trsm(side, uplo, notranspose, diag, alpha, A, X);
+}
+
+}
+
+// Solve multiple triangular linear systems
+// performs BLAS xTRSM
+
+// not-in-place overload
+MDSPAN_TEMPLATE_REQUIRES(class ExecSpace,
+    class ElementType_A,
+    std::experimental::extents<>::size_type numRows_A,
+    std::experimental::extents<>::size_type numCols_A,
+    class Layout_A,
+    class Triangle,
+    class DiagonalStorage,
+    class ElementType_B,
+    std::experimental::extents<>::size_type numRows_B,
+    std::experimental::extents<>::size_type numCols_B,
+    class Layout_B,
+    class ElementType_X,
+    std::experimental::extents<>::size_type numRows_X,
+    std::experimental::extents<>::size_type numCols_X,
+    class Layout_X,
+  /* requires */ (Impl::is_unique_layout_v<Layout_X, numRows_X, numCols_X>
+        and Impl::is_unique_layout_v<Layout_B, numRows_B, numCols_B>
+        and (Impl::is_unique_layout_v<Layout_A, numRows_A, numCols_A>
+        or Impl::is_layout_blas_packed_v<Layout_A>)))
+void triangular_matrix_matrix_left_solve(kokkos_exec<ExecSpace> &&exec,
+  std::experimental::mdspan<ElementType_A, std::experimental::extents<numRows_A, numCols_A>,
+    Layout_A, std::experimental::default_accessor<ElementType_A>> A,
+  Triangle t,
+  DiagonalStorage d,
+  std::experimental::mdspan<ElementType_B, std::experimental::extents<numRows_B, numCols_B>,
+    Layout_B, std::experimental::default_accessor<ElementType_A>> B,
+  std::experimental::mdspan<ElementType_X, std::experimental::extents<numRows_X, numCols_X>,
+    Layout_X, std::experimental::default_accessor<ElementType_A>> X)
+{
+  // P1673 constraints (redundant to mdspan extents in the header)
+  static_assert(A.rank() == 2);
+  static_assert(X.rank() == 2);
+  static_assert(B.rank() == 2);
+  static_assert(Impl::triangle_layout_match_v<Layout_A, Triangle>);
+
+  // P1673 mandates
+  static_assert(Impl::static_extent_match(A.static_extent(0), A.static_extent(1)));
+  static_assert(Impl::static_extent_match(A.static_extent(1), B.static_extent(0)));
+  static_assert(Impl::static_extent_match(X.static_extent(0), B.static_extent(0)));
+  static_assert(Impl::static_extent_match(X.static_extent(1), B.static_extent(1)));
+
+  // P1673 preconditions
+  if ( A.extent(0) != A.extent(1) ){
+    throw std::runtime_error("KokkosBlas: triangular_matrix_vector_solve: A.extent(0) != A.extent(1)");
+  }
+  if ( A.extent(1) != B.extent(0) ){
+    throw std::runtime_error("KokkosBlas: triangular_matrix_vector_solve: A.extent(1) != B.extent(0)");
+  }
+  if ( X.extent(0) != B.extent(0) ){
+    throw std::runtime_error("KokkosBlas: triangular_matrix_vector_solve: X.extent(0) != B.extent(0)");
+  }
+  if ( X.extent(1) != B.extent(1) ){
+    throw std::runtime_error("KokkosBlas: triangular_matrix_vector_solve: X.extent(1) != B.extent(1)");
+  }
+
+  Impl::signal_kokkos_impl_called("triangular_matrix_matrix_left_solve");
+
+  // convert mdspans to views
+  const auto A_view = Impl::mdspan_to_view(A);
+  const auto B_view = Impl::mdspan_to_view(B);
+  auto X_view = Impl::mdspan_to_view(X);
+
+  Kokkos::deep_copy(X_view, B_view);
+
+  trimatmatsolve_impl::trsm(std::experimental::linalg::left_side, t, d, A_view, X_view);
+}
+
+// not-in-place overload
+MDSPAN_TEMPLATE_REQUIRES(class ExecSpace,
+    class ElementType_A,
+    std::experimental::extents<>::size_type numRows_A,
+    std::experimental::extents<>::size_type numCols_A,
+    class Layout_A,
+    class Triangle,
+    class DiagonalStorage,
+    class ElementType_B,
+    std::experimental::extents<>::size_type numRows_B,
+    std::experimental::extents<>::size_type numCols_B,
+    class Layout_B,
+    class ElementType_X,
+    std::experimental::extents<>::size_type numRows_X,
+    std::experimental::extents<>::size_type numCols_X,
+    class Layout_X,
+  /* requires */ (Impl::is_unique_layout_v<Layout_X, numRows_X, numCols_X>
+        and Impl::is_unique_layout_v<Layout_B, numRows_B, numCols_B>
+        and (Impl::is_unique_layout_v<Layout_A, numRows_A, numCols_A>
+        or Impl::is_layout_blas_packed_v<Layout_A>)))
+void triangular_matrix_matrix_right_solve(kokkos_exec<ExecSpace> &&exec,
+  std::experimental::mdspan<ElementType_A, std::experimental::extents<numRows_A, numCols_A>,
+    Layout_A, std::experimental::default_accessor<ElementType_A>> A,
+  Triangle t,
+  DiagonalStorage d,
+  std::experimental::mdspan<ElementType_B, std::experimental::extents<numRows_B, numCols_B>,
+    Layout_B, std::experimental::default_accessor<ElementType_A>> B,
+  std::experimental::mdspan<ElementType_X, std::experimental::extents<numRows_X, numCols_X>,
+    Layout_X, std::experimental::default_accessor<ElementType_A>> X)
+{
+  // P1673 constraints (redundant to mdspan extents in the header)
+  static_assert(A.rank() == 2);
+  static_assert(X.rank() == 2);
+  static_assert(B.rank() == 2);
+  static_assert(Impl::triangle_layout_match_v<Layout_A, Triangle>);
+
+  // P1673 mandates
+  static_assert(Impl::static_extent_match(A.static_extent(0), A.static_extent(1)));
+  static_assert(Impl::static_extent_match(A.static_extent(1), B.static_extent(1)));
+  static_assert(Impl::static_extent_match(X.static_extent(0), B.static_extent(0)));
+  static_assert(Impl::static_extent_match(X.static_extent(1), B.static_extent(1)));
+
+  // P1673 preconditions
+  if ( A.extent(0) != A.extent(1) ){
+    throw std::runtime_error("KokkosBlas: triangular_matrix_vector_solve: A.extent(0) != A.extent(1)");
+  }
+  if ( A.extent(1) != B.extent(1) ){
+    throw std::runtime_error("KokkosBlas: triangular_matrix_vector_solve: A.extent(1) != B.extent(1)");
+  }
+  if ( X.extent(0) != B.extent(0) ){
+    throw std::runtime_error("KokkosBlas: triangular_matrix_vector_solve: X.extent(0) != B.extent(0)");
+  }
+  if ( X.extent(1) != B.extent(1) ){
+    throw std::runtime_error("KokkosBlas: triangular_matrix_vector_solve: X.extent(1) != B.extent(1)");
+  }
+
+  Impl::signal_kokkos_impl_called("triangular_matrix_matrix_right_solve");
+
+  // convert mdspans to views
+  const auto A_view = Impl::mdspan_to_view(A);
+  const auto B_view = Impl::mdspan_to_view(B);
+  auto X_view = Impl::mdspan_to_view(X);
+
+  Kokkos::deep_copy(X_view, B_view);
+
+  trimatmatsolve_impl::trsm(std::experimental::linalg::right_side, t, d, A_view, X_view);
+}
+
+} // namespace KokkosKernelsSTD
+#endif


### PR DESCRIPTION
This PR introduces Kokkos implementation for `triangular_matrix_matrix_{left,right}_solve()` - based on [KokkosBLAS::trsm()](https://github.com/kokkos/kokkos-kernels/wiki/BLAS-3%3A%3Atrsm) - and unit tests.

### Model

Let me present [P1673R7](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p1673r7.html)-based TRSM model, so it's easier for us to catch my bugs and track down discrepancies.

#### [Triangles](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p1673r7.html#triangle-tags-linalgtagstriangle)

<div align="center">

![triangles](https://user-images.githubusercontent.com/29018159/167638026-0063c517-9016-43c2-9b63-6a4d866cd5ce.png)
</div>

> **Note:** I avoid naming rows and columns to abstract out [the matrix layout](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p1673r6.html#layouts-for-general-and-packed-matrix-types-linalglayouts) and use row-major indexing on the pictures below so _X<sub>MxN</sub>_ means _X_ has _M_ rows and _N_ columns, and _A<sub>i,j</sub>_ means i-th row and j-th column.

#### [TRSM](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p1673r7.html#solve-multiple-triangular-linear-systems-linalgalgblas3trsm)

For left TRSM we compute `i`-th element of `k`-th solution vector accumulating with `j` (dots): _X<sub>i,k</sub> = B<sub>i,k</sub> – ( ∑<sub>j≠i</sub> A<sub>i,j</sub> X<sub>j,k</sub> ) / A<sub>i,i</sub>_

<div align="center">

![trsm_left](https://user-images.githubusercontent.com/29018159/167644081-ceaa1729-61a2-402f-829e-1c59e5b3ad29.png)
</div>

For right TRSM we compute `k`-th element of `i`-th solution vector accumulating with `j` (dots): _X<sub>i,k</sub> = B<sub>i,k</sub> – ( ∑<sub>j≠k</sub> X<sub>i,j</sub> A<sub>j,k</sub> ) / A<sub>k,k</sub>_
<div align="center">

![trsm_right](https://user-images.githubusercontent.com/29018159/167644106-a7ded8b6-c603-4eba-bf10-0d0abd964813.png)
</div>

#### Solving order

Solving starts at the corner that yields the _X<sub>i,i</sub> = B<sub>i,i</sub>_ equation, which makes `i` iterate over elements in _reversed order_ in the _lower_ triangle of matrix `A` and in normal order in the _upper_ triangle.
<div align="center">

![solving_order png](https://user-images.githubusercontent.com/29018159/167647932-6f77fb68-0252-4f14-8d68-68bb811f2d4c.png)
</div>
