### PR TITLE
[ready] gemv kokkos: fix tolerances in test and constraint in impl

### DIFF
--- a/tests/kokkos-based/overwriting_matrix_vector_product.cpp
+++ b/tests/kokkos-based/overwriting_matrix_vector_product.cpp
@@ -51,7 +51,7 @@ void kokkos_blas_overwriting_gemv_impl(A_t A, x_t x, y_t y)
     // check A and y
     std::size_t count=0;
     for (std::size_t i=0; i<extent0; ++i){
-      EXPECT_FLOAT_EQ(y(i), y_gold(i));
+      EXPECT_NEAR(y(i), y_gold(i), 1e-2);
       for (std::size_t j=0; j<extent1; ++j){
 	EXPECT_FLOAT_EQ(A(i,j), A_preKernel[count++]);
       }
@@ -67,7 +67,7 @@ void kokkos_blas_overwriting_gemv_impl(A_t A, x_t x, y_t y)
     // check A and y
     std::size_t count=0;
     for (std::size_t i=0; i<extent0; ++i){
-      EXPECT_DOUBLE_EQ(y(i), y_gold(i));
+      EXPECT_NEAR(y(i), y_gold(i), 1e-9);
       for (std::size_t j=0; j<extent1; ++j){
 	EXPECT_DOUBLE_EQ(A(i,j), A_preKernel[count++]);
       }
@@ -84,8 +84,8 @@ void kokkos_blas_overwriting_gemv_impl(A_t A, x_t x, y_t y)
     // check A and y
     std::size_t count=0;
     for (std::size_t i=0; i<extent0; ++i){
-      EXPECT_DOUBLE_EQ(y(i).real(), y_gold(i).real());
-      EXPECT_DOUBLE_EQ(y(i).imag(), y_gold(i).imag());
+      EXPECT_NEAR(y(i).real(), y_gold(i).real(), 1e-9);
+      EXPECT_NEAR(y(i).imag(), y_gold(i).imag(), 1e-9);
 
       for (std::size_t j=0; j<extent1; ++j){
 	EXPECT_DOUBLE_EQ(A(i,j).real(), A_preKernel[count].real());

--- a/tests/kokkos-based/updating_matrix_vector_product.cpp
+++ b/tests/kokkos-based/updating_matrix_vector_product.cpp
@@ -52,7 +52,7 @@ void kokkos_blas_updating_gemv_impl(A_t A, x_t x, y_t y, z_t z)
     // check A, z, y
     std::size_t count=0;
     for (std::size_t i=0; i<extent0; ++i){
-      EXPECT_FLOAT_EQ(z(i), z_gold(i));
+      EXPECT_NEAR(z(i), z_gold(i), 1e-2);
       EXPECT_FLOAT_EQ(y(i), y_preKernel[i]);
       for (std::size_t j=0; j<extent1; ++j){
 	EXPECT_FLOAT_EQ(A(i,j), A_preKernel[count++]);
@@ -69,8 +69,8 @@ void kokkos_blas_updating_gemv_impl(A_t A, x_t x, y_t y, z_t z)
     // check A, y, z
     std::size_t count=0;
     for (std::size_t i=0; i<extent0; ++i){
-      EXPECT_FLOAT_EQ(z(i), z_gold(i));
-      EXPECT_FLOAT_EQ(y(i), y_preKernel[i]);
+      EXPECT_NEAR(z(i), z_gold(i), 1e-9);
+      EXPECT_DOUBLE_EQ(y(i), y_preKernel[i]);
       for (std::size_t j=0; j<extent1; ++j){
 	EXPECT_DOUBLE_EQ(A(i,j), A_preKernel[count++]);
       }
@@ -87,8 +87,8 @@ void kokkos_blas_updating_gemv_impl(A_t A, x_t x, y_t y, z_t z)
     // check A, y, z
     std::size_t count=0;
     for (std::size_t i=0; i<extent0; ++i){
-      EXPECT_DOUBLE_EQ(z(i).real(), z_gold(i).real());
-      EXPECT_DOUBLE_EQ(z(i).imag(), z_gold(i).imag());
+      EXPECT_NEAR(z(i).real(), z_gold(i).real(), 1e-9);
+      EXPECT_NEAR(z(i).imag(), z_gold(i).imag(), 1e-9);
 
       EXPECT_DOUBLE_EQ(y(i).real(), y_preKernel[i].real());
       EXPECT_DOUBLE_EQ(y(i).imag(), y_preKernel[i].imag());


### PR DESCRIPTION
@mhoemmen 
two changes here:
- fixed constraint in kokkos impl that for some reason gave me trouble 
- fixed tolerances in tests (this is in line with what we do for other tests. If needed, will do another pass later to set tolerances more appropriately)