### PR TITLE
Fix C++23 build (GCC 13.1.0)

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -102,8 +102,6 @@ jobs:
         
   test-stdBLAS:
     runs-on: ubuntu-latest
-    container:
-      image: amklinv/mdspan-dependencies:latest
     needs: build-stdblas
     
     steps:

--- a/examples/01_scale.cpp
+++ b/examples/01_scale.cpp
@@ -1,3 +1,9 @@
+// Examples currently use parentheses (e.g., A(i,j))
+// for the array access operator,
+// instead of square brackets (e.g., A[i,j]).
+// This must be defined before including any mdspan headers.
+#define MDSPAN_USE_PAREN_OPERATOR 1
+
 #include <experimental/linalg>
 
 #include <iostream>
@@ -10,10 +16,14 @@
 #  include <execution>
 #endif
 
-// Make mdspan less verbose
 using std::experimental::mdspan;
 using std::experimental::extents;
-using std::experimental::dynamic_extent;
+#if defined(__cpp_lib_span)
+#include <span>
+  using std::dynamic_extent;
+#else
+  using std::experimental::dynamic_extent;
+#endif
 
 int main(int argc, char* argv[]) {
   std::cout << "Scale" << std::endl;
@@ -23,7 +33,10 @@ int main(int argc, char* argv[]) {
     std::vector<double> x_vec(N);
 
     // Create and initialize mdspan
-    // With CTAD working we could do, GCC 11.1 works but some others are buggy
+    //
+    // With CTAD working we could do the following.
+    // GCC 11.1 works but some other compilers are buggy.
+    //
     // mdspan x(x_vec.data(), N);
     mdspan<double, extents<std::size_t, dynamic_extent>> x(x_vec.data(),N);
     for(int i=0; i<x.extent(0); i++) x(i) = i;

--- a/examples/02_matrix_vector_product_basic.cpp
+++ b/examples/02_matrix_vector_product_basic.cpp
@@ -1,3 +1,9 @@
+// Examples currently use parentheses (e.g., A(i,j))
+// for the array access operator,
+// instead of square brackets (e.g., A[i,j]).
+// This must be defined before including any mdspan headers.
+#define MDSPAN_USE_PAREN_OPERATOR 1
+
 #include <experimental/linalg>
 
 #include <iostream>
@@ -10,10 +16,14 @@
 #  include <execution>
 #endif
 
-// Make mdspan less verbose
 using std::experimental::mdspan;
 using std::experimental::extents;
-using std::experimental::dynamic_extent;
+#if defined(__cpp_lib_span)
+#include <span>
+  using std::dynamic_extent;
+#else
+  using std::experimental::dynamic_extent;
+#endif
 
 int main(int argc, char* argv[]) {
   std::cout << "Matrix Vector Product Basic" << std::endl;

--- a/examples/03_matrix_vector_product_mixedprec.cpp
+++ b/examples/03_matrix_vector_product_mixedprec.cpp
@@ -1,13 +1,23 @@
+// Examples currently use parentheses (e.g., A(i,j))
+// for the array access operator,
+// instead of square brackets (e.g., A[i,j]).
+// This must be defined before including any mdspan headers.
+#define MDSPAN_USE_PAREN_OPERATOR 1
+
 #include <experimental/linalg>
 
 #include <iostream>
 
-// Make mdspan less verbose
-using std::experimental::mdspan;
+#if defined(__cpp_lib_span)
+#include <span>
+  using std::dynamic_extent;
+#else
+  using std::experimental::dynamic_extent;
+#endif
 using std::experimental::extents;
-using std::experimental::dynamic_extent;
+using std::full_extent; // not in experimental namespace
+using std::experimental::mdspan;
 using std::experimental::submdspan;
-using std::experimental::full_extent;
 
 int main(int argc, char* argv[]) {
   std::cout << "Matrix Vector Product MixedPrec" << std::endl;
@@ -44,4 +54,3 @@ int main(int argc, char* argv[]) {
     for(int i=0; i<y.extent(0); i+=5) std::cout << i << " " << y(i,1) << std::endl;
   }
 }
-

--- a/tests/native/add.cpp
+++ b/tests/native/add.cpp
@@ -1,14 +1,10 @@
-#include "gtest/gtest.h"
+#include "./gtest_fixtures.hpp"
 
 #include <experimental/linalg>
-#include <experimental/mdspan>
 #include <array>
 #include <vector>
 
 namespace {
-  using std::experimental::dynamic_extent;
-  using std::experimental::extents;
-  using std::experimental::mdspan;
   using std::experimental::linalg::add;
 
   TEST(BLAS1_add, vector_double)

--- a/tests/native/conjugate_transposed.cpp
+++ b/tests/native/conjugate_transposed.cpp
@@ -1,14 +1,8 @@
-#include "gtest/gtest.h"
+#include "./gtest_fixtures.hpp"
 
 #include <experimental/linalg>
-#include <experimental/mdspan>
-#include <complex>
-#include <vector>
 
 namespace {
-  using std::experimental::dynamic_extent;
-  using std::experimental::extents;
-  using std::experimental::mdspan;
   using std::experimental::linalg::conjugate_transposed;
 
   TEST(conjugate_transposed, mdspan_complex_double)

--- a/tests/native/conjugated.cpp
+++ b/tests/native/conjugated.cpp
@@ -1,15 +1,8 @@
-#include "gtest/gtest.h"
+#include "./gtest_fixtures.hpp"
 
 #include <experimental/linalg>
-#include <experimental/mdspan>
-#include <complex>
-#include <vector>
 
 namespace {
-  using std::experimental::dextents;
-  using std::experimental::dynamic_extent;
-  using std::experimental::extents;
-  using std::experimental::mdspan;
   using std::experimental::linalg::conjugated;
 
   template<class ValueType>

--- a/tests/native/copy.cpp
+++ b/tests/native/copy.cpp
@@ -1,14 +1,8 @@
-#include "gtest/gtest.h"
+#include "./gtest_fixtures.hpp"
 
 #include <experimental/linalg>
-#include <experimental/mdspan>
-#include <complex>
-#include <vector>
 
 namespace {
-  using std::experimental::dynamic_extent;
-  using std::experimental::extents;
-  using std::experimental::mdspan;
   using std::experimental::linalg::copy;
 
   template<class Real>

--- a/tests/native/dot.cpp
+++ b/tests/native/dot.cpp
@@ -1,8 +1,6 @@
-#include "gtest/gtest.h"
+#include "./gtest_fixtures.hpp"
 
 #include <experimental/linalg>
-#include <experimental/mdspan>
-#include <vector>
 
 // FIXME (mfh 2022/06/17) Temporarily disable calling the BLAS,
 // to get PR testing workflow running with mdspan tag.
@@ -22,9 +20,6 @@ double ddot_wrapper (const int N, const double* DX,
 #endif // 0
 
 namespace {
-  using std::experimental::dynamic_extent;
-  using std::experimental::extents;
-  using std::experimental::mdspan;
   using std::experimental::linalg::dot;
   using std::experimental::linalg::dotc;
 

--- a/tests/native/gemm.cpp
+++ b/tests/native/gemm.cpp
@@ -1,20 +1,14 @@
-#include "gtest/gtest.h"
+#include "./gtest_fixtures.hpp"
 
 #include <experimental/linalg>
-#include <experimental/mdspan>
-#include <vector>
 #include <iostream>
 
 namespace {
-  using std::experimental::mdspan;
-  using std::experimental::dynamic_extent;
-  using std::experimental::extents;
-  using std::experimental::layout_left;
   using std::experimental::linalg::explicit_diagonal;
   using std::experimental::linalg::implicit_unit_diagonal;
   using std::experimental::linalg::lower_triangle;
   using std::experimental::linalg::matrix_product;
-  using std::experimental::linalg::scaled;  
+  using std::experimental::linalg::scaled;
   using std::experimental::linalg::transposed;
   using std::experimental::linalg::upper_triangle;
   using std::cout;

--- a/tests/native/gemv.cpp
+++ b/tests/native/gemv.cpp
@@ -1,15 +1,9 @@
-#include "gtest/gtest.h"
+#include "./gtest_fixtures.hpp"
 
 #include <experimental/linalg>
-#include <experimental/mdspan>
-#include <vector>
 #include <iostream>
 
 namespace {
-  using std::experimental::mdspan;
-  using std::experimental::dynamic_extent;
-  using std::experimental::extents;
-  using std::experimental::layout_left;
   using std::experimental::linalg::matrix_vector_product;
   using std::experimental::linalg::transposed;
   using std::cout;

--- a/tests/native/gemv_no_ambig.cpp
+++ b/tests/native/gemv_no_ambig.cpp
@@ -1,8 +1,6 @@
-#include "gtest/gtest.h"
+#include "./gtest_fixtures.hpp"
 
 #include <experimental/linalg>
-#include <experimental/mdspan>
-#include <vector>
 #include <iostream>
 
 #if (! defined(__GNUC__)) || (__GNUC__ > 9)
@@ -14,9 +12,6 @@
 
 namespace {
 
-using std::experimental::mdspan;
-using std::experimental::extents;
-using std::experimental::dynamic_extent;
 using std::experimental::linalg::matrix_vector_product;
 using std::experimental::linalg::scaled;
 

--- a/tests/native/givens.cpp
+++ b/tests/native/givens.cpp
@@ -1,14 +1,9 @@
-#include "gtest/gtest.h"
+#include "./gtest_fixtures.hpp"
 
 #include <experimental/linalg>
-#include <experimental/mdspan>
 #include <limits>
-#include <vector>
 
 namespace {
-  using std::experimental::dynamic_extent;
-  using std::experimental::extents;
-  using std::experimental::mdspan;
   using std::experimental::linalg::givens_rotation_setup;
   using std::experimental::linalg::givens_rotation_apply;
 

--- a/tests/native/gtest_fixtures.hpp
+++ b/tests/native/gtest_fixtures.hpp
@@ -45,13 +45,32 @@
 
 #include "gtest/gtest.h"
 
+// Tests currently use parentheses (e.g., A(i,j))
+// for the array access operator,
+// instead of square brackets (e.g., A[i,j]).
+// This must be defined before including any mdspan headers.
+#define MDSPAN_USE_PAREN_OPERATOR 1
+
 #include <experimental/mdspan>
 #include <complex>
 #include <vector>
 
+  using std::experimental::default_accessor;
+  using std::dextents; // not in experimental namespace
+#if defined(__cpp_lib_span)
+#include <span>
+  using std::dynamic_extent;
+#else
   using std::experimental::dynamic_extent;
+#endif
   using std::experimental::extents;
+  using std::full_extent; // not in experimental namespace
+  using std::experimental::layout_left;
+  using std::experimental::layout_right;
+  using std::experimental::layout_stride;
   using std::experimental::mdspan;
+  using std::experimental::submdspan;
+
   using dbl_vector_t = mdspan<double, extents<std::size_t, dynamic_extent>>;
   using cpx_vector_t = mdspan<std::complex<double>, extents<std::size_t, dynamic_extent>>;
   constexpr ptrdiff_t NROWS(10);
@@ -64,8 +83,8 @@
         storage(10),
         v(storage.data(), 10)
       {
-        v(0) = 0.5;  
-        v(1) = 0.2;  
+        v(0) = 0.5;
+        v(1) = 0.2;
         v(2) = 0.1;
         v(3) = 0.4;
         v(4) = 0.8;
@@ -75,7 +94,7 @@
         v(8) = 0.2;
         v(9) = 0.9;
       }
-    
+
       std::vector<double> storage;
       dbl_vector_t v;
   }; // end class unsigned_double_vector
@@ -88,8 +107,8 @@
         storage(10),
         v(storage.data(), 10)
       {
-        v(0) =  0.5;  
-        v(1) =  0.2;  
+        v(0) =  0.5;
+        v(1) =  0.2;
         v(2) =  0.1;
         v(3) =  0.4;
         v(4) = -0.8;
@@ -99,7 +118,7 @@
         v(8) =  0.2;
         v(9) = -0.9;
       }
-    
+
       std::vector<double> storage;
       dbl_vector_t v;
   }; // end class signed_double_vector
@@ -119,7 +138,7 @@
         v(3) = std::complex<double>(-0.3,  0.5);
         v(4) = std::complex<double>( 0.2, -0.9);
       }
-    
+
       std::vector<std::complex<double>> storage;
       cpx_vector_t v;
   }; // end class signed_double_vector

--- a/tests/native/hemm.cpp
+++ b/tests/native/hemm.cpp
@@ -1,16 +1,9 @@
-#include "gtest/gtest.h"
+#include "./gtest_fixtures.hpp"
 
 #include <experimental/linalg>
-#include <experimental/mdspan>
-#include <complex>
 #include <iostream>
-#include <vector>
 
 namespace {
-  using std::experimental::mdspan;
-  using std::experimental::dynamic_extent;
-  using std::experimental::extents;
-  using std::experimental::layout_left;
   using std::experimental::linalg::explicit_diagonal;
   using std::experimental::linalg::implicit_unit_diagonal;
   using std::experimental::linalg::lower_triangle;
@@ -52,7 +45,7 @@ namespace {
     A(2,0) = 4.4 + 2.2i;
     A(2,1) = -2.8 - 4.0i;
     A(2,2) = -1.2;
-    
+
     // Fill B
     B(0,0) = 1.3;
     B(0,1) = 2.5;
@@ -75,8 +68,8 @@ namespace {
     constexpr double TOL = 1e-9;
     for (ptrdiff_t j = 0; j < n; ++j) {
       for (ptrdiff_t i = 0; i < m; ++i) {
-        EXPECT_COMPLEX_NEAR(gs(i,j), C(i,j), TOL) 
-          << "Matrices differ at index (" 
+        EXPECT_COMPLEX_NEAR(gs(i,j), C(i,j), TOL)
+          << "Matrices differ at index ("
           << i << "," << j << ")\n";
       }
     }
@@ -108,7 +101,7 @@ namespace {
     A(0,2) = 4.4 - 2.2i;
     A(1,2) = -2.8 + 4.0i;
     A(2,2) = -1.2;
-    
+
     // Fill B
     B(0,0) = 1.3;
     B(0,1) = 2.5;
@@ -131,8 +124,8 @@ namespace {
     constexpr double TOL = 1e-9;
     for (ptrdiff_t j = 0; j < n; ++j) {
       for (ptrdiff_t i = 0; i < m; ++i) {
-        EXPECT_COMPLEX_NEAR(gs(i,j), C(i,j), TOL) 
-          << "Matrices differ at index (" 
+        EXPECT_COMPLEX_NEAR(gs(i,j), C(i,j), TOL)
+          << "Matrices differ at index ("
           << i << "," << j << ")\n";
       }
     }
@@ -164,7 +157,7 @@ namespace {
     A(2,0) = 4.4 + 2.2i;
     A(2,1) = -2.8 - 4.0i;
     A(2,2) = -1.2;
-    
+
     // Fill B
     B(0,0) = 1.3;
     B(1,0) = 2.5;
@@ -187,8 +180,8 @@ namespace {
     constexpr double TOL = 1e-9;
     for (ptrdiff_t j = 0; j < m; ++j) {
       for (ptrdiff_t i = 0; i < n; ++i) {
-        EXPECT_COMPLEX_NEAR(gs(i,j), C(i,j), TOL) 
-          << "Matrices differ at index (" 
+        EXPECT_COMPLEX_NEAR(gs(i,j), C(i,j), TOL)
+          << "Matrices differ at index ("
           << i << "," << j << ")\n";
       }
     }
@@ -220,7 +213,7 @@ namespace {
     A(0,2) = 4.4 - 2.2i;
     A(1,2) = -2.8 + 4.0i;
     A(2,2) = -1.2;
-    
+
     // Fill B
     B(0,0) = 1.3;
     B(1,0) = 2.5;
@@ -243,8 +236,8 @@ namespace {
     constexpr double TOL = 1e-9;
     for (ptrdiff_t j = 0; j < m; ++j) {
       for (ptrdiff_t i = 0; i < n; ++i) {
-        EXPECT_COMPLEX_NEAR(gs(i,j), C(i,j), TOL) 
-          << "Matrices differ at index (" 
+        EXPECT_COMPLEX_NEAR(gs(i,j), C(i,j), TOL)
+          << "Matrices differ at index ("
           << i << "," << j << ")\n";
       }
     }

--- a/tests/native/idx_abs_max.cpp
+++ b/tests/native/idx_abs_max.cpp
@@ -1,9 +1,6 @@
-#include "gtest/gtest.h"
-#include "gtest_fixtures.hpp"
+#include "./gtest_fixtures.hpp"
 
 #include <experimental/linalg>
-#include <experimental/mdspan>
-#include <vector>
 
 namespace {
 
@@ -11,32 +8,33 @@ namespace {
 
   TEST_F(unsigned_double_vector, idx_abs_max)
   {
-    EXPECT_EQ(9, idx_abs_max(v));
+    constexpr size_t expected(9);
+    EXPECT_EQ(expected, idx_abs_max(v));
   }
 
   TEST_F(signed_double_vector, idx_abs_max)
   {
-    EXPECT_EQ(9, idx_abs_max(v));
+    constexpr size_t expected(9);
+    EXPECT_EQ(expected, idx_abs_max(v));
   }
 
   TEST_F(signed_complex_vector, idx_abs_max)
   {
-    EXPECT_EQ(2, idx_abs_max(v));
+    constexpr size_t expected(2);
+    EXPECT_EQ(expected, idx_abs_max(v));
   }
 
   TEST(BLAS1_idx_abs_max, trivial_case)
   {
-    namespace stdexp = std::experimental;
-
     constexpr auto expected = std::numeric_limits<std::size_t>::max();
 
     std::array<double, 0> arr;
-    using extents_type = stdexp::extents<std::size_t, stdexp::dynamic_extent>;
-    stdexp::mdspan<double, extents_type> a(arr.data(),0);
+    using extents_type = extents<std::size_t, dynamic_extent>;
+    mdspan<double, extents_type> a(arr.data(),0);
     EXPECT_EQ(expected, idx_abs_max(a));
 
-    using extents_type2 = stdexp::extents<std::size_t, 0>;
-    stdexp::mdspan<double, extents_type2> b(arr.data());
+    using extents_type2 = extents<std::size_t, 0>;
+    mdspan<double, extents_type2> b(arr.data());
     EXPECT_EQ(expected, idx_abs_max(b));
   }
 

--- a/tests/native/iterator.cpp
+++ b/tests/native/iterator.cpp
@@ -1,24 +1,13 @@
-#include "gtest/gtest.h"
+#include "./gtest_fixtures.hpp"
 
 #include <experimental/linalg>
-#include <experimental/mdspan>
 #include <algorithm>
 #include <iterator>
 #include <limits>
 #include <type_traits>
 #include <typeinfo>
-#include <vector>
 
 namespace {
-  using std::experimental::full_extent;
-  using std::experimental::dynamic_extent;
-  using std::experimental::extents;
-  using std::experimental::layout_left;
-  using std::experimental::layout_right;
-  using std::experimental::layout_stride; // does compile
-  using std::experimental::mdspan;
-  using std::experimental::submdspan;
-
   MDSPAN_TEMPLATE_REQUIRES(
     class ElementType,
     class Extents,

--- a/tests/native/matrix_inf_norm.cpp
+++ b/tests/native/matrix_inf_norm.cpp
@@ -1,10 +1,8 @@
-#include "gtest/gtest.h"
+#include "./gtest_fixtures.hpp"
 
 #include <experimental/linalg>
-#include <experimental/mdspan>
 #include <iostream>
 #include <limits>
-#include <vector>
 
 namespace {
   using std::experimental::linalg::matrix_inf_norm;
@@ -12,13 +10,13 @@ namespace {
   using std::endl;
 
   template<class ElementType, class Layout>
-  using basic_matrix_t = std::experimental::mdspan<
+  using basic_matrix_t = mdspan<
     ElementType,
-    std::experimental::extents<std::size_t,
-      std::experimental::dynamic_extent,
-      std::experimental::dynamic_extent>,
+    extents<std::size_t,
+      dynamic_extent,
+      dynamic_extent>,
     Layout,
-    std::experimental::default_accessor<ElementType>>;
+    default_accessor<ElementType>>;
 
   template<class Scalar>
   struct Magnitude {
@@ -63,7 +61,6 @@ namespace {
   {
     using std::abs;
     using scalar_t = Scalar;
-    using std::experimental::layout_left;
     using matrix_t = basic_matrix_t<scalar_t, layout_left>;
 
     constexpr size_t maxNumRows = 7;

--- a/tests/native/matrix_one_norm.cpp
+++ b/tests/native/matrix_one_norm.cpp
@@ -1,28 +1,23 @@
-#include "gtest/gtest.h"
+#include "./gtest_fixtures.hpp"
 
 #include <experimental/linalg>
-#include <experimental/mdspan>
 #include <iostream>
 #include <limits>
-#include <vector>
 
 namespace {
-  //using std::experimental::mdspan;
-  //using std::experimental::dynamic_extent;
-  //using std::experimental::extents;
   using std::experimental::linalg::matrix_one_norm;
   using std::cout;
   using std::endl;
 
   template<class ElementType, class Layout>
-  using basic_matrix_t = std::experimental::mdspan<
+  using basic_matrix_t = mdspan<
     ElementType,
-    std::experimental::extents<
+    extents<
       std::size_t,
-      std::experimental::dynamic_extent,
-      std::experimental::dynamic_extent>,
+      dynamic_extent,
+      dynamic_extent>,
     Layout,
-    std::experimental::default_accessor<ElementType>>;
+    default_accessor<ElementType>>;
 
   template<class Scalar>
   struct Magnitude {
@@ -67,7 +62,6 @@ namespace {
   {
     using std::abs;
     using scalar_t = Scalar;
-    using std::experimental::layout_left;
     using matrix_t = basic_matrix_t<scalar_t, layout_left>;
 
     constexpr size_t maxNumRows = 7;

--- a/tests/native/norm2.cpp
+++ b/tests/native/norm2.cpp
@@ -1,9 +1,7 @@
-#include "gtest/gtest.h"
+#include "./gtest_fixtures.hpp"
 
 #include <experimental/linalg>
-#include <experimental/mdspan>
 #include <type_traits>
-#include <vector>
 
 // FIXME (mfh 2022/06/17) Temporarily disable calling the BLAS,
 // to get PR testing workflow running with mdspan tag.
@@ -21,9 +19,6 @@ double dnrm2_wrapper(const int N, const double* X, const int INCX)
 #endif // 0
 
 namespace {
-  using std::experimental::dynamic_extent;
-  using std::experimental::extents;
-  using std::experimental::mdspan;
   using std::experimental::linalg::vector_norm2;
 
   TEST(BLAS1_norm2, mdspan_zero)

--- a/tests/native/scale.cpp
+++ b/tests/native/scale.cpp
@@ -1,13 +1,8 @@
-#include "gtest/gtest.h"
+#include "./gtest_fixtures.hpp"
 
 #include <experimental/linalg>
-#include <experimental/mdspan>
-#include <vector>
 
 namespace {
-  using std::experimental::dynamic_extent;
-  using std::experimental::extents;
-  using std::experimental::mdspan;
   using std::experimental::linalg::scale;
 
   TEST(BLAS1_scale, mdspan_double)

--- a/tests/native/scaled.cpp
+++ b/tests/native/scaled.cpp
@@ -1,21 +1,15 @@
-#include "gtest/gtest.h"
+#include "./gtest_fixtures.hpp"
 
 #include <experimental/linalg>
-#include <experimental/mdspan>
 #include <type_traits>
-#include <vector>
 
 namespace {
-  using std::experimental::dynamic_extent;
-  using std::experimental::extents;
-  using std::experimental::mdspan;
   using std::experimental::linalg::scaled;
 
   template<class ScalingFactor, class OriginalValueType>
   void test_accessor_scaled_element_constification()
   {
     using std::experimental::linalg::accessor_scaled;
-    using std::experimental::default_accessor;
     using std::experimental::linalg::scaled_scalar;
 
     using nc_def_acc_type = default_accessor<OriginalValueType>;

--- a/tests/native/swap.cpp
+++ b/tests/native/swap.cpp
@@ -1,13 +1,8 @@
-#include "gtest/gtest.h"
+#include "./gtest_fixtures.hpp"
 
 #include <experimental/linalg>
-#include <experimental/mdspan>
-#include <vector>
 
 namespace {
-  using std::experimental::dynamic_extent;
-  using std::experimental::extents;
-  using std::experimental::mdspan;
   using std::experimental::linalg::swap_elements;
 
   TEST(BLAS1_swap, mdspan_double)

--- a/tests/native/symm.cpp
+++ b/tests/native/symm.cpp
@@ -1,16 +1,9 @@
-#include "gtest/gtest.h"
+#include "./gtest_fixtures.hpp"
 
 #include <experimental/linalg>
-#include <experimental/mdspan>
-#include <complex>
 #include <iostream>
-#include <vector>
 
 namespace {
-  using std::experimental::mdspan;
-  using std::experimental::dynamic_extent;
-  using std::experimental::extents;
-  using std::experimental::layout_left;
   using std::experimental::linalg::explicit_diagonal;
   using std::experimental::linalg::implicit_unit_diagonal;
   using std::experimental::linalg::lower_triangle;
@@ -52,7 +45,7 @@ namespace {
     A(2,0) = 4.4 + 2.2i;
     A(2,1) = -2.8 - 4.0i;
     A(2,2) = -1.2 + 1.7i;
-    
+
     // Fill B
     B(0,0) = 1.3;
     B(0,1) = 2.5;
@@ -75,8 +68,8 @@ namespace {
     constexpr double TOL = 1e-9;
     for (ptrdiff_t j = 0; j < n; ++j) {
       for (ptrdiff_t i = 0; i < m; ++i) {
-        EXPECT_COMPLEX_NEAR(gs(i,j), C(i,j), TOL) 
-          << "Matrices differ at index (" 
+        EXPECT_COMPLEX_NEAR(gs(i,j), C(i,j), TOL)
+          << "Matrices differ at index ("
           << i << "," << j << ")\n";
       }
     }
@@ -108,7 +101,7 @@ namespace {
     A(0,2) = 4.4 + 2.2i;
     A(1,2) = -2.8 - 4.0i;
     A(2,2) = -1.2 + 1.7i;
-    
+
     // Fill B
     B(0,0) = 1.3;
     B(0,1) = 2.5;
@@ -131,8 +124,8 @@ namespace {
     constexpr double TOL = 1e-9;
     for (ptrdiff_t j = 0; j < n; ++j) {
       for (ptrdiff_t i = 0; i < m; ++i) {
-        EXPECT_COMPLEX_NEAR(gs(i,j), C(i,j), TOL) 
-          << "Matrices differ at index (" 
+        EXPECT_COMPLEX_NEAR(gs(i,j), C(i,j), TOL)
+          << "Matrices differ at index ("
           << i << "," << j << ")\n";
       }
     }
@@ -164,7 +157,7 @@ namespace {
     A(2,0) = 4.4 + 2.2i;
     A(2,1) = -2.8 - 4.0i;
     A(2,2) = -1.2 + 1.7i;
-    
+
     // Fill B
     B(0,0) = 1.3;
     B(1,0) = 2.5;
@@ -187,8 +180,8 @@ namespace {
     constexpr double TOL = 1e-9;
     for (ptrdiff_t j = 0; j < m; ++j) {
       for (ptrdiff_t i = 0; i < n; ++i) {
-        EXPECT_COMPLEX_NEAR(gs(i,j), C(i,j), TOL) 
-          << "Matrices differ at index (" 
+        EXPECT_COMPLEX_NEAR(gs(i,j), C(i,j), TOL)
+          << "Matrices differ at index ("
           << i << "," << j << ")\n";
       }
     }
@@ -220,7 +213,7 @@ namespace {
     A(0,2) = 4.4 + 2.2i;
     A(1,2) = -2.8 - 4.0i;
     A(2,2) = -1.2 + 1.7i;
-    
+
     // Fill B
     B(0,0) = 1.3;
     B(1,0) = 2.5;
@@ -243,8 +236,8 @@ namespace {
     constexpr double TOL = 1e-9;
     for (ptrdiff_t j = 0; j < m; ++j) {
       for (ptrdiff_t i = 0; i < n; ++i) {
-        EXPECT_COMPLEX_NEAR(gs(i,j), C(i,j), TOL) 
-          << "Matrices differ at index (" 
+        EXPECT_COMPLEX_NEAR(gs(i,j), C(i,j), TOL)
+          << "Matrices differ at index ("
           << i << "," << j << ")\n";
       }
     }

--- a/tests/native/transposed.cpp
+++ b/tests/native/transposed.cpp
@@ -1,14 +1,9 @@
-#include "gtest/gtest.h"
+#include "./gtest_fixtures.hpp"
 
 #include <experimental/linalg>
-#include <experimental/mdspan>
 #include <type_traits>
-#include <vector>
 
 namespace {
-  using std::experimental::dynamic_extent;
-  using std::experimental::extents;
-  using std::experimental::mdspan;
   using std::experimental::linalg::transposed;
 
   template<std::size_t ext0, std::size_t ext1>

--- a/tests/native/trmm.cpp
+++ b/tests/native/trmm.cpp
@@ -1,9 +1,7 @@
-#include "gtest/gtest.h"
+#include "./gtest_fixtures.hpp"
 
 #include <experimental/linalg>
-#include <experimental/mdspan>
 #include <iostream>
-#include <vector>
 
 namespace {
   using std::experimental::linalg::explicit_diagonal;
@@ -12,11 +10,6 @@ namespace {
   using std::experimental::linalg::matrix_product;
   using std::experimental::linalg::transposed;
   using std::experimental::linalg::upper_triangle;
-  using std::experimental::dextents;
-  using std::experimental::dynamic_extent;
-  using std::experimental::extents;
-  using std::experimental::layout_left;
-  using std::experimental::mdspan;
   using std::cout;
   using std::endl;
 

--- a/tests/native/trsm.cpp
+++ b/tests/native/trsm.cpp
@@ -1,18 +1,9 @@
-#include "gtest/gtest.h"
+#include "./gtest_fixtures.hpp"
 
 #include <experimental/linalg>
-#include <experimental/mdspan>
-#include <vector>
 #include <iostream>
 
 namespace {
-
-  using std::experimental::mdspan;
-  using std::experimental::dynamic_extent;
-  using std::experimental::dextents;
-  using std::experimental::layout_right;
-  using std::experimental::layout_left;
-
   constexpr std::size_t num_rows_A = 3;
   constexpr std::size_t num_cols_A = 3;
   constexpr double storage_A[] =


### PR DESCRIPTION
Fix tests and examples to build with C++23, using GCC 13.1.0.

I set the following CMake options.

```bash
cmake ${SOME_SOURCE_DIRECTORY_ROOT}/stdBLAS \
  -DCMAKE_CXX_COMPILER=${PATH_TO_LOCAL_GCC}/bin/g++ \
  -DCMAKE_C_COMPILER=${PATH_TO_LOCAL_GCC}/bin/gcc \
  -DLINALG_ENABLE_TESTS=ON \
  -DLINALG_ENABLE_EXAMPLES=ON \
  -DLINALG_CXX_STANDARD=23
```

where `SOME_SOURCE_DIRECTORY_ROOT` is the parent directory of my stdBLAS source checkout, and `PATH_TO_LOCAL_GCC` is the installation directory of my local GCC 13.1.0 build.