### PR TITLE
kokkos: fix `Kokkos::abs()` namespacing

### DIFF
--- a/tests/kokkos-based/helpers.hpp
+++ b/tests/kokkos-based/helpers.hpp
@@ -47,7 +47,7 @@
 #include <experimental/mdspan>
 #include <random>
 
-#if KOKKOS_VERSION <= 30600
+#if KOKKOS_VERSION < 30699
 namespace Kokkos {
   using Experimental::abs;
 }

--- a/tests/kokkos-based/helpers.hpp
+++ b/tests/kokkos-based/helpers.hpp
@@ -47,6 +47,12 @@
 #include <experimental/mdspan>
 #include <random>
 
+#if KOKKOS_VERSION <= 30600
+namespace Kokkos {
+  using Experimental::abs;
+}
+#endif
+
 namespace kokkostesting{
 
 template<class T>


### PR DESCRIPTION
Fix compilation error on `Kokkos::abs()` not being recognized when stdBLAS is built aginast Kokkos `3.6.00`, because the function is still in `Kokkos::Experimental` there.