### PR TITLE
Fix infinite recursion crash in `gemm` cross-test

### DIFF
--- a/include/experimental/__p1673_bits/blas3_matrix_product.hpp
+++ b/include/experimental/__p1673_bits/blas3_matrix_product.hpp
@@ -368,23 +368,6 @@ constexpr bool extractConj ()
 template <class Exec, class A_t, class B_t, class C_t, class = void>
 struct is_custom_matrix_product_avail : std::false_type {};
 
-template <class Exec, class A_t, class B_t, class C_t>
-struct is_custom_matrix_product_avail<
-  Exec, A_t, B_t, C_t,
-  std::enable_if_t<
-    std::is_void_v<
-      decltype(
-	       matrix_product
-	       (std::declval<Exec>(),
-		std::declval<A_t>(),
-		std::declval<B_t>(),
-		std::declval<C_t>()))
-      >
-    && !linalg::impl::is_inline_exec_v<Exec>
-    >
-  >
-  : std::true_type{};
-
 template <class Exec, class A_t, class B_t, class E_t, class C_t, class = void>
 struct is_custom_matrix_product_with_update_avail : std::false_type {};
 
@@ -2235,6 +2218,36 @@ void hermitian_matrix_right_product(
   hermitian_matrix_right_product(std::experimental::linalg::impl::default_exec_t(), A, t, B, E, C);
 }
 
+template <class Exec, class A_t, class B_t, class C_t>
+struct is_custom_matrix_product_avail<
+  Exec, A_t, B_t, C_t,
+  std::enable_if_t<
+    std::is_void_v<
+      decltype(
+	      matrix_product(
+          std::declval<Exec>(),
+          std::declval<A_t>(),
+		      std::declval<B_t>(),
+		      std::declval<C_t>()))
+      >
+    && !std::is_same_v< // see #218
+      decltype(
+        std::experimental::linalg::matrix_product(
+          std::declval<Exec>(),
+          std::declval<A_t>(),
+		      std::declval<B_t>(),
+		      std::declval<C_t>())),
+      decltype(
+        matrix_product(
+          std::declval<Exec>(),
+          std::declval<A_t>(),
+		      std::declval<B_t>(),
+		      std::declval<C_t>()))
+      >
+    && !linalg::impl::is_inline_exec_v<Exec>
+    >
+  >
+  : std::true_type{};
 
 } // end namespace linalg
 } // end inline namespace __p1673_version_0


### PR DESCRIPTION
In build with default Kokkos execution space (both `LINALG_ENABLE_KOKKOS` and `LINALG_ENABLE_KOKKOS_DEFAULT` enabled) the native `gemm` test executes Kokkos `matrix_product()` implementation and fails on missing overloads for [`transposed`](https://github.com/kokkos/stdBLAS/blob/93a1fa2aead9d2eb723d3587b009c229a623ae98/tests/native/gemm.cpp#L171-L172)- and [`scaled`](https://github.com/kokkos/stdBLAS/blob/93a1fa2aead9d2eb723d3587b009c229a623ae98/tests/native/gemm.cpp#L217-L218)-wrapped inputs - see https://github.com/kokkos/stdBLAS/issues/218.

This PR fixes adds recursion detection to `is_custom_matrix_product_avail<...>` check allowing proper fallback to inline implementation, as proposed/explained in https://github.com/kokkos/stdBLAS/issues/218#issuecomment-1137094702.

> This PR offers alternative solution to https://github.com/kokkos/stdBLAS/pull/220 (disable test) as requested in https://github.com/kokkos/stdBLAS/pull/220#issuecomment-1139229166