### PR TITLE
kokkos: fix build failng with KOKKOS_DEFAULT=OFF

### DIFF
--- a/include/experimental/__p1673_bits/linalg_execpolicy_mapper.hpp
+++ b/include/experimental/__p1673_bits/linalg_execpolicy_mapper.hpp
@@ -24,7 +24,7 @@ template<class T> inline constexpr bool is_inline_exec_v = is_inline_exec<T>::va
 }
 
 
-#if defined(LINALG_ENABLE_KOKKOS) && defined(LINALG_ENABLE_KOKKOS_DEFAULT)
+#if defined(LINALG_ENABLE_KOKKOS)
 #include <experimental/__p1673_bits/kokkos-kernels/exec_policy_wrapper_kk.hpp>
 #endif
 


### PR DESCRIPTION
Fix build failing on missing `kokkos_exec` when `LINALG_ENABLE_KOKKOS` is `ON` but   `LINALG_ENABLE_KOKKOS_DEFAULT` is `OFF`