### PR TITLE
kokkos: fix empty matrix check in `matrix_inf_norm` #225

### DIFF
--- a/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas1_matrix_inf_norm_kk.hpp
+++ b/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas1_matrix_inf_norm_kk.hpp
@@ -24,7 +24,7 @@ Scalar matrix_inf_norm(kokkos_exec<ExeSpace> /*kexe*/,
 
   Impl::signal_kokkos_impl_called("matrix_inf_norm");
 
-  if (A.extent(0) == 0){
+  if (A.extent(0) == 0 || A.extent(1) == 0){
     return init;
   }
 


### PR DESCRIPTION
Fixes #225