### PR TITLE
cmake fix: require Kokkos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,8 +99,8 @@ add_library(std::linalg ALIAS linalg)
 
 target_link_libraries(linalg INTERFACE std::mdspan)
 if(LINALG_ENABLE_KOKKOS)
-  find_package(Kokkos)
-  find_package(KokkosKernels)
+  find_package(Kokkos REQUIRED)
+  find_package(KokkosKernels REQUIRED)
   target_link_libraries(linalg INTERFACE Kokkos::kokkos)
   target_link_libraries(linalg INTERFACE Kokkos::kokkoskernels)
   target_include_directories(linalg INTERFACE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,15 @@ option(LINALG_ENABLE_BLAS
   "Assume that we are linking with a BLAS library."
   ${BLAS_FOUND})
 
+find_package(KokkosKernels)
+option(LINALG_ENABLE_KOKKOS
+  "Enable Kokkos-based implementation. Default: autodetect Kokkos installation."
+  ${KokkosKernels_FOUND})
+if(LINALG_ENABLE_KOKKOS)
+  find_package(Kokkos REQUIRED)
+  find_package(KokkosKernels REQUIRED)
+endif()
+
 ################################################################################
 
 CONFIGURE_FILE(include/experimental/__p1673_bits/linalg_config.h.in
@@ -98,9 +107,8 @@ add_library(linalg INTERFACE)
 add_library(std::linalg ALIAS linalg)
 
 target_link_libraries(linalg INTERFACE std::mdspan)
+
 if(LINALG_ENABLE_KOKKOS)
-  find_package(Kokkos REQUIRED)
-  find_package(KokkosKernels REQUIRED)
   target_link_libraries(linalg INTERFACE Kokkos::kokkos)
   target_link_libraries(linalg INTERFACE Kokkos::kokkoskernels)
   target_include_directories(linalg INTERFACE


### PR DESCRIPTION
Replace CMake complaints on missing Kokkos _targets_ with clear messages and hints about missing Kokkos _libraries_.