### PR TITLE
Fix the build; make layout_transpose and conjugated_accessor conform

### DIFF
--- a/compilation_tests/ctest_common.hpp
+++ b/compilation_tests/ctest_common.hpp
@@ -41,7 +41,7 @@
 //@HEADER
 */
 
-#include <experimental/mdspan>
+#include <mdspan/mdspan.hpp>
 
 #include <type_traits>
 

--- a/examples/01_scale.cpp
+++ b/examples/01_scale.cpp
@@ -4,8 +4,9 @@
 // This must be defined before including any mdspan headers.
 #define MDSPAN_USE_PAREN_OPERATOR 1
 
+#include <mdspan/mdspan.hpp>
+#include "experimental/__p2630_bits/submdspan.hpp"
 #include <experimental/linalg>
-
 #include <iostream>
 
 #if (! defined(__GNUC__)) || (__GNUC__ > 9)
@@ -16,13 +17,16 @@
 #  include <execution>
 #endif
 
-using std::experimental::mdspan;
-using std::experimental::extents;
+namespace MdSpan = MDSPAN_IMPL_STANDARD_NAMESPACE;
+namespace LinearAlgebra = MDSPAN_IMPL_STANDARD_NAMESPACE :: MDSPAN_IMPL_PROPOSED_NAMESPACE :: linalg;
+
+using MdSpan::mdspan;
+using MdSpan::extents;
 #if defined(__cpp_lib_span)
 #include <span>
   using std::dynamic_extent;
 #else
-  using std::experimental::dynamic_extent;
+  using MdSpan::dynamic_extent;
 #endif
 
 int main(int argc, char* argv[]) {
@@ -38,17 +42,21 @@ int main(int argc, char* argv[]) {
     // GCC 11.1 works but some other compilers are buggy.
     //
     // mdspan x(x_vec.data(), N);
-    mdspan<double, extents<std::size_t, dynamic_extent>> x(x_vec.data(),N);
-    for(int i=0; i<x.extent(0); i++) x(i) = i;
+    mdspan<double, extents<int, dynamic_extent>> x(x_vec.data(), N);
+    for (int i = 0; i < x.extent(0); ++i) {
+      x(i) = i;
+    }
 
     // Call linalg::scale x = 2.0*x;
-    std::experimental::linalg::scale(2.0, x);
+    LinearAlgebra::scale(2.0, x);
 #ifdef MDSPAN_EXAMPLES_USE_EXECUTION_POLICIES
-    std::experimental::linalg::scale(std::execution::par, 2.0, x);
+    LinearAlgebra::scale(std::execution::par, 2.0, x);
 #else
-    std::experimental::linalg::scale(2.0, x);
+    LinearAlgebra::scale(2.0, x);
 #endif
 
-    for(int i=0; i<x.extent(0); i+=5) std::cout << i << " " << x(i) << std::endl;
+    for (int i = 0; i < x.extent(0); i += 5) {
+      std::cout << i << " " << x(i) << std::endl;
+    }
   }
 }

--- a/examples/02_matrix_vector_product_basic.cpp
+++ b/examples/02_matrix_vector_product_basic.cpp
@@ -4,8 +4,8 @@
 // This must be defined before including any mdspan headers.
 #define MDSPAN_USE_PAREN_OPERATOR 1
 
+#include <mdspan/mdspan.hpp>
 #include <experimental/linalg>
-
 #include <iostream>
 
 #if (! defined(__GNUC__)) || (__GNUC__ > 9)
@@ -16,13 +16,16 @@
 #  include <execution>
 #endif
 
-using std::experimental::mdspan;
-using std::experimental::extents;
+namespace MdSpan = MDSPAN_IMPL_STANDARD_NAMESPACE;
+namespace LinearAlgebra = MDSPAN_IMPL_STANDARD_NAMESPACE :: MDSPAN_IMPL_PROPOSED_NAMESPACE :: linalg;
+
+using MdSpan::mdspan;
+using MdSpan::extents;
 #if defined(__cpp_lib_span)
 #include <span>
   using std::dynamic_extent;
 #else
-  using std::experimental::dynamic_extent;
+  using MdSpan::dynamic_extent;
 #endif
 
 int main(int argc, char* argv[]) {
@@ -36,30 +39,36 @@ int main(int argc, char* argv[]) {
 
     // Create and initialize mdspan
     // Would look simple with CTAD, GCC 11.1 works but some others are buggy
-    mdspan<double, extents<std::size_t, dynamic_extent,dynamic_extent>> A(A_vec.data(),N,M);
-    mdspan<double, extents<std::size_t, dynamic_extent>> x(x_vec.data(),M);
-    mdspan<double, extents<std::size_t, dynamic_extent>> y(y_vec.data(),N);
-    for(int i=0; i<A.extent(0); i++)
-      for(int j=0; j<A.extent(1); j++)
-        A(i,j) = 100.0*i+j;
-    for(int i=0; i<x.extent(0); i++)
-      x(i) = 1. * i;
-    for(int i=0; i<y.extent(0); i++)
-      y(i) = -1. * i;
+    mdspan<double, extents<int, dynamic_extent,dynamic_extent>> A(A_vec.data(), N, M);
+    mdspan<double, extents<int, dynamic_extent>> x(x_vec.data(), M);
+    mdspan<double, extents<int, dynamic_extent>> y(y_vec.data(), N);
+    for (int i = 0; i < A.extent(0); ++i) {
+      for (int j = 0; j < A.extent(1); ++j) {
+        A(i,j) = 100.0 * i + j;
+      }
+    }
+    for (int i = 0; i < x.extent(0); ++i) {
+      x(i) = 1.0 * i;
+    }
+    for (int i = 0; i < y.extent(0); ++i) {
+      y(i) = -1.0 * i;
+    }
 
     // y = A * x
-    std::experimental::linalg::matrix_vector_product(A, x, y);
+    LinearAlgebra::matrix_vector_product(A, x, y);
 
     // y = 0.5 * y + 2 * A * x
 #ifdef MDSPAN_EXAMPLES_USE_EXECUTION_POLICIES
-    std::experimental::linalg::matrix_vector_product(std::execution::par,
-       std::experimental::linalg::scaled(2.0, A), x,
-       std::experimental::linalg::scaled(0.5, y), y);
+    LinearAlgebra::matrix_vector_product(std::execution::par,
+      LinearAlgebra::scaled(2.0, A), x,
+      LinearAlgebra::scaled(0.5, y), y);
 #else
-    std::experimental::linalg::matrix_vector_product(
-       std::experimental::linalg::scaled(2.0, A), x,
-       std::experimental::linalg::scaled(0.5, y), y);
+    LinearAlgebra::matrix_vector_product(
+      LinearAlgebra::scaled(2.0, A), x,
+      LinearAlgebra::scaled(0.5, y), y);
 #endif
-    for(int i=0; i<y.extent(0); i+=5) std::cout << i << " " << y(i) << std::endl;
+    for (int i = 0; i < y.extent(0); i += 5) {
+      std::cout << i << " " << y(i) << std::endl;
+    }
   }
 }

--- a/examples/03_matrix_vector_product_mixedprec.cpp
+++ b/examples/03_matrix_vector_product_mixedprec.cpp
@@ -4,55 +4,66 @@
 // This must be defined before including any mdspan headers.
 #define MDSPAN_USE_PAREN_OPERATOR 1
 
-#include <experimental/mdspan>
+#include <mdspan/mdspan.hpp>
 #include "experimental/__p2630_bits/submdspan.hpp"
 #include <experimental/linalg>
 #include <iostream>
 
+namespace MdSpan = MDSPAN_IMPL_STANDARD_NAMESPACE;
+namespace LinearAlgebra = MDSPAN_IMPL_STANDARD_NAMESPACE :: MDSPAN_IMPL_PROPOSED_NAMESPACE :: linalg;
+
+using MdSpan::mdspan;
+using MdSpan::extents;
+using MdSpan::full_extent;
+using MdSpan::submdspan;
 #if defined(__cpp_lib_span)
 #include <span>
   using std::dynamic_extent;
 #else
-  using std::experimental::dynamic_extent;
+  using MdSpan::dynamic_extent;
 #endif
-using std::experimental::extents;
-using std::full_extent; // not in experimental namespace
-using std::experimental::mdspan;
-
-using MDSPAN_IMPL_STANDARD_NAMESPACE :: submdspan;
 
 int main(int argc, char* argv[]) {
   std::cout << "Matrix Vector Product MixedPrec" << std::endl;
   int M = 40;
   {
     // Create Data
-    std::vector<float> A_vec(M*8*4);
-    std::vector<double> x_vec(M*4);
-    std::vector<double> y_vec(M*8);
+    std::vector<float> A_vec(M * 8 * 4);
+    std::vector<double> x_vec(M * 4);
+    std::vector<double> y_vec(M * 8);
 
     // Create and initialize mdspan
-    mdspan<float, extents<std::size_t, dynamic_extent, 8,4>> A(A_vec.data(),M);
-    mdspan<double, extents<std::size_t, 4, dynamic_extent>> x(x_vec.data(),M);
-    mdspan<double, extents<std::size_t, dynamic_extent, 8>> y(y_vec.data(),M);
-    for(int m=0; m<A.extent(0); m++)
-      for(int i=0; i<A.extent(1); i++)
-        for(int j=0; j<A.extent(2); j++)
-        A(m,i,j) = 1000.0 * m + 100.0 * i + j;
-    for(int i=0; i<x.extent(0); i++)
-      for(int m=0; m<x.extent(1); m++)
-        x(i,m) = 33. * i + 0.33 * m;
-    for(int m=0; m<y.extent(0); m++)
-      for(int i=0; i<y.extent(1); i++)
-        y(m,i) = 33. * m + 0.33 * i;
+    mdspan<float, extents<int, dynamic_extent, 8, 4>> A(A_vec.data(), M);
+    mdspan<double, extents<int, 4, dynamic_extent>> x(x_vec.data(), M);
+    mdspan<double, extents<int, dynamic_extent, 8>> y(y_vec.data(), M);
+    for (int m = 0; m < A.extent(0); ++m) {
+      for (int i = 0; i < A.extent(1); ++i) {
+        for (int j = 0; j < A.extent(2); ++j) {
+          A(m,i,j) = 1000.0 * m + 100.0 * i + j;
+        }
+      }
+    }
+    for (int i = 0; i < x.extent(0); ++i) {
+      for (int m = 0; m < x.extent(1); ++m) {
+        x(i,m) = 33.0 * i + 0.33 * m;
+      }
+    }
+    for (int m = 0; m < y.extent(0); ++m) {
+      for (int i = 0; i < y.extent(1); ++i) {
+        y(m,i) = 33.0 * m + 0.33 * i;
+      }
+    }
 
-    for(int m = 0; m < M; m++) {
+    for (int m = 0; m < M; ++m) {
       auto A_m = submdspan(A, m, full_extent, full_extent);
       auto x_m = submdspan(x, full_extent, m);
       auto y_m = submdspan(y, m, full_extent);
       // y_m = A * x_m
-      std::experimental::linalg::matrix_vector_product(A_m, x_m, y_m);
+      LinearAlgebra::matrix_vector_product(A_m, x_m, y_m);
     }
 
-    for(int i=0; i<y.extent(0); i+=5) std::cout << i << " " << y(i,1) << std::endl;
+    for (int i = 0; i < y.extent(0); i += 5) {
+      std::cout << i << " " << y(i,1) << std::endl;
+    }
   }
 }

--- a/include/experimental/__p1673_bits/blas1_dot.hpp
+++ b/include/experimental/__p1673_bits/blas1_dot.hpp
@@ -45,8 +45,8 @@
 
 #include <type_traits>
 
-namespace std {
-namespace experimental {
+namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
+namespace MDSPAN_IMPL_PROPOSED_NAMESPACE {
 inline namespace __p1673_version_0 {
 namespace linalg {
 
@@ -70,7 +70,7 @@ struct is_custom_dot_avail<
 	       ),
       Scalar
       >::value
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! impl::is_inline_exec_v<Exec>
     >
   >
   : std::true_type {};
@@ -90,9 +90,9 @@ template<class ElementType1,
          class Accessor2,
          class Scalar>
 Scalar dot(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
-  std::experimental::mdspan<ElementType1, std::experimental::extents<SizeType1, ext1>, Layout1, Accessor1> v1,
-  std::experimental::mdspan<ElementType2, std::experimental::extents<SizeType2, ext2>, Layout2, Accessor2> v2,
+  impl::inline_exec_t&& /* exec */,
+  mdspan<ElementType1, extents<SizeType1, ext1>, Layout1, Accessor1> v1,
+  mdspan<ElementType2, extents<SizeType2, ext2>, Layout2, Accessor2> v2,
   Scalar init)
 {
   static_assert(v1.static_extent(0) == dynamic_extent ||
@@ -120,8 +120,8 @@ template<class ExecutionPolicy,
          class Scalar>
 Scalar dot(
   ExecutionPolicy&& exec ,
-  std::experimental::mdspan<ElementType1, std::experimental::extents<SizeType1, ext1>, Layout1, Accessor1> v1,
-  std::experimental::mdspan<ElementType2, std::experimental::extents<SizeType2, ext2>, Layout2, Accessor2> v2,
+  mdspan<ElementType1, extents<SizeType1, ext1>, Layout1, Accessor1> v1,
+  mdspan<ElementType2, extents<SizeType2, ext2>, Layout2, Accessor2> v2,
   Scalar init)
 {
   static_assert(v1.static_extent(0) == dynamic_extent ||
@@ -132,11 +132,11 @@ Scalar dot(
     decltype(execpolicy_mapper(exec)), decltype(v1), decltype(v2), Scalar
     >::value;
 
-  if constexpr(use_custom){
+  if constexpr (use_custom) {
     return dot(execpolicy_mapper(exec), v1, v2, init);
   }
-  else{
-    return dot(std::experimental::linalg::impl::inline_exec_t(), v1, v2, init);
+  else {
+    return dot(impl::inline_exec_t{}, v1, v2, init);
   }
 }
 
@@ -151,11 +151,11 @@ template<class ElementType1,
          class Layout2,
          class Accessor2,
          class Scalar>
-Scalar dot(std::experimental::mdspan<ElementType1, std::experimental::extents<SizeType1, ext1>, Layout1, Accessor1> v1,
-           std::experimental::mdspan<ElementType2, std::experimental::extents<SizeType2, ext2>, Layout2, Accessor2> v2,
+Scalar dot(mdspan<ElementType1, extents<SizeType1, ext1>, Layout1, Accessor1> v1,
+           mdspan<ElementType2, extents<SizeType2, ext2>, Layout2, Accessor2> v2,
            Scalar init)
 {
-  return dot(std::experimental::linalg::impl::default_exec_t(), v1, v2, init);
+  return dot(impl::default_exec_t{}, v1, v2, init);
 }
 
 template<class ElementType1,
@@ -170,8 +170,8 @@ template<class ElementType1,
          class Accessor2,
          class Scalar>
 Scalar dotc(
-  std::experimental::mdspan<ElementType1, std::experimental::extents<SizeType1, ext1>, Layout1, Accessor1> v1,
-  std::experimental::mdspan<ElementType2, std::experimental::extents<SizeType2, ext2>, Layout2, Accessor2> v2,
+  mdspan<ElementType1, extents<SizeType1, ext1>, Layout1, Accessor1> v1,
+  mdspan<ElementType2, extents<SizeType2, ext2>, Layout2, Accessor2> v2,
   Scalar init)
 {
   return dot(conjugated(v1), v2, init);
@@ -191,8 +191,8 @@ template<class ExecutionPolicy,
          class Scalar>
 Scalar dotc(
   ExecutionPolicy&& exec,
-  std::experimental::mdspan<ElementType1, std::experimental::extents<SizeType1, ext1>, Layout1, Accessor1> v1,
-  std::experimental::mdspan<ElementType2, std::experimental::extents<SizeType2, ext2>, Layout2, Accessor2> v2,
+  mdspan<ElementType1, extents<SizeType1, ext1>, Layout1, Accessor1> v1,
+  mdspan<ElementType2, extents<SizeType2, ext2>, Layout2, Accessor2> v2,
   Scalar init)
 {
   return dot(exec, conjugated(v1), v2, init);
@@ -215,8 +215,8 @@ namespace dot_detail {
     class Layout2,
     class Accessor2>
   auto dot_return_type_deducer(
-    std::experimental::mdspan<ElementType1, std::experimental::extents<SizeType1, ext1>, Layout1, Accessor1> x,
-    std::experimental::mdspan<ElementType2, std::experimental::extents<SizeType2, ext2>, Layout2, Accessor2> y)
+    mdspan<ElementType1, extents<SizeType1, ext1>, Layout1, Accessor1> x,
+    mdspan<ElementType2, extents<SizeType2, ext2>, Layout2, Accessor2> y)
   -> decltype(x(0) * y(0));
 } // namespace dot_detail
 
@@ -232,8 +232,8 @@ template<class ElementType1,
          class Layout2,
          class Accessor2>
 auto dot(
-  std::experimental::mdspan<ElementType1, std::experimental::extents<SizeType1, ext1>, Layout1, Accessor1> v1,
-  std::experimental::mdspan<ElementType2, std::experimental::extents<SizeType2, ext2>, Layout2, Accessor2> v2)
+  mdspan<ElementType1, extents<SizeType1, ext1>, Layout1, Accessor1> v1,
+  mdspan<ElementType2, extents<SizeType2, ext2>, Layout2, Accessor2> v2)
 -> decltype(dot_detail::dot_return_type_deducer(v1, v2))
 {
   using return_t = decltype(dot_detail::dot_return_type_deducer(v1, v2));
@@ -253,8 +253,8 @@ template<class ExecutionPolicy,
          class Accessor2>
 auto dot(
   ExecutionPolicy&& exec,
-  std::experimental::mdspan<ElementType1, std::experimental::extents<SizeType1, ext1>, Layout1, Accessor1> v1,
-  std::experimental::mdspan<ElementType2, std::experimental::extents<SizeType2, ext2>, Layout2, Accessor2> v2)
+  mdspan<ElementType1, extents<SizeType1, ext1>, Layout1, Accessor1> v1,
+  mdspan<ElementType2, extents<SizeType2, ext2>, Layout2, Accessor2> v2)
 -> decltype(dot_detail::dot_return_type_deducer(v1, v2))
 {
   using return_t = decltype(dot_detail::dot_return_type_deducer(v1, v2));
@@ -272,8 +272,8 @@ template<class ElementType1,
          class Layout2,
          class Accessor2>
 auto dotc(
-  std::experimental::mdspan<ElementType1, std::experimental::extents<SizeType1, ext1>, Layout1, Accessor1> v1,
-  std::experimental::mdspan<ElementType2, std::experimental::extents<SizeType2, ext2>, Layout2, Accessor2> v2)
+  mdspan<ElementType1, extents<SizeType1, ext1>, Layout1, Accessor1> v1,
+  mdspan<ElementType2, extents<SizeType2, ext2>, Layout2, Accessor2> v2)
   -> decltype(dot_detail::dot_return_type_deducer(conjugated(v1), v2))
 {
   using return_t = decltype(dot_detail::dot_return_type_deducer(conjugated(v1), v2));
@@ -293,8 +293,8 @@ template<class ExecutionPolicy,
          class Accessor2>
 auto dotc(
   ExecutionPolicy&& exec,
-  std::experimental::mdspan<ElementType1, std::experimental::extents<SizeType1, ext1>, Layout1, Accessor1> v1,
-  std::experimental::mdspan<ElementType2, std::experimental::extents<SizeType2, ext2>, Layout2, Accessor2> v2)
+  mdspan<ElementType1, extents<SizeType1, ext1>, Layout1, Accessor1> v1,
+  mdspan<ElementType2, extents<SizeType2, ext2>, Layout2, Accessor2> v2)
  -> decltype(dot_detail::dot_return_type_deducer(conjugated(v1), v2))
 {
   using return_t = decltype(dot_detail::dot_return_type_deducer(conjugated(v1), v2));
@@ -303,7 +303,7 @@ auto dotc(
 
 } // end namespace linalg
 } // end inline namespace __p1673_version_0
-} // end namespace experimental
-} // end namespace std
+} // end namespace MDSPAN_IMPL_PROPOSED_NAMESPACE
+} // end namespace MDSPAN_IMPL_STANDARD_NAMESPACE
 
 #endif //LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_BLAS1_DOT_HPP_

--- a/include/experimental/__p1673_bits/blas1_givens.hpp
+++ b/include/experimental/__p1673_bits/blas1_givens.hpp
@@ -46,8 +46,8 @@
 #include <cmath>
 #include <complex>
 
-namespace std {
-namespace experimental {
+namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
+namespace MDSPAN_IMPL_PROPOSED_NAMESPACE {
 inline namespace __p1673_version_0 {
 namespace linalg {
 
@@ -103,15 +103,13 @@ struct is_custom_givens_rotation_apply_avail<
 		)
 	       )
       >
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! impl::is_inline_exec_v<Exec>
     >
   >
   : std::true_type{};
 } // end anonymous namespace
 
-
-
-MDSPAN_TEMPLATE_REQUIRES( class Real, /* requires */ ( _MDSPAN_TRAIT(is_floating_point, Real) ) )
+MDSPAN_TEMPLATE_REQUIRES( class Real, /* requires */ ( _MDSPAN_TRAIT(std::is_floating_point, Real) ) )
 void givens_rotation_setup(const Real f,
                            const Real g,
                            Real& cs,
@@ -217,8 +215,8 @@ void givens_rotation_setup(const Real f,
 }
 
 namespace impl {
-MDSPAN_TEMPLATE_REQUIRES( class Real, /* requires */ ( _MDSPAN_TRAIT(is_floating_point, Real) ) )
-Real abs1(const complex<Real>& ff) {
+MDSPAN_TEMPLATE_REQUIRES( class Real, /* requires */ ( _MDSPAN_TRAIT(std::is_floating_point, Real) ) )
+Real abs1(const std::complex<Real>& ff) {
   using std::abs;
   using std::imag;
   using std::max;
@@ -227,8 +225,8 @@ Real abs1(const complex<Real>& ff) {
   return max(abs(real(ff)), abs(imag(ff)));
 }
 
-MDSPAN_TEMPLATE_REQUIRES( class Real, /* requires */ ( _MDSPAN_TRAIT(is_floating_point, Real) ) )
-Real abssq(const complex<Real>& ff) {
+MDSPAN_TEMPLATE_REQUIRES( class Real, /* requires */ ( _MDSPAN_TRAIT(std::is_floating_point, Real) ) )
+Real abssq(const std::complex<Real>& ff) {
   using std::imag;
   using std::real;
 
@@ -236,24 +234,26 @@ Real abssq(const complex<Real>& ff) {
 }
 }
 
-MDSPAN_TEMPLATE_REQUIRES( class Real, /* requires */ ( _MDSPAN_TRAIT(is_floating_point, Real) ) )
-void givens_rotation_setup(const complex<Real>& f,
-                           const complex<Real>& g,
+MDSPAN_TEMPLATE_REQUIRES( class Real, /* requires */ ( _MDSPAN_TRAIT(std::is_floating_point, Real) ) )
+void givens_rotation_setup(const std::complex<Real>& f,
+                           const std::complex<Real>& g,
                            Real& cs,
-                           complex<Real>& sn,
-                           complex<Real>& r)
+                           std::complex<Real>& sn,
+                           std::complex<Real>& r)
 {
+  using std::abs;
+  using std::complex;
+  using std::imag;
+  using std::isnan;
+  using std::log;
+  using std::max;
+  using std::pow;
+  using std::real;
+
   const Real two = 2.0;
   const Real one = 1.0;
   const Real zero = 0.0;
   const complex<Real> czero (0.0, 0.0);
-
-  using std::abs;
-  using std::imag;
-  using std::isnan;
-  using std::log;
-  using std::pow;
-  using std::real;
 
   // safmin == min (smallest normalized positive floating-point
   // number) for IEEE 754 floating-point arithmetic only.
@@ -383,12 +383,12 @@ MDSPAN_TEMPLATE_REQUIRES(
          class Layout2,
          class Accessor2,
          class Real,
-         /* requires */ (_MDSPAN_TRAIT(is_floating_point, Real))
+         /* requires */ (_MDSPAN_TRAIT(std::is_floating_point, Real))
 )
 void givens_rotation_apply(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
-  std::experimental::mdspan<ElementType1, std::experimental::extents<SizeType1, ext1>, Layout1, Accessor1> x,
-  std::experimental::mdspan<ElementType2, std::experimental::extents<SizeType2, ext2>, Layout2, Accessor2> y,
+  impl::inline_exec_t&& /* exec */,
+  mdspan<ElementType1, extents<SizeType1, ext1>, Layout1, Accessor1> x,
+  mdspan<ElementType2, extents<SizeType2, ext2>, Layout2, Accessor2> y,
   const Real c,
   const Real s)
 {
@@ -418,12 +418,12 @@ MDSPAN_TEMPLATE_REQUIRES(
          class Layout2,
          class Accessor2,
          class Real,
-         /* requires */ (_MDSPAN_TRAIT(is_floating_point, Real))
+         /* requires */ (_MDSPAN_TRAIT(std::is_floating_point, Real))
 )
 void givens_rotation_apply(
   ExecutionPolicy&& exec,
-  std::experimental::mdspan<ElementType1, std::experimental::extents<SizeType1, ext1>, Layout1, Accessor1> x,
-  std::experimental::mdspan<ElementType2, std::experimental::extents<SizeType2, ext2>, Layout2, Accessor2> y,
+  mdspan<ElementType1, extents<SizeType1, ext1>, Layout1, Accessor1> x,
+  mdspan<ElementType2, extents<SizeType2, ext2>, Layout2, Accessor2> y,
   const Real c,
   const Real s)
 {
@@ -437,7 +437,7 @@ void givens_rotation_apply(
   }
   else
   {
-    givens_rotation_apply(std::experimental::linalg::impl::inline_exec_t(), x, y, c, s);
+    givens_rotation_apply(impl::inline_exec_t(), x, y, c, s);
   }
 }
 
@@ -453,15 +453,15 @@ MDSPAN_TEMPLATE_REQUIRES(
          class Layout2,
          class Accessor2,
          class Real,
-         /* requires */ (_MDSPAN_TRAIT(is_floating_point, Real))
+         /* requires */ (_MDSPAN_TRAIT(std::is_floating_point, Real))
 )
 void givens_rotation_apply(
-  std::experimental::mdspan<ElementType1, std::experimental::extents<SizeType1, ext1>, Layout1, Accessor1> x,
-  std::experimental::mdspan<ElementType2, std::experimental::extents<SizeType2, ext2>, Layout2, Accessor2> y,
+  mdspan<ElementType1, extents<SizeType1, ext1>, Layout1, Accessor1> x,
+  mdspan<ElementType2, extents<SizeType2, ext2>, Layout2, Accessor2> y,
   const Real c,
   const Real s)
 {
-  givens_rotation_apply(std::experimental::linalg::impl::default_exec_t(), x, y, c, s);
+  givens_rotation_apply(impl::default_exec_t{}, x, y, c, s);
 }
 
 
@@ -479,14 +479,14 @@ MDSPAN_TEMPLATE_REQUIRES(
          class Layout2,
          class Accessor2,
          class Real,
-         /* requires */ (_MDSPAN_TRAIT(is_floating_point, Real))
+         /* requires */ (_MDSPAN_TRAIT(std::is_floating_point, Real))
 )
 void givens_rotation_apply(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
-  std::experimental::mdspan<ElementType1, std::experimental::extents<SizeType1, ext1>, Layout1, Accessor1> x,
-  std::experimental::mdspan<ElementType2, std::experimental::extents<SizeType2, ext2>, Layout2, Accessor2> y,
+  impl::inline_exec_t&& /* exec */,
+  mdspan<ElementType1, extents<SizeType1, ext1>, Layout1, Accessor1> x,
+  mdspan<ElementType2, extents<SizeType2, ext2>, Layout2, Accessor2> y,
   const Real c,
-  const complex<Real> s)
+  const std::complex<Real> s)
 {
   static_assert(x.static_extent(0) == dynamic_extent ||
                 y.static_extent(0) == dynamic_extent ||
@@ -515,26 +515,24 @@ MDSPAN_TEMPLATE_REQUIRES(
          class Layout2,
          class Accessor2,
          class Real,
-         /* requires */ (_MDSPAN_TRAIT(is_floating_point, Real))
+         /* requires */ (_MDSPAN_TRAIT(std::is_floating_point, Real))
 )
 void givens_rotation_apply(
   ExecutionPolicy&& exec,
-  std::experimental::mdspan<ElementType1, std::experimental::extents<SizeType1, ext1>, Layout1, Accessor1> x,
-  std::experimental::mdspan<ElementType2, std::experimental::extents<SizeType2, ext2>, Layout2, Accessor2> y,
+  mdspan<ElementType1, extents<SizeType1, ext1>, Layout1, Accessor1> x,
+  mdspan<ElementType2, extents<SizeType2, ext2>, Layout2, Accessor2> y,
   const Real c,
-  const complex<Real> s)
+  const std::complex<Real> s)
 {
-
   constexpr bool use_custom = is_custom_givens_rotation_apply_avail<
-    decltype(execpolicy_mapper(exec)), decltype(x), decltype(y), Real, complex<Real>
+    decltype(execpolicy_mapper(exec)), decltype(x), decltype(y), Real, std::complex<Real>
     >::value;
 
-  if constexpr(use_custom){
+  if constexpr(use_custom) {
     givens_rotation_apply(execpolicy_mapper(exec), x, y, c, s);
   }
-  else
-  {
-    givens_rotation_apply(std::experimental::linalg::impl::inline_exec_t(), x, y, c, s);
+  else {
+    givens_rotation_apply(impl::inline_exec_t{}, x, y, c, s);
   }
 }
 
@@ -550,20 +548,20 @@ MDSPAN_TEMPLATE_REQUIRES(
          class Layout2,
          class Accessor2,
          class Real,
-         /* requires */ (_MDSPAN_TRAIT(is_floating_point, Real))
+         /* requires */ (_MDSPAN_TRAIT(std::is_floating_point, Real))
 )
 void givens_rotation_apply(
-  std::experimental::mdspan<ElementType1, std::experimental::extents<SizeType1, ext1>, Layout1, Accessor1> x,
-  std::experimental::mdspan<ElementType2, std::experimental::extents<SizeType2, ext2>, Layout2, Accessor2> y,
+  mdspan<ElementType1, extents<SizeType1, ext1>, Layout1, Accessor1> x,
+  mdspan<ElementType2, extents<SizeType2, ext2>, Layout2, Accessor2> y,
   const Real c,
-  const complex<Real> s)
+  const std::complex<Real> s)
 {
-  givens_rotation_apply(std::experimental::linalg::impl::default_exec_t(), x, y, c, s);
+  givens_rotation_apply(impl::default_exec_t{}, x, y, c, s);
 }
 
 } // end namespace linalg
 } // end inline namespace __p1673_version_0
-} // end namespace experimental
-} // end namespace std
+} // end namespace MDSPAN_IMPL_PROPOSED_NAMESPACE
+} // end namespace MDSPAN_IMPL_STANDARD_NAMESPACE
 
 #endif //LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_BLAS1_GIVENS_HPP_

--- a/include/experimental/__p1673_bits/blas1_linalg_add.hpp
+++ b/include/experimental/__p1673_bits/blas1_linalg_add.hpp
@@ -43,8 +43,8 @@
 #ifndef LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_BLAS1_LINALG_ADD_HPP_
 #define LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_BLAS1_LINALG_ADD_HPP_
 
-namespace std {
-namespace experimental {
+namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
+namespace MDSPAN_IMPL_PROPOSED_NAMESPACE {
 inline namespace __p1673_version_0 {
 namespace linalg {
 
@@ -66,9 +66,9 @@ template<class ElementType_x,
          class Layout_z,
          class Accessor_z>
 void add_rank_1(
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_y, std::experimental::extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y,
-  std::experimental::mdspan<ElementType_z, std::experimental::extents<SizeType_z, ext_z>, Layout_z, Accessor_z> z)
+  mdspan<ElementType_x, extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_y, extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y,
+  mdspan<ElementType_z, extents<SizeType_z, ext_z>, Layout_z, Accessor_z> z)
 {
   static_assert(x.static_extent(0) == dynamic_extent ||
                 z.static_extent(0) == dynamic_extent ||
@@ -105,9 +105,9 @@ template<class ElementType_x,
          class Layout_z,
          class Accessor_z>
 void add_rank_2(
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, numRows_x, numCols_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_y, std::experimental::extents<SizeType_y, numRows_y, numCols_y>, Layout_y, Accessor_y> y,
-  std::experimental::mdspan<ElementType_z, std::experimental::extents<SizeType_z, numRows_z, numCols_z>, Layout_z, Accessor_z> z)
+  mdspan<ElementType_x, extents<SizeType_x, numRows_x, numCols_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_y, extents<SizeType_y, numRows_y, numCols_y>, Layout_y, Accessor_y> y,
+  mdspan<ElementType_z, extents<SizeType_z, numRows_z, numCols_z>, Layout_z, Accessor_z> z)
 {
   static_assert(x.static_extent(0) == dynamic_extent ||
                 z.static_extent(0) == dynamic_extent ||
@@ -153,7 +153,7 @@ struct is_custom_add_avail<
 		)
 	       )
       >
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! impl::is_inline_exec_v<Exec>
     >
   >
   : std::true_type{};
@@ -180,10 +180,10 @@ MDSPAN_TEMPLATE_REQUIRES(
          /* requires */ (sizeof...(ext_x) == sizeof...(ext_y) && sizeof...(ext_x) == sizeof...(ext_z))
 )
 void add(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x ...>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_y, std::experimental::extents<SizeType_y, ext_y ...>, Layout_y, Accessor_y> y,
-  std::experimental::mdspan<ElementType_z, std::experimental::extents<SizeType_z, ext_z ...>, Layout_z, Accessor_z> z)
+  impl::inline_exec_t&& /* exec */,
+  mdspan<ElementType_x, extents<SizeType_x, ext_x ...>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_y, extents<SizeType_y, ext_y ...>, Layout_y, Accessor_y> y,
+  mdspan<ElementType_z, extents<SizeType_z, ext_z ...>, Layout_z, Accessor_z> z)
 {
   // this static assert is only here because for
   // the default case we support rank-1 and rank2.
@@ -218,9 +218,9 @@ MDSPAN_TEMPLATE_REQUIRES(
 )
 void add(
   ExecutionPolicy&& exec,
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x ...>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_y, std::experimental::extents<SizeType_y, ext_y ...>, Layout_y, Accessor_y> y,
-  std::experimental::mdspan<ElementType_z, std::experimental::extents<SizeType_z, ext_z ...>, Layout_z, Accessor_z> z)
+  mdspan<ElementType_x, extents<SizeType_x, ext_x ...>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_y, extents<SizeType_y, ext_y ...>, Layout_y, Accessor_y> y,
+  mdspan<ElementType_z, extents<SizeType_z, ext_z ...>, Layout_z, Accessor_z> z)
 {
 
   constexpr bool use_custom = is_custom_add_avail<
@@ -233,7 +233,7 @@ void add(
   }
   else
   {
-    add(std::experimental::linalg::impl::inline_exec_t(), x, y, z);
+    add(impl::inline_exec_t{}, x, y, z);
   }
 }
 
@@ -256,16 +256,16 @@ MDSPAN_TEMPLATE_REQUIRES(
          /* requires */ (sizeof...(ext_x) == sizeof...(ext_y) && sizeof...(ext_x) == sizeof...(ext_z))
 )
 void add(
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x ...>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_y, std::experimental::extents<SizeType_y, ext_y ...>, Layout_y, Accessor_y> y,
-  std::experimental::mdspan<ElementType_z, std::experimental::extents<SizeType_z, ext_z ...>, Layout_z, Accessor_z> z)
+  mdspan<ElementType_x, extents<SizeType_x, ext_x ...>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_y, extents<SizeType_y, ext_y ...>, Layout_y, Accessor_y> y,
+  mdspan<ElementType_z, extents<SizeType_z, ext_z ...>, Layout_z, Accessor_z> z)
 {
-  add(std::experimental::linalg::impl::default_exec_t(), x, y, z);
+  add(impl::default_exec_t{}, x, y, z);
 }
 
 } // end namespace linalg
 } // end inline namespace __p1673_version_0
-} // end namespace experimental
-} // end namespace std
+} // end namespace MDSPAN_IMPL_PROPOSED_NAMESPACE
+} // end namespace MDSPAN_IMPL_STANDARD_NAMESPACE
 
 #endif //LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_BLAS1_LINALG_ADD_HPP_

--- a/include/experimental/__p1673_bits/blas1_linalg_copy.hpp
+++ b/include/experimental/__p1673_bits/blas1_linalg_copy.hpp
@@ -43,8 +43,8 @@
 #ifndef LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_BLAS1_LINALG_COPY_HPP_
 #define LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_BLAS1_LINALG_COPY_HPP_
 
-namespace std {
-namespace experimental {
+namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
+namespace MDSPAN_IMPL_PROPOSED_NAMESPACE {
 inline namespace __p1673_version_0 {
 namespace linalg {
 
@@ -61,8 +61,8 @@ template<class ElementType_x,
          class Layout_y,
          class Accessor_y>
 void copy_rank_1(
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_y, std::experimental::extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y)
+  mdspan<ElementType_x, extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_y, extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y)
 {
   static_assert(x.static_extent(0) == dynamic_extent ||
                 y.static_extent(0) == dynamic_extent ||
@@ -86,8 +86,8 @@ template<class ElementType_x,
          class Layout_y,
          class Accessor_y>
 void copy_rank_2(
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, numRows_x, numCols_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_y, std::experimental::extents<SizeType_y, numRows_y, numCols_y>, Layout_y, Accessor_y> y)
+  mdspan<ElementType_x, extents<SizeType_x, numRows_x, numCols_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_y, extents<SizeType_y, numRows_y, numCols_y>, Layout_y, Accessor_y> y)
 {
   static_assert(x.static_extent(0) == dynamic_extent ||
                 y.static_extent(0) == dynamic_extent ||
@@ -118,7 +118,7 @@ struct is_custom_copy_avail<
 		)
 	       )
       >
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! impl::is_inline_exec_v<Exec>
     >
   >
   : std::true_type{};
@@ -140,9 +140,9 @@ MDSPAN_TEMPLATE_REQUIRES(
          /* requires */ (sizeof...(ext_x) == sizeof...(ext_y) && sizeof...(ext_x) <= 2)
 )
 void copy(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x ...>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_y, std::experimental::extents<SizeType_y, ext_y ...>, Layout_y, Accessor_y> y)
+  impl::inline_exec_t&& /* exec */,
+  mdspan<ElementType_x, extents<SizeType_x, ext_x ...>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_y, extents<SizeType_y, ext_y ...>, Layout_y, Accessor_y> y)
 {
   if constexpr (x.rank() == 1) {
     copy_rank_1(x, y);
@@ -168,8 +168,8 @@ MDSPAN_TEMPLATE_REQUIRES(
 )
 void copy(
   ExecutionPolicy&& exec,
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x ...>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_y, std::experimental::extents<SizeType_y, ext_y ...>, Layout_y, Accessor_y> y)
+  mdspan<ElementType_x, extents<SizeType_x, ext_x ...>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_y, extents<SizeType_y, ext_y ...>, Layout_y, Accessor_y> y)
 {
 
   constexpr bool use_custom = is_custom_copy_avail<
@@ -179,9 +179,8 @@ void copy(
   if constexpr(use_custom){
     copy(execpolicy_mapper(exec), x, y);
   }
-  else
-  {
-    copy(std::experimental::linalg::impl::inline_exec_t(), x, y);
+  else {
+    copy(impl::inline_exec_t{}, x, y);
   }
 }
 
@@ -199,15 +198,15 @@ MDSPAN_TEMPLATE_REQUIRES(
          /* requires */ (sizeof...(ext_x) == sizeof...(ext_y))
 )
 void copy(
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x ...>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_y, std::experimental::extents<SizeType_y, ext_y ...>, Layout_y, Accessor_y> y)
+  mdspan<ElementType_x, extents<SizeType_x, ext_x ...>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_y, extents<SizeType_y, ext_y ...>, Layout_y, Accessor_y> y)
 {
-  copy(std::experimental::linalg::impl::default_exec_t(), x, y);
+  copy(impl::default_exec_t(), x, y);
 }
 
 } // end namespace linalg
 } // end inline namespace __p1673_version_0
-} // end namespace experimental
-} // end namespace std
+} // end namespace MDSPAN_IMPL_PROPOSED_NAMESPACE
+} // end namespace MDSPAN_IMPL_STANDARD_NAMESPACE
 
 #endif //LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_BLAS1_LINALG_COPY_HPP_

--- a/include/experimental/__p1673_bits/blas1_linalg_swap.hpp
+++ b/include/experimental/__p1673_bits/blas1_linalg_swap.hpp
@@ -45,12 +45,12 @@
 
 #include <utility>
 
-namespace std {
-namespace experimental {
+namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
+namespace MDSPAN_IMPL_PROPOSED_NAMESPACE {
 inline namespace __p1673_version_0 {
 namespace linalg {
 
-namespace {
+namespace impl {
 
 template<class ElementType_x,
 	 class SizeType_x,
@@ -63,8 +63,8 @@ template<class ElementType_x,
          class Layout_y,
          class Accessor_y>
 void swap_rank_1(
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_y, std::experimental::extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y)
+  mdspan<ElementType_x, extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_y, extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y)
 {
   static_assert(x.static_extent(0) == dynamic_extent ||
                 y.static_extent(0) == dynamic_extent ||
@@ -91,8 +91,8 @@ template<class ElementType_x,
          class Layout_y,
          class Accessor_y>
 void swap_rank_2(
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, numRows_x, numCols_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_y, std::experimental::extents<SizeType_y, numRows_y, numCols_y>, Layout_y, Accessor_y> y)
+  mdspan<ElementType_x, extents<SizeType_x, numRows_x, numCols_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_y, extents<SizeType_y, numRows_y, numCols_y>, Layout_y, Accessor_y> y)
 {
   static_assert(x.static_extent(0) == dynamic_extent ||
                 y.static_extent(0) == dynamic_extent ||
@@ -124,12 +124,12 @@ struct is_custom_vector_swap_elements_avail<
 			     std::declval<y_t>())
 	       )
       >
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! is_inline_exec_v<Exec>
     >
   >
   : std::true_type{};
 
-} // end anonymous namespace
+} // namespace impl
 
 MDSPAN_TEMPLATE_REQUIRES(
          class ElementType_x,
@@ -145,17 +145,17 @@ MDSPAN_TEMPLATE_REQUIRES(
          /* requires */ (sizeof...(ext_x) == sizeof...(ext_y))
 )
 void swap_elements(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x ...>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_y, std::experimental::extents<SizeType_y, ext_y ...>, Layout_y, Accessor_y> y)
+  impl::inline_exec_t&& /* exec */,
+  mdspan<ElementType_x, extents<SizeType_x, ext_x ...>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_y, extents<SizeType_y, ext_y ...>, Layout_y, Accessor_y> y)
 {
   static_assert(x.rank() <= 2);
 
   if constexpr (x.rank() == 1 && y.rank() == 1) {
-    swap_rank_1(x, y);
+    impl::swap_rank_1(x, y);
   }
   else if constexpr (x.rank() == 2 && y.rank() == 2) {
-    swap_rank_2(x, y);
+    impl::swap_rank_2(x, y);
   }
 }
 
@@ -175,19 +175,17 @@ MDSPAN_TEMPLATE_REQUIRES(
 )
 void swap_elements(
   ExecutionPolicy&& exec,
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x ...>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_y, std::experimental::extents<SizeType_y, ext_y ...>, Layout_y, Accessor_y> y)
+  mdspan<ElementType_x, extents<SizeType_x, ext_x ...>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_y, extents<SizeType_y, ext_y ...>, Layout_y, Accessor_y> y)
 {
-  constexpr bool use_custom = is_custom_vector_swap_elements_avail<
-    decltype(execpolicy_mapper(exec)), decltype(x), decltype(y)
-    >::value;
+  constexpr bool use_custom = impl::is_custom_vector_swap_elements_avail<
+    decltype(execpolicy_mapper(exec)), decltype(x), decltype(y)>::value;
 
-  if constexpr(use_custom){
+  if constexpr (use_custom) {
     return swap_elements(execpolicy_mapper(exec), x, y);
   }
-  else
-  {
-    return swap_elements(std::experimental::linalg::impl::inline_exec_t(), x, y);
+  else {
+    return swap_elements(impl::inline_exec_t{}, x, y);
   }
 }
 
@@ -205,15 +203,15 @@ MDSPAN_TEMPLATE_REQUIRES(
          /* requires */ (sizeof...(ext_x) == sizeof...(ext_y))
 )
 void swap_elements(
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x ...>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_y, std::experimental::extents<SizeType_y, ext_y ...>, Layout_y, Accessor_y> y)
+  mdspan<ElementType_x, extents<SizeType_x, ext_x ...>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_y, extents<SizeType_y, ext_y ...>, Layout_y, Accessor_y> y)
 {
-  swap_elements(std::experimental::linalg::impl::default_exec_t(), x, y);
+  swap_elements(impl::default_exec_t{}, x, y);
 }
 
 } // end namespace linalg
 } // end inline namespace __p1673_version_0
-} // end namespace experimental
-} // end namespace std
+} // end namespace MDSPAN_IMPL_PROPOSED_NAMESPACE
+} // end namespace MDSPAN_IMPL_STANDARD_NAMESPACE
 
 #endif //LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_BLAS1_LINALG_SWAP_HPP_

--- a/include/experimental/__p1673_bits/blas1_matrix_frob_norm.hpp
+++ b/include/experimental/__p1673_bits/blas1_matrix_frob_norm.hpp
@@ -46,8 +46,8 @@
 #include <cmath>
 #include <cstdlib>
 
-namespace std {
-namespace experimental {
+namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
+namespace MDSPAN_IMPL_PROPOSED_NAMESPACE {
 inline namespace __p1673_version_0 {
 namespace linalg {
 
@@ -70,7 +70,7 @@ struct is_custom_matrix_frob_norm_avail<
 	       ),
       Scalar
       >::value
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! impl::is_inline_exec_v<Exec>
     >
   >
   : std::true_type{};
@@ -85,8 +85,8 @@ template<
     class Accessor,
     class Scalar>
 Scalar matrix_frob_norm(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
-  std::experimental::mdspan<ElementType, std::experimental::extents<SizeType, numRows, numCols>, Layout, Accessor> A,
+  impl::inline_exec_t&& /* exec */,
+  mdspan<ElementType, extents<SizeType, numRows, numCols>, Layout, Accessor> A,
   Scalar init)
 {
   using std::abs;
@@ -135,19 +135,18 @@ template<class ExecutionPolicy,
   class Scalar>
 Scalar matrix_frob_norm(
   ExecutionPolicy&& exec,
-  std::experimental::mdspan<ElementType, std::experimental::extents<SizeType, numRows, numCols>, Layout, Accessor> A,
+  mdspan<ElementType, extents<SizeType, numRows, numCols>, Layout, Accessor> A,
   Scalar init)
 {
-
   constexpr bool use_custom = is_custom_matrix_frob_norm_avail<
     decltype(execpolicy_mapper(exec)), decltype(A), Scalar
     >::value;
 
-  if constexpr(use_custom){
+  if constexpr (use_custom) {
     return matrix_frob_norm(execpolicy_mapper(exec), A, init);
   }
-  else{
-    return matrix_frob_norm(std::experimental::linalg::impl::inline_exec_t(), A, init);
+  else {
+    return matrix_frob_norm(impl::inline_exec_t{}, A, init);
   }
 }
 
@@ -160,19 +159,17 @@ template<
     class Accessor,
     class Scalar>
 Scalar matrix_frob_norm(
-  std::experimental::mdspan<
+  mdspan<
     ElementType,
-    std::experimental::extents<SizeType, numRows, numCols>,
+    extents<SizeType, numRows, numCols>,
     Layout,
     Accessor> A,
   Scalar init)
 {
-  return matrix_frob_norm(std::experimental::linalg::impl::default_exec_t(), A, init);
+  return matrix_frob_norm(impl::default_exec_t{}, A, init);
 }
 
-namespace matrix_frob_norm_detail
-{
-
+namespace matrix_frob_norm_detail {
   // The point of this is to do correct ADL for abs,
   // without exposing "using std::abs" in the outer namespace.
   using std::abs;
@@ -182,9 +179,9 @@ namespace matrix_frob_norm_detail
     class Layout,
     class Accessor>
   auto matrix_frob_norm_return_type_deducer(
-    std::experimental::mdspan<
+    mdspan<
       ElementType,
-      std::experimental::extents<SizeType, numRows, numCols>,
+      extents<SizeType, numRows, numCols>,
       Layout,
       Accessor
     > A) -> decltype( abs(A(0,0)) * abs(A(0,0)) );
@@ -199,8 +196,8 @@ template<
   class Layout,
   class Accessor>
 auto matrix_frob_norm(
-  std::experimental::mdspan<
-    ElementType, std::experimental::extents<SizeType, numRows, numCols>, Layout, Accessor
+  mdspan<
+    ElementType, extents<SizeType, numRows, numCols>, Layout, Accessor
   > A)
   -> decltype(matrix_frob_norm_detail::matrix_frob_norm_return_type_deducer(A))
 {
@@ -218,9 +215,9 @@ template<
   class Accessor>
 auto matrix_frob_norm(
   ExecutionPolicy&& exec,
-  std::experimental::mdspan<
+  mdspan<
     ElementType,
-    std::experimental::extents<SizeType, numRows, numCols>,
+    extents<SizeType, numRows, numCols>,
     Layout,
     Accessor
   > A)
@@ -232,7 +229,7 @@ auto matrix_frob_norm(
 
 } // end namespace linalg
 } // end inline namespace __p1673_version_0
-} // end namespace experimental
-} // end namespace std
+} // end namespace MDSPAN_IMPL_PROPOSED_NAMESPACE
+} // end namespace MDSPAN_IMPL_STANDARD_NAMESPACE
 
 #endif //LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_BLAS1_MATRIX_FROB_NORM_HPP_

--- a/include/experimental/__p1673_bits/blas1_matrix_inf_norm.hpp
+++ b/include/experimental/__p1673_bits/blas1_matrix_inf_norm.hpp
@@ -46,8 +46,8 @@
 #include <cmath>
 #include <cstdlib>
 
-namespace std {
-namespace experimental {
+namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
+namespace MDSPAN_IMPL_PROPOSED_NAMESPACE {
 inline namespace __p1673_version_0 {
 namespace linalg {
 
@@ -70,7 +70,7 @@ struct is_custom_matrix_inf_norm_avail<
 	       ),
       Scalar
       >::value
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! impl::is_inline_exec_v<Exec>
     >
   >
   : std::true_type{};
@@ -86,8 +86,8 @@ template<
     class Accessor,
     class Scalar>
 Scalar matrix_inf_norm(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
-  std::experimental::mdspan<ElementType, std::experimental::extents<SizeType, numRows, numCols>, Layout, Accessor> A,
+  impl::inline_exec_t&& /* exec */,
+  mdspan<ElementType, extents<SizeType, numRows, numCols>, Layout, Accessor> A,
   Scalar init)
 {
   using std::abs;
@@ -125,7 +125,7 @@ template<
   class Scalar>
 Scalar matrix_inf_norm(
   ExecutionPolicy&& exec,
-  std::experimental::mdspan<ElementType, std::experimental::extents<SizeType, numRows, numCols>, Layout, Accessor> A,
+  mdspan<ElementType, extents<SizeType, numRows, numCols>, Layout, Accessor> A,
   Scalar init)
 {
 
@@ -137,7 +137,7 @@ Scalar matrix_inf_norm(
     return matrix_inf_norm(execpolicy_mapper(exec), A, init);
   }
   else{
-    return matrix_inf_norm(std::experimental::linalg::impl::inline_exec_t(), A, init);
+    return matrix_inf_norm(impl::inline_exec_t{}, A, init);
   }
 }
 
@@ -150,10 +150,10 @@ template<
     class Accessor,
     class Scalar>
 Scalar matrix_inf_norm(
-  std::experimental::mdspan<ElementType, std::experimental::extents<SizeType, numRows, numCols>, Layout, Accessor> A,
+  mdspan<ElementType, extents<SizeType, numRows, numCols>, Layout, Accessor> A,
   Scalar init)
 {
-  return matrix_inf_norm(std::experimental::linalg::impl::default_exec_t(), A, init);
+  return matrix_inf_norm(impl::default_exec_t{}, A, init);
 }
 
 namespace matrix_inf_norm_detail {
@@ -170,7 +170,7 @@ namespace matrix_inf_norm_detail {
     class Layout,
     class Accessor>
   auto matrix_inf_norm_return_type_deducer(
-    std::experimental::mdspan<ElementType, std::experimental::extents<SizeType, numRows, numCols>, Layout, Accessor> A) -> decltype(abs(A(0,0)));
+    mdspan<ElementType, extents<SizeType, numRows, numCols>, Layout, Accessor> A) -> decltype(abs(A(0,0)));
 
 } // namespace matrix_inf_norm_detail
 
@@ -182,7 +182,7 @@ template<
   class Layout,
   class Accessor>
 auto matrix_inf_norm(
-  std::experimental::mdspan<ElementType, std::experimental::extents<SizeType, numRows, numCols>, Layout, Accessor> A)
+  mdspan<ElementType, extents<SizeType, numRows, numCols>, Layout, Accessor> A)
 -> decltype(matrix_inf_norm_detail::matrix_inf_norm_return_type_deducer(A))
 {
   using return_t = decltype(matrix_inf_norm_detail::matrix_inf_norm_return_type_deducer(A));
@@ -198,7 +198,7 @@ template<class ExecutionPolicy,
          class Accessor>
 auto matrix_inf_norm(
   ExecutionPolicy&& exec,
-  std::experimental::mdspan<ElementType, std::experimental::extents<SizeType, numRows, numCols>, Layout, Accessor> A)
+  mdspan<ElementType, extents<SizeType, numRows, numCols>, Layout, Accessor> A)
 -> decltype(matrix_inf_norm_detail::matrix_inf_norm_return_type_deducer(A))
 {
   using return_t = decltype(matrix_inf_norm_detail::matrix_inf_norm_return_type_deducer(A));
@@ -207,7 +207,7 @@ auto matrix_inf_norm(
 
 } // end namespace linalg
 } // end inline namespace __p1673_version_0
-} // end namespace experimental
-} // end namespace std
+} // end namespace MDSPAN_IMPL_PROPOSED_NAMESPACE
+} // end namespace MDSPAN_IMPL_STANDARD_NAMESPACE
 
 #endif //LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_BLAS1_MATRIX_INF_NORM_HPP_

--- a/include/experimental/__p1673_bits/blas1_matrix_one_norm.hpp
+++ b/include/experimental/__p1673_bits/blas1_matrix_one_norm.hpp
@@ -46,8 +46,8 @@
 #include <cmath>
 #include <cstdlib>
 
-namespace std {
-namespace experimental {
+namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
+namespace MDSPAN_IMPL_PROPOSED_NAMESPACE {
 inline namespace __p1673_version_0 {
 namespace linalg {
 
@@ -70,7 +70,7 @@ struct is_custom_matrix_one_norm_avail<
 	       ),
       Scalar
       >::value
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! impl::is_inline_exec_v<Exec>
     >
   >
   : std::true_type{};
@@ -87,8 +87,8 @@ template<
     class Accessor,
     class Scalar>
 Scalar matrix_one_norm(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
-  std::experimental::mdspan<ElementType, std::experimental::extents<SizeType, numRows, numCols>, Layout, Accessor> A,
+  impl::inline_exec_t&& /* exec */,
+  mdspan<ElementType, extents<SizeType, numRows, numCols>, Layout, Accessor> A,
   Scalar init)
 {
   using std::abs;
@@ -128,7 +128,7 @@ template<
   class Scalar>
 Scalar matrix_one_norm(
   ExecutionPolicy&& exec,
-  std::experimental::mdspan<ElementType, std::experimental::extents<SizeType, numRows, numCols>, Layout, Accessor> A,
+  mdspan<ElementType, extents<SizeType, numRows, numCols>, Layout, Accessor> A,
   Scalar init)
 {
 
@@ -136,11 +136,11 @@ Scalar matrix_one_norm(
     decltype(execpolicy_mapper(exec)), decltype(A), Scalar
     >::value;
 
-  if constexpr(use_custom){
+  if constexpr (use_custom) {
     return matrix_one_norm(execpolicy_mapper(exec), A, init);
   }
-  else{
-    return matrix_one_norm(std::experimental::linalg::impl::inline_exec_t(), A, init);
+  else {
+    return matrix_one_norm(impl::inline_exec_t{}, A, init);
   }
 }
 
@@ -153,10 +153,10 @@ template<
     class Accessor,
     class Scalar>
 Scalar matrix_one_norm(
-  std::experimental::mdspan<ElementType, std::experimental::extents<SizeType, numRows, numCols>, Layout, Accessor> A,
+  mdspan<ElementType, extents<SizeType, numRows, numCols>, Layout, Accessor> A,
   Scalar init)
 {
-  return matrix_one_norm(std::experimental::linalg::impl::default_exec_t(), A, init);
+  return matrix_one_norm(impl::default_exec_t{}, A, init);
 }
 
 
@@ -171,7 +171,7 @@ namespace matrix_one_norm_detail {
     class Layout,
     class Accessor>
   auto matrix_one_norm_return_type_deducer(
-    std::experimental::mdspan<ElementType, std::experimental::extents<SizeType, numRows, numCols>, Layout, Accessor> A) -> decltype(abs(A(0,0)));
+    mdspan<ElementType, extents<SizeType, numRows, numCols>, Layout, Accessor> A) -> decltype(abs(A(0,0)));
 
 } // namespace matrix_one_norm_detail
 
@@ -182,7 +182,7 @@ template<
   class Layout,
   class Accessor>
 auto matrix_one_norm(
-  std::experimental::mdspan<ElementType, std::experimental::extents<SizeType, numRows, numCols>, Layout, Accessor> A)
+  mdspan<ElementType, extents<SizeType, numRows, numCols>, Layout, Accessor> A)
 -> decltype(matrix_one_norm_detail::matrix_one_norm_return_type_deducer(A))
 {
   using return_t = decltype(matrix_one_norm_detail::matrix_one_norm_return_type_deducer(A));
@@ -198,7 +198,7 @@ template<class ExecutionPolicy,
          class Accessor>
 auto matrix_one_norm(
   ExecutionPolicy&& exec,
-  std::experimental::mdspan<ElementType, std::experimental::extents<SizeType, numRows, numCols>, Layout, Accessor> A)
+  mdspan<ElementType, extents<SizeType, numRows, numCols>, Layout, Accessor> A)
 -> decltype(matrix_one_norm_detail::matrix_one_norm_return_type_deducer(A))
 {
   using return_t = decltype(matrix_one_norm_detail::matrix_one_norm_return_type_deducer(A));
@@ -207,7 +207,7 @@ auto matrix_one_norm(
 
 } // end namespace linalg
 } // end inline namespace __p1673_version_0
-} // end namespace experimental
-} // end namespace std
+} // end namespace MDSPAN_IMPL_PROPOSED_NAMESPACE
+} // end namespace MDSPAN_IMPL_STANDARD_NAMESPACE
 
 #endif //LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_BLAS1_MATRIX_ONE_NORM_HPP_

--- a/include/experimental/__p1673_bits/blas1_scale.hpp
+++ b/include/experimental/__p1673_bits/blas1_scale.hpp
@@ -43,8 +43,8 @@
 #ifndef LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_BLAS1_SCALE_HPP_
 #define LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_BLAS1_SCALE_HPP_
 
-namespace std {
-namespace experimental {
+namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
+namespace MDSPAN_IMPL_PROPOSED_NAMESPACE {
 inline namespace __p1673_version_0 {
 namespace linalg {
 
@@ -58,7 +58,7 @@ template<class ElementType,
          class Scalar>
 void linalg_scale_rank_1(
   const Scalar alpha,
-  std::experimental::mdspan<ElementType, std::experimental::extents<SizeType, ext0>, Layout, Accessor> x)
+  mdspan<ElementType, extents<SizeType, ext0>, Layout, Accessor> x)
 {
   for (SizeType i = 0; i < x.extent(0); ++i) {
     x(i) *= alpha;
@@ -74,7 +74,7 @@ template<class ElementType,
          class Scalar>
 void linalg_scale_rank_2(
   const Scalar alpha,
-  std::experimental::mdspan<ElementType, std::experimental::extents<SizeType, numRows, numCols>, Layout, Accessor> A)
+  mdspan<ElementType, extents<SizeType, numRows, numCols>, Layout, Accessor> A)
 {
   for (SizeType j = 0; j < A.extent(1); ++j) {
     for (SizeType i = 0; i < A.extent(0); ++i) {
@@ -95,7 +95,7 @@ struct is_custom_scale_avail<
 		     std::declval<Scalar>(),
 		     std::declval<x_t>()))
       >
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! impl::is_inline_exec_v<Exec>
     >
   >
   : std::true_type{};
@@ -109,9 +109,9 @@ template<class Scalar,
          class Layout,
          class Accessor>
 void scale(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
+  impl::inline_exec_t&& /* exec */,
   const Scalar alpha,
-  std::experimental::mdspan<ElementType, std::experimental::extents<SizeType, ext ...>, Layout, Accessor> x)
+  mdspan<ElementType, extents<SizeType, ext ...>, Layout, Accessor> x)
 {
   static_assert(x.rank() <= 2);
 
@@ -133,7 +133,7 @@ template<class ExecutionPolicy,
 void scale(
   ExecutionPolicy&& exec,
   const Scalar alpha,
-  std::experimental::mdspan<ElementType, std::experimental::extents<SizeType, ext ...>, Layout, Accessor> x)
+  mdspan<ElementType, extents<SizeType, ext ...>, Layout, Accessor> x)
 {
   // Call custom overload if available else call std implementation
 
@@ -141,10 +141,10 @@ void scale(
     decltype(execpolicy_mapper(exec)), decltype(alpha), decltype(x)
     >::value;
 
-  if constexpr(use_custom) {
+  if constexpr (use_custom) {
     scale(execpolicy_mapper(exec), alpha, x);
   } else {
-    scale(std::experimental::linalg::impl::inline_exec_t(), alpha, x);
+    scale(impl::inline_exec_t{}, alpha, x);
   }
 }
 
@@ -155,14 +155,14 @@ template<class Scalar,
          class Layout,
          class Accessor>
 void scale(const Scalar alpha,
-           std::experimental::mdspan<ElementType, std::experimental::extents<SizeType, ext ...>, Layout, Accessor> x)
+           mdspan<ElementType, extents<SizeType, ext ...>, Layout, Accessor> x)
 {
-  scale(std::experimental::linalg::impl::default_exec_t(), alpha, x);
+  scale(impl::default_exec_t{}, alpha, x);
 }
 
 } // end namespace linalg
 } // end inline namespace __p1673_version_0
-} // end namespace experimental
-} // end namespace std
+} // end namespace MDSPAN_IMPL_PROPOSED_NAMESPACE
+} // end namespace MDSPAN_IMPL_STANDARD_NAMESPACE
 
 #endif //LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_BLAS1_SCALE_HPP_

--- a/include/experimental/__p1673_bits/blas1_vector_abs_sum.hpp
+++ b/include/experimental/__p1673_bits/blas1_vector_abs_sum.hpp
@@ -46,8 +46,8 @@
 #include <cstdlib>
 #include <cmath>
 
-namespace std {
-namespace experimental {
+namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
+namespace MDSPAN_IMPL_PROPOSED_NAMESPACE {
 inline namespace __p1673_version_0 {
 namespace linalg {
 
@@ -67,7 +67,7 @@ struct is_custom_vector_abs_sum_avail<
 	       ),
       Scalar
       >::value
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! impl::is_inline_exec_v<Exec>
     >
   >
   : std::true_type{};
@@ -80,8 +80,8 @@ template<class ElementType,
          class Accessor,
          class Scalar>
 Scalar vector_abs_sum(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
-  std::experimental::mdspan<ElementType, std::experimental::extents<SizeType, ext0>, Layout, Accessor> v,
+  impl::inline_exec_t&& /* exec */,
+  mdspan<ElementType, extents<SizeType, ext0>, Layout, Accessor> v,
   Scalar init)
 {
   const SizeType numElt = v.extent(0);
@@ -100,19 +100,18 @@ template<class ExecutionPolicy,
          class Scalar>
 Scalar vector_abs_sum(
   ExecutionPolicy&& exec,
-  std::experimental::mdspan<ElementType, std::experimental::extents<SizeType, ext0>, Layout, Accessor> v,
+  mdspan<ElementType, extents<SizeType, ext0>, Layout, Accessor> v,
   Scalar init)
 {
   constexpr bool use_custom = is_custom_vector_abs_sum_avail<
     decltype(execpolicy_mapper(exec)), decltype(v), Scalar
     >::value;
 
-  if constexpr(use_custom){
+  if constexpr (use_custom) {
     return vector_abs_sum(execpolicy_mapper(exec), v, init);
   }
-  else
-  {
-    return vector_abs_sum(std::experimental::linalg::impl::inline_exec_t(), v, init);
+  else {
+    return vector_abs_sum(impl::inline_exec_t{}, v, init);
   }
 }
 
@@ -122,10 +121,10 @@ template<class ElementType,
          class Accessor,
          class Scalar>
 Scalar vector_abs_sum(
-  std::experimental::mdspan<ElementType, std::experimental::extents<SizeType, ext0>, Layout, Accessor> v,
+  mdspan<ElementType, extents<SizeType, ext0>, Layout, Accessor> v,
   Scalar init)
 {
-  return vector_abs_sum(std::experimental::linalg::impl::default_exec_t(), v, init);
+  return vector_abs_sum(impl::default_exec_t{}, v, init);
 }
 
 namespace vector_abs_detail {
@@ -139,7 +138,7 @@ namespace vector_abs_detail {
     class Layout,
     class Accessor>
   auto vector_abs_return_type_deducer(
-    std::experimental::mdspan<ElementType, std::experimental::extents<SizeType, ext0>, Layout, Accessor> x)
+    mdspan<ElementType, extents<SizeType, ext0>, Layout, Accessor> x)
   -> decltype(abs(x(0)));
 } // namespace vector_abs_detail
 
@@ -149,7 +148,7 @@ template<class ElementType,
          class Layout,
          class Accessor>
 auto vector_abs_sum(
-  std::experimental::mdspan<ElementType, std::experimental::extents<SizeType, ext0>, Layout, Accessor> x)
+  mdspan<ElementType, extents<SizeType, ext0>, Layout, Accessor> x)
 -> decltype(vector_abs_detail::vector_abs_return_type_deducer(x))
 {
   using return_t = decltype(vector_abs_detail::vector_abs_return_type_deducer(x));
@@ -163,7 +162,7 @@ template<class ExecutionPolicy,
          class Accessor>
 auto vector_abs_sum(
   ExecutionPolicy&& exec,
-  std::experimental::mdspan<ElementType, std::experimental::extents<SizeType, ext0>, Layout, Accessor> x)
+  mdspan<ElementType, extents<SizeType, ext0>, Layout, Accessor> x)
 -> decltype(vector_abs_detail::vector_abs_return_type_deducer(x))
 {
   using return_t = decltype(vector_abs_detail::vector_abs_return_type_deducer(x));
@@ -172,7 +171,7 @@ auto vector_abs_sum(
 
 } // end namespace linalg
 } // end inline namespace __p1673_version_0
-} // end namespace experimental
-} // end namespace std
+} // end namespace MDSPAN_IMPL_PROPOSED_NAMESPACE
+} // end namespace MDSPAN_IMPL_STANDARD_NAMESPACE
 
 #endif //LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_BLAS1_VECTOR_ABS_SUM_HPP_

--- a/include/experimental/__p1673_bits/blas1_vector_idx_abs_max.hpp
+++ b/include/experimental/__p1673_bits/blas1_vector_idx_abs_max.hpp
@@ -43,8 +43,8 @@
 #ifndef LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_BLAS1_VECTOR_IDX_ABS_MAX_HPP_
 #define LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_BLAS1_VECTOR_IDX_ABS_MAX_HPP_
 
-namespace std {
-namespace experimental {
+namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
+namespace MDSPAN_IMPL_PROPOSED_NAMESPACE {
 inline namespace __p1673_version_0 {
 namespace linalg {
 
@@ -63,7 +63,7 @@ struct is_custom_idx_abs_max_avail<
       decltype(idx_abs_max(std::declval<Exec>(), std::declval<v_t>())),
       typename v_t::extents_type::size_type
       >::value
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! impl::is_inline_exec_v<Exec>
     >
   >
   : std::true_type{};
@@ -73,7 +73,7 @@ template<class ElementType,
          class Layout,
          class Accessor>
 SizeType idx_abs_max_default_impl(
-  std::experimental::mdspan<ElementType, std::experimental::extents<SizeType, ext0>, Layout, Accessor> v)
+  mdspan<ElementType, extents<SizeType, ext0>, Layout, Accessor> v)
 {
   using std::abs;
   using magnitude_type = decltype(abs(v(0)));
@@ -100,8 +100,8 @@ template<class ElementType,
          class Layout,
          class Accessor>
 SizeType idx_abs_max(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
-  std::experimental::mdspan<ElementType, std::experimental::extents<SizeType, ext0>, Layout, Accessor> v)
+  impl::inline_exec_t&& /* exec */,
+  mdspan<ElementType, extents<SizeType, ext0>, Layout, Accessor> v)
 {
   return idx_abs_max_default_impl(v);
 }
@@ -113,7 +113,7 @@ template<class ExecutionPolicy,
          class Accessor>
 SizeType idx_abs_max(
   ExecutionPolicy&& exec,
-  std::experimental::mdspan<ElementType, std::experimental::extents<SizeType, ext0>, Layout, Accessor> v)
+  mdspan<ElementType, extents<SizeType, ext0>, Layout, Accessor> v)
 {
   if (v.extent(0) == 0) {
     return std::numeric_limits<SizeType>::max();
@@ -123,11 +123,11 @@ SizeType idx_abs_max(
     decltype(execpolicy_mapper(exec)), decltype(v)
     >::value;
 
-  if constexpr(use_custom){
+  if constexpr (use_custom) {
     return idx_abs_max(execpolicy_mapper(exec), v);
   }
-  else{
-    return idx_abs_max(std::experimental::linalg::impl::inline_exec_t(), v);
+  else {
+    return idx_abs_max(impl::inline_exec_t{}, v);
   }
 }
 
@@ -136,14 +136,14 @@ template<class ElementType,
          class Layout,
          class Accessor>
 SizeType idx_abs_max(
-  std::experimental::mdspan<ElementType, std::experimental::extents<SizeType, ext0>, Layout, Accessor> v)
+  mdspan<ElementType, extents<SizeType, ext0>, Layout, Accessor> v)
 {
-  return idx_abs_max(std::experimental::linalg::impl::default_exec_t(), v);
+  return idx_abs_max(impl::default_exec_t{}, v);
 }
 
 } // end namespace linalg
 } // end inline namespace __p1673_version_0
-} // end namespace experimental
-} // end namespace std
+} // end namespace MDSPAN_IMPL_PROPOSED_NAMESPACE
+} // end namespace MDSPAN_IMPL_STANDARD_NAMESPACE
 
 #endif //LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_BLAS1_VECTOR_IDX_ABS_MAX_HPP_

--- a/include/experimental/__p1673_bits/blas1_vector_norm2.hpp
+++ b/include/experimental/__p1673_bits/blas1_vector_norm2.hpp
@@ -47,8 +47,8 @@
 #include <cmath>
 #include <cstdlib>
 
-namespace std {
-namespace experimental {
+namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
+namespace MDSPAN_IMPL_PROPOSED_NAMESPACE {
 inline namespace __p1673_version_0 {
 namespace linalg {
 
@@ -69,7 +69,7 @@ struct is_custom_vector_norm2_avail<
 	       ),
       Scalar
       >::value
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! impl::is_inline_exec_v<Exec>
     >
   >
   : std::true_type{};
@@ -81,8 +81,8 @@ template<class ElementType,
          class Accessor,
          class Scalar>
 Scalar vector_norm2(
-  std::experimental::linalg::impl::inline_exec_t&& exec,
-  std::experimental::mdspan<ElementType, std::experimental::extents<SizeType, ext0>, Layout, Accessor> x,
+  impl::inline_exec_t&& exec,
+  mdspan<ElementType, extents<SizeType, ext0>, Layout, Accessor> x,
   Scalar init)
 {
   // Initialize the sum of squares result
@@ -107,19 +107,18 @@ template<class ExecutionPolicy,
          class Scalar>
 Scalar vector_norm2(
   ExecutionPolicy&& exec,
-  std::experimental::mdspan<ElementType, std::experimental::extents<SizeType, ext0>, Layout, Accessor> x,
+  mdspan<ElementType, extents<SizeType, ext0>, Layout, Accessor> x,
   Scalar init)
 {
   constexpr bool use_custom = is_custom_vector_norm2_avail<
     decltype(execpolicy_mapper(exec)), decltype(x), Scalar
     >::value;
 
-  if constexpr(use_custom){
+  if constexpr (use_custom) {
     return vector_norm2(execpolicy_mapper(exec), x, init);
   }
-  else
-  {
-    return vector_norm2(std::experimental::linalg::impl::inline_exec_t(), x, init);
+  else {
+    return vector_norm2(impl::inline_exec_t{}, x, init);
   }
 }
 
@@ -129,10 +128,10 @@ template<class ElementType,
          class Accessor,
          class Scalar>
 Scalar vector_norm2(
-  std::experimental::mdspan<ElementType, std::experimental::extents<SizeType, ext0>, Layout, Accessor> x,
+  mdspan<ElementType, extents<SizeType, ext0>, Layout, Accessor> x,
   Scalar init)
 {
-  return vector_norm2(std::experimental::linalg::impl::default_exec_t(), x, init);
+  return vector_norm2(impl::default_exec_t{}, x, init);
 }
 
 
@@ -147,7 +146,7 @@ namespace vector_norm2_detail {
     class Layout,
     class Accessor>
   auto vector_norm2_return_type_deducer(
-    std::experimental::mdspan<ElementType, std::experimental::extents<SizeType, ext0>, Layout, Accessor> x)
+    mdspan<ElementType, extents<SizeType, ext0>, Layout, Accessor> x)
   -> decltype(abs(x(0)) * abs(x(0)));
 } // namespace vector_norm2_detail
 
@@ -156,7 +155,7 @@ template<class ElementType,
          class Layout,
          class Accessor>
 auto vector_norm2(
-  std::experimental::mdspan<ElementType, std::experimental::extents<SizeType, ext0>, Layout, Accessor> x)
+  mdspan<ElementType, extents<SizeType, ext0>, Layout, Accessor> x)
 -> decltype(vector_norm2_detail::vector_norm2_return_type_deducer(x))
 {
   using return_t = decltype(vector_norm2_detail::vector_norm2_return_type_deducer(x));
@@ -170,7 +169,7 @@ template<class ExecutionPolicy,
          class Accessor>
 auto vector_norm2(
   ExecutionPolicy&& exec,
-  std::experimental::mdspan<ElementType, std::experimental::extents<SizeType, ext0>, Layout, Accessor> x)
+  mdspan<ElementType, extents<SizeType, ext0>, Layout, Accessor> x)
 -> decltype(vector_norm2_detail::vector_norm2_return_type_deducer(x))
 {
   using return_t = decltype(vector_norm2_detail::vector_norm2_return_type_deducer(x));
@@ -179,7 +178,7 @@ auto vector_norm2(
 
 } // end namespace linalg
 } // end inline namespace __p1673_version_0
-} // end namespace experimental
-} // end namespace std
+} // end namespace MDSPAN_IMPL_PROPOSED_NAMESPACE
+} // end namespace MDSPAN_IMPL_STANDARD_NAMESPACE
 
 #endif //LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_BLAS1_VECTOR_NORM2_HPP_

--- a/include/experimental/__p1673_bits/blas1_vector_sum_of_squares.hpp
+++ b/include/experimental/__p1673_bits/blas1_vector_sum_of_squares.hpp
@@ -46,8 +46,8 @@
 #include <cmath>
 #include <cstdlib>
 
-namespace std {
-namespace experimental {
+namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
+namespace MDSPAN_IMPL_PROPOSED_NAMESPACE {
 inline namespace __p1673_version_0 {
 namespace linalg {
 
@@ -75,7 +75,7 @@ struct is_custom_vector_sum_of_squares_avail<
 	       ),
       sum_of_squares_result<Scalar>
       >::value
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! impl::is_inline_exec_v<Exec>
     >
   >
   : std::true_type{};
@@ -89,8 +89,8 @@ template<class ElementType,
          class Accessor,
          class Scalar>
 sum_of_squares_result<Scalar> vector_sum_of_squares(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
-  std::experimental::mdspan<ElementType, std::experimental::extents<SizeType, ext0>, Layout, Accessor> x,
+  impl::inline_exec_t&& /* exec */,
+  mdspan<ElementType, extents<SizeType, ext0>, Layout, Accessor> x,
   sum_of_squares_result<Scalar> init)
 {
   using std::abs;
@@ -133,7 +133,7 @@ template<class ExecutionPolicy,
          class Scalar>
 sum_of_squares_result<Scalar> vector_sum_of_squares(
   ExecutionPolicy&& exec,
-  std::experimental::mdspan<ElementType, std::experimental::extents<SizeType, ext0>, Layout, Accessor> v,
+  mdspan<ElementType, extents<SizeType, ext0>, Layout, Accessor> v,
   sum_of_squares_result<Scalar> init)
 {
 
@@ -141,12 +141,11 @@ sum_of_squares_result<Scalar> vector_sum_of_squares(
     decltype(execpolicy_mapper(exec)), decltype(v), Scalar
     >::value;
 
-  if constexpr(use_custom){
+  if constexpr (use_custom) {
     return vector_sum_of_squares(execpolicy_mapper(exec), v, init);
   }
-  else
-  {
-    return vector_sum_of_squares(std::experimental::linalg::impl::inline_exec_t(), v, init);
+  else {
+    return vector_sum_of_squares(impl::inline_exec_t{}, v, init);
   }
 }
 
@@ -157,16 +156,16 @@ template<class ElementType,
          class Accessor,
          class Scalar>
 sum_of_squares_result<Scalar> vector_sum_of_squares(
-  std::experimental::mdspan<ElementType, std::experimental::extents<SizeType, ext0>, Layout, Accessor> v,
+  mdspan<ElementType, extents<SizeType, ext0>, Layout, Accessor> v,
   sum_of_squares_result<Scalar> init)
 {
-  return vector_sum_of_squares(std::experimental::linalg::impl::default_exec_t(), v, init);
+  return vector_sum_of_squares(impl::default_exec_t{}, v, init);
 }
 
 
 } // end namespace linalg
 } // end inline namespace __p1673_version_0
-} // end namespace experimental
-} // end namespace std
+} // end namespace MDSPAN_IMPL_PROPOSED_NAMESPACE
+} // end namespace MDSPAN_IMPL_STANDARD_NAMESPACE
 
 #endif //LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_BLAS1_VECTOR_SUM_OF_SQUARES_HPP_

--- a/include/experimental/__p1673_bits/blas2_matrix_rank_1_update.hpp
+++ b/include/experimental/__p1673_bits/blas2_matrix_rank_1_update.hpp
@@ -43,8 +43,8 @@
 #ifndef LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_BLAS2_MATRIX_RANK_1_UPDATE_HPP_
 #define LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_BLAS2_MATRIX_RANK_1_UPDATE_HPP_
 
-namespace std {
-namespace experimental {
+namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
+namespace MDSPAN_IMPL_PROPOSED_NAMESPACE {
 inline namespace __p1673_version_0 {
 namespace linalg {
 
@@ -66,7 +66,7 @@ struct is_custom_matrix_rank_1_update_avail<
 		)
 	       )
       >
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! impl::is_inline_exec_v<Exec>
     >
   >
   : std::true_type{};
@@ -88,7 +88,7 @@ struct is_custom_symmetric_matrix_rank_1_update_avail<
 		)
 	       )
       >
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! impl::is_inline_exec_v<Exec>
     >
   >
   : std::true_type
@@ -108,7 +108,7 @@ struct is_custom_symmetric_matrix_rank_1_update_avail<
 		)
 	       )
       >
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! impl::is_inline_exec_v<Exec>
     >
   >
   : std::true_type
@@ -131,7 +131,7 @@ struct is_custom_hermitian_matrix_rank_1_update_avail<
 		)
 	       )
       >
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! impl::is_inline_exec_v<Exec>
     >
   >
   : std::true_type
@@ -151,7 +151,7 @@ struct is_custom_hermitian_matrix_rank_1_update_avail<
 		)
 	       )
       >
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! impl::is_inline_exec_v<Exec>
     >
   >
   : std::true_type
@@ -175,10 +175,10 @@ template<class ElementType_x,
          class Layout_A,
          class Accessor_A>
 void matrix_rank_1_update(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_y, std::experimental::extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A)
+  impl::inline_exec_t&& /* exec */,
+  mdspan<ElementType_x, extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_y, extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A)
 {
   using size_type = ::std::common_type_t<SizeType_x, SizeType_y, SizeType_A>;
 
@@ -205,21 +205,20 @@ template<class ExecutionPolicy,
          class Accessor_A>
 void matrix_rank_1_update(
   ExecutionPolicy&& exec,
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_y, std::experimental::extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A)
+  mdspan<ElementType_x, extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_y, extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A)
 {
 
   constexpr bool use_custom = is_custom_matrix_rank_1_update_avail<
     decltype(execpolicy_mapper(exec)), decltype(x), decltype(y), decltype(A)
     >::value;
 
-  if constexpr(use_custom){
+  if constexpr (use_custom) {
     matrix_rank_1_update(execpolicy_mapper(exec), x, y, A);
   }
-  else
-  {
-    matrix_rank_1_update(std::experimental::linalg::impl::inline_exec_t(), x, y, A);
+  else {
+    matrix_rank_1_update(impl::inline_exec_t{}, x, y, A);
   }
 }
 
@@ -237,11 +236,11 @@ template<class ElementType_x,
          class Layout_A,
          class Accessor_A>
 void matrix_rank_1_update(
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_y, std::experimental::extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A)
+  mdspan<ElementType_x, extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_y, extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A)
 {
-  matrix_rank_1_update(std::experimental::linalg::impl::default_exec_t(), x, y, A);
+  matrix_rank_1_update(impl::default_exec_t{}, x, y, A);
 }
 
 
@@ -261,9 +260,9 @@ template<class ElementType_x,
          class Layout_A,
          class Accessor_A>
 void matrix_rank_1_update_c(
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_y, std::experimental::extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A)
+  mdspan<ElementType_x, extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_y, extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A)
 {
   matrix_rank_1_update(x, conjugated(y), A);
 }
@@ -284,9 +283,9 @@ template<class ExecutionPolicy,
          class Accessor_A>
 void matrix_rank_1_update_c(
   ExecutionPolicy&& exec,
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_y, std::experimental::extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A)
+  mdspan<ElementType_x, extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_y, extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A)
 {
   matrix_rank_1_update(exec, x, conjugated(y), A);
 }
@@ -313,10 +312,10 @@ MDSPAN_TEMPLATE_REQUIRES(
   )
 )
 void symmetric_matrix_rank_1_update(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
+  impl::inline_exec_t&& /* exec */,
   ScaleFactorType alpha,
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_x, extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle /* t */)
 {
   using size_type = std::common_type_t<SizeType_x, SizeType_A>;
@@ -359,8 +358,8 @@ MDSPAN_TEMPLATE_REQUIRES(
 void symmetric_matrix_rank_1_update(
   ExecutionPolicy&& exec,
   ScaleFactorType alpha,
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_x, extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t)
 {
   constexpr bool use_custom = is_custom_symmetric_matrix_rank_1_update_avail<
@@ -369,8 +368,9 @@ void symmetric_matrix_rank_1_update(
 
   if constexpr (use_custom) {
     symmetric_matrix_rank_1_update(execpolicy_mapper(exec), alpha, x, A, t);
-  } else {
-    symmetric_matrix_rank_1_update(std::experimental::linalg::impl::inline_exec_t(), alpha, x, A, t);
+  }
+  else {
+    symmetric_matrix_rank_1_update(impl::inline_exec_t{}, alpha, x, A, t);
   }
 }
 
@@ -394,11 +394,11 @@ MDSPAN_TEMPLATE_REQUIRES(
 )
 void symmetric_matrix_rank_1_update(
   ScaleFactorType alpha,
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_x, extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t)
 {
-  symmetric_matrix_rank_1_update(std::experimental::linalg::impl::default_exec_t(), alpha, x, A, t);
+  symmetric_matrix_rank_1_update(impl::default_exec_t{}, alpha, x, A, t);
 }
 
 // Rank-1 update of a symmetric matrix without scaling factor alpha
@@ -420,9 +420,9 @@ MDSPAN_TEMPLATE_REQUIRES(
   )
 )
 void symmetric_matrix_rank_1_update(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  impl::inline_exec_t&& /* exec */,
+  mdspan<ElementType_x, extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle /* t */)
 {
   using size_type = std::common_type_t<SizeType_x, SizeType_A>;
@@ -463,8 +463,8 @@ MDSPAN_TEMPLATE_REQUIRES(
 )
 void symmetric_matrix_rank_1_update(
   ExecutionPolicy&& exec,
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_x, extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t)
 {
   constexpr bool use_custom = is_custom_symmetric_matrix_rank_1_update_avail<
@@ -473,8 +473,9 @@ void symmetric_matrix_rank_1_update(
 
   if constexpr (use_custom) {
     symmetric_matrix_rank_1_update(execpolicy_mapper(exec), x, A, t);
-  } else {
-    symmetric_matrix_rank_1_update(std::experimental::linalg::impl::inline_exec_t(), x, A, t);
+  }
+  else {
+    symmetric_matrix_rank_1_update(impl::inline_exec_t{}, x, A, t);
   }
 }
 
@@ -495,11 +496,11 @@ MDSPAN_TEMPLATE_REQUIRES(
   )
 )
 void symmetric_matrix_rank_1_update(
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_x, extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t)
 {
-  symmetric_matrix_rank_1_update(std::experimental::linalg::impl::default_exec_t(), x, A, t);
+  symmetric_matrix_rank_1_update(impl::default_exec_t{}, x, A, t);
 }
 
 // Rank-k update of a Hermitian matrix
@@ -524,10 +525,10 @@ MDSPAN_TEMPLATE_REQUIRES(
   )
 )
 void hermitian_matrix_rank_1_update(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
+  impl::inline_exec_t&& /* exec */,
   ScaleFactorType alpha,
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_x, extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle /* t */)
 {
   using size_type = std::common_type_t<SizeType_x, SizeType_A>;
@@ -570,8 +571,8 @@ MDSPAN_TEMPLATE_REQUIRES(
 void hermitian_matrix_rank_1_update(
   ExecutionPolicy&& exec,
   ScaleFactorType alpha,
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_x, extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t)
 {
   constexpr bool use_custom = is_custom_hermitian_matrix_rank_1_update_avail<
@@ -580,8 +581,9 @@ void hermitian_matrix_rank_1_update(
 
   if constexpr (use_custom) {
     hermitian_matrix_rank_1_update(execpolicy_mapper(exec), alpha, x, A, t);
-  } else {
-    hermitian_matrix_rank_1_update(std::experimental::linalg::impl::inline_exec_t(), alpha, x, A, t);
+  }
+  else {
+    hermitian_matrix_rank_1_update(impl::inline_exec_t{}, alpha, x, A, t);
   }
 }
 
@@ -605,11 +607,11 @@ MDSPAN_TEMPLATE_REQUIRES(
 )
 void hermitian_matrix_rank_1_update(
   ScaleFactorType alpha,
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_x, extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t)
 {
-  hermitian_matrix_rank_1_update(std::experimental::linalg::impl::default_exec_t(), alpha, x, A, t);
+  hermitian_matrix_rank_1_update(impl::default_exec_t{}, alpha, x, A, t);
 }
 
 // Rank-1 update of a Hermitian matrix without scaling factor alpha
@@ -631,9 +633,9 @@ MDSPAN_TEMPLATE_REQUIRES(
   )
 )
 void hermitian_matrix_rank_1_update(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  impl::inline_exec_t&& /* exec */,
+  mdspan<ElementType_x, extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle /* t */)
 {
   using size_type = std::common_type_t<SizeType_x, SizeType_A>;
@@ -674,8 +676,8 @@ MDSPAN_TEMPLATE_REQUIRES(
 )
 void hermitian_matrix_rank_1_update(
   ExecutionPolicy&& exec,
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_x, extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t)
 {
   constexpr bool use_custom = is_custom_hermitian_matrix_rank_1_update_avail<
@@ -684,8 +686,9 @@ void hermitian_matrix_rank_1_update(
 
   if constexpr (use_custom) {
     hermitian_matrix_rank_1_update(execpolicy_mapper(exec), x, A, t);
-  } else {
-    hermitian_matrix_rank_1_update(std::experimental::linalg::impl::inline_exec_t(), x, A, t);
+  }
+  else {
+    hermitian_matrix_rank_1_update(impl::inline_exec_t{}, x, A, t);
   }
 }
 
@@ -706,16 +709,16 @@ MDSPAN_TEMPLATE_REQUIRES(
   )
 )
 void hermitian_matrix_rank_1_update(
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_x, extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t)
 {
-  hermitian_matrix_rank_1_update(std::experimental::linalg::impl::default_exec_t(), x, A, t);
+  hermitian_matrix_rank_1_update(impl::default_exec_t{}, x, A, t);
 }
 
 } // end namespace linalg
 } // end inline namespace __p1673_version_0
-} // end namespace experimental
-} // end namespace std
+} // end namespace MDSPAN_IMPL_PROPOSED_NAMESPACE
+} // end namespace MDSPAN_IMPL_STANDARD_NAMESPACE
 
 #endif //LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_BLAS2_MATRIX_RANK_1_UPDATE_HPP_

--- a/include/experimental/__p1673_bits/blas2_matrix_rank_2_update.hpp
+++ b/include/experimental/__p1673_bits/blas2_matrix_rank_2_update.hpp
@@ -43,8 +43,8 @@
 #ifndef LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_BLAS2_MATRIX_RANK_2_UPDATE_HPP_
 #define LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_BLAS2_MATRIX_RANK_2_UPDATE_HPP_
 
-namespace std {
-namespace experimental {
+namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
+namespace MDSPAN_IMPL_PROPOSED_NAMESPACE {
 inline namespace __p1673_version_0 {
 namespace linalg {
 
@@ -67,7 +67,7 @@ struct is_custom_symmetric_matrix_rank_2_update_avail<
 		)
 	       )
       >
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! impl::is_inline_exec_v<Exec>
     >
   >
   : std::true_type{};
@@ -89,7 +89,7 @@ struct is_custom_hermitian_matrix_rank_2_update_avail<
 		)
 	       )
       >
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! impl::is_inline_exec_v<Exec>
     >
   >
   : std::true_type{};
@@ -112,10 +112,10 @@ template<class ElementType_x,
          class Accessor_A,
          class Triangle>
 void symmetric_matrix_rank_2_update(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_y, std::experimental::extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  impl::inline_exec_t&& /* exec */,
+  mdspan<ElementType_x, extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_y, extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle /* t */)
 {
   using size_type = std::common_type_t<SizeType_x, SizeType_y, SizeType_A>;
@@ -147,22 +147,20 @@ template<class ExecutionPolicy,
          class Triangle>
 void symmetric_matrix_rank_2_update(
   ExecutionPolicy&& exec,
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_y, std::experimental::extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_x, extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_y, extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t)
 {
-
   constexpr bool use_custom = is_custom_symmetric_matrix_rank_2_update_avail<
     decltype(execpolicy_mapper(exec)), decltype(x), decltype(y), decltype(A), Triangle
     >::value;
 
-  if constexpr(use_custom){
+  if constexpr (use_custom) {
     symmetric_matrix_rank_2_update(execpolicy_mapper(exec), x, y, A, t);
   }
-  else
-  {
-    symmetric_matrix_rank_2_update(std::experimental::linalg::impl::inline_exec_t(), x, y, A, t);
+  else {
+    symmetric_matrix_rank_2_update(impl::inline_exec_t{}, x, y, A, t);
   }
 }
 
@@ -180,12 +178,12 @@ template<class ElementType_x,
          class Accessor_A,
          class Triangle>
 void symmetric_matrix_rank_2_update(
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_y, std::experimental::extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_x, extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_y, extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t)
 {
-  symmetric_matrix_rank_2_update(std::experimental::linalg::impl::default_exec_t(), x, y, A, t);
+  symmetric_matrix_rank_2_update(impl::default_exec_t{}, x, y, A, t);
 }
 
 
@@ -205,10 +203,10 @@ template<class ElementType_x,
          class Accessor_A,
          class Triangle>
 void hermitian_matrix_rank_2_update(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_y, std::experimental::extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  impl::inline_exec_t&& /* exec */,
+  mdspan<ElementType_x, extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_y, extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle /* t */)
 {
   using size_type = std::common_type_t<SizeType_x, SizeType_y, SizeType_A>;
@@ -241,9 +239,9 @@ template<class ExecutionPolicy,
          class Triangle>
 void hermitian_matrix_rank_2_update(
   ExecutionPolicy&& exec,
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_y, std::experimental::extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_x, extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_y, extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t)
 {
 
@@ -251,12 +249,11 @@ void hermitian_matrix_rank_2_update(
     decltype(execpolicy_mapper(exec)), decltype(x), decltype(y), decltype(A), Triangle
     >::value;
 
-  if constexpr(use_custom){
+  if constexpr (use_custom) {
     hermitian_matrix_rank_2_update(execpolicy_mapper(exec), x, y, A, t);
   }
-  else
-  {
-    hermitian_matrix_rank_2_update(std::experimental::linalg::impl::inline_exec_t(), x, y, A, t);
+  else {
+    hermitian_matrix_rank_2_update(impl::inline_exec_t{}, x, y, A, t);
   }
 }
 
@@ -274,17 +271,17 @@ template<class ElementType_x,
          class Accessor_A,
          class Triangle>
 void hermitian_matrix_rank_2_update(
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_y, std::experimental::extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_x, extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_y, extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t)
 {
-  hermitian_matrix_rank_2_update(std::experimental::linalg::impl::default_exec_t(), x, y, A, t);
+  hermitian_matrix_rank_2_update(impl::default_exec_t{}, x, y, A, t);
 }
 
 } // end namespace linalg
 } // end inline namespace __p1673_version_0
-} // end namespace experimental
-} // end namespace std
+} // end namespace MDSPAN_IMPL_PROPOSED_NAMESPACE
+} // end namespace MDSPAN_IMPL_STANDARD_NAMESPACE
 
 #endif //LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_BLAS2_MATRIX_RANK_2_UPDATE_HPP_

--- a/include/experimental/__p1673_bits/blas2_matrix_vector_product.hpp
+++ b/include/experimental/__p1673_bits/blas2_matrix_vector_product.hpp
@@ -46,8 +46,8 @@
 #include <complex>
 #include <type_traits>
 
-namespace std {
-namespace experimental {
+namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
+namespace MDSPAN_IMPL_PROPOSED_NAMESPACE {
 inline namespace __p1673_version_0 {
 namespace linalg {
 
@@ -69,7 +69,7 @@ struct is_custom_mat_vec_product_avail<
 		std::declval<X_t>(),
 		std::declval<Y_t>()))
       >
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! impl::is_inline_exec_v<Exec>
     >
   >
   : std::true_type{};
@@ -89,7 +89,7 @@ struct is_custom_mat_vec_product_with_update_avail<
 				     std::declval<Y_t>(),
 				     std::declval<Z_t>()))
       >
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! impl::is_inline_exec_v<Exec>
     >
   >
   : std::true_type{};
@@ -109,7 +109,7 @@ struct is_custom_sym_mat_vec_product_avail<
 					       std::declval<X_t>(),
 					       std::declval<Y_t>()))
       >
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! impl::is_inline_exec_v<Exec>
     >
   >
   : std::true_type{};
@@ -130,7 +130,7 @@ struct is_custom_sym_mat_vec_product_with_update_avail<
 					       std::declval<Y_t>(),
 					       std::declval<Z_t>()))
       >
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! impl::is_inline_exec_v<Exec>
     >
   >
   : std::true_type{};
@@ -150,7 +150,7 @@ struct is_custom_hermitian_mat_vec_product_avail<
 					       std::declval<X_t>(),
 					       std::declval<Y_t>()))
       >
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! impl::is_inline_exec_v<Exec>
     >
   >
   : std::true_type{};
@@ -171,7 +171,7 @@ struct is_custom_hermitian_mat_vec_product_with_update_avail<
 					       std::declval<Y_t>(),
 					       std::declval<Z_t>()))
       >
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! impl::is_inline_exec_v<Exec>
     >
   >
   : std::true_type{};
@@ -195,7 +195,7 @@ struct is_custom_tri_mat_vec_product_avail<
 		)
 	       )
       >
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! impl::is_inline_exec_v<Exec>
     >
   >
   : std::true_type{};
@@ -220,7 +220,7 @@ struct is_custom_tri_mat_vec_product_with_update_avail<
 		)
 	       )
       >
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! impl::is_inline_exec_v<Exec>
     >
   >
   : std::true_type{};
@@ -235,7 +235,7 @@ namespace impl {
   };
 
   template<class ElementType, class Extents, class Layout, class Accessor>
-  struct is_mdspan<::std::experimental::mdspan<ElementType, Extents, Layout, Accessor>> {
+  struct is_mdspan<mdspan<ElementType, Extents, Layout, Accessor>> {
     // FIXME (mfh 2022/06/19) not quite enough -- the template
     // parameters also need to meet mdspan's requirements -- but this
     // is enough to resolve ambiguity between the overwriting +
@@ -266,10 +266,10 @@ MDSPAN_TEMPLATE_REQUIRES(
          /* requires */ (Layout_A::template mapping<extents<SizeType_A, numRows_A, numCols_A> >::is_always_unique())
 )
 void matrix_vector_product(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_y, std::experimental::extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y)
+  impl::inline_exec_t&& /* exec */,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_x, extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_y, extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y)
 {
   using size_type = std::common_type_t<
     std::common_type_t<
@@ -303,17 +303,18 @@ MDSPAN_TEMPLATE_REQUIRES(
 )
 void matrix_vector_product(
   ExecutionPolicy&& exec,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_y, std::experimental::extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y)
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_x, extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_y, extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y)
 {
   constexpr bool use_custom = is_custom_mat_vec_product_avail<
     decltype(execpolicy_mapper(exec)), decltype(A), decltype(x), decltype(y)>::value;
 
-  if constexpr(use_custom) {
+  if constexpr (use_custom) {
     matrix_vector_product(execpolicy_mapper(exec), A, x, y);
-  } else {
-    matrix_vector_product(std::experimental::linalg::impl::inline_exec_t(), A, x, y);
+  }
+  else {
+    matrix_vector_product(impl::inline_exec_t{}, A, x, y);
   }
 }
 
@@ -331,11 +332,11 @@ template<class ElementType_A,
          class Layout_y,
          class Accessor_y>
 void matrix_vector_product(
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_y, std::experimental::extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y)
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_x, extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_y, extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y)
 {
-  matrix_vector_product(std::experimental::linalg::impl::default_exec_t(), A, x, y);
+  matrix_vector_product(impl::default_exec_t{}, A, x, y);
 }
 
 namespace impl {
@@ -345,7 +346,7 @@ namespace impl {
   };
 
   template<class Layout, class SizeType, size_t ... Extents>
-  struct always_unique_mapping<Layout, ::std::experimental::extents<SizeType, Extents...>> {
+  struct always_unique_mapping<Layout, extents<SizeType, Extents...>> {
   private:
     using extents_type = extents<SizeType, Extents...>;
   public:
@@ -383,11 +384,11 @@ MDSPAN_TEMPLATE_REQUIRES(
          /* requires */ (impl::always_unique_mapping_v<Layout_A, Extents_A /* SizeType_A, numRows_A, numCols_A */> && Extents_A::rank() == 2)
 )
 void matrix_vector_product(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
-  std::experimental::mdspan<ElementType_A, Extents_A /* std::experimental::extents<SizeType_A, numRows_A, numCols_A> */, Layout_A, Accessor_A> A,
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_y, std::experimental::extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y,
-  std::experimental::mdspan<ElementType_z, std::experimental::extents<SizeType_z, ext_z>, Layout_z, Accessor_z> z)
+  impl::inline_exec_t&& /* exec */,
+  mdspan<ElementType_A, Extents_A /* extents<SizeType_A, numRows_A, numCols_A> */, Layout_A, Accessor_A> A,
+  mdspan<ElementType_x, extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_y, extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y,
+  mdspan<ElementType_z, extents<SizeType_z, ext_z>, Layout_z, Accessor_z> z)
 {
   using size_type = std::common_type_t<
     std::common_type_t<
@@ -429,19 +430,20 @@ MDSPAN_TEMPLATE_REQUIRES(
 )
 void matrix_vector_product(
   ExecutionPolicy&& exec,
-  std::experimental::mdspan<ElementType_A, Extents_A /* std::experimental::extents<SizeType_A, numRows_A, numCols_A> */ , Layout_A, Accessor_A> A,
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x> , Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_y, std::experimental::extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y,
-  std::experimental::mdspan<ElementType_z, Extents_z /* std::experimental::extents<SizeType_z, ext_z> */ , Layout_z, Accessor_z> z)
+  mdspan<ElementType_A, Extents_A /* extents<SizeType_A, numRows_A, numCols_A> */ , Layout_A, Accessor_A> A,
+  mdspan<ElementType_x, extents<SizeType_x, ext_x> , Layout_x, Accessor_x> x,
+  mdspan<ElementType_y, extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y,
+  mdspan<ElementType_z, Extents_z /* extents<SizeType_z, ext_z> */ , Layout_z, Accessor_z> z)
 {
 
   constexpr bool use_custom = is_custom_mat_vec_product_with_update_avail<
     decltype(execpolicy_mapper(exec)), decltype(A), decltype(x), decltype(y), decltype(z)>::value;
 
-  if constexpr(use_custom) {
+  if constexpr (use_custom) {
     matrix_vector_product(execpolicy_mapper(exec), A, x, y, z);
-  } else {
-    matrix_vector_product(std::experimental::linalg::impl::inline_exec_t(), A, x, y, z);
+  }
+  else {
+    matrix_vector_product(impl::inline_exec_t{}, A, x, y, z);
   }
 }
 
@@ -469,12 +471,12 @@ MDSPAN_TEMPLATE_REQUIRES(
          /* requires */ (impl::always_unique_mapping_v<Layout_A, Extents_A /* extents<SizeType_A, numRows_A, numCols_A> */ > && Extents_A::rank() == 2)
 )
 void matrix_vector_product(
-  std::experimental::mdspan<ElementType_A, Extents_A /* std::experimental::extents<SizeType_A, numRows_A, numCols_A> */, Layout_A, Accessor_A> A,
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_y, std::experimental::extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y,
-  std::experimental::mdspan<ElementType_z, std::experimental::extents<SizeType_z, ext_z>, Layout_z, Accessor_z> z)
+  mdspan<ElementType_A, Extents_A /* extents<SizeType_A, numRows_A, numCols_A> */, Layout_A, Accessor_A> A,
+  mdspan<ElementType_x, extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_y, extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y,
+  mdspan<ElementType_z, extents<SizeType_z, ext_z>, Layout_z, Accessor_z> z)
 {
-  matrix_vector_product(std::experimental::linalg::impl::default_exec_t(), A, x, y, z);
+  matrix_vector_product(impl::default_exec_t{}, A, x, y, z);
 }
 
 
@@ -495,14 +497,14 @@ MDSPAN_TEMPLATE_REQUIRES(
          class SizeType_y, ::std::size_t ext_y,
          class Layout_y,
          class Accessor_y,
-         /* requires */ (Layout_A::template mapping<std::experimental::extents<SizeType_A, numRows_A, numCols_A>>::is_always_unique())
+         /* requires */ (Layout_A::template mapping<extents<SizeType_A, numRows_A, numCols_A>>::is_always_unique())
 )
 void symmetric_matrix_vector_product(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  impl::inline_exec_t&& /* exec */,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t,
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_y, std::experimental::extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y)
+  mdspan<ElementType_x, extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_y, extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y)
 {
   using size_type = std::common_type_t<
       std::common_type_t<SizeType_A, SizeType_x>,
@@ -549,18 +551,19 @@ template<class ExecutionPolicy,
          class Accessor_y>
 void symmetric_matrix_vector_product(
   ExecutionPolicy&& exec,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t,
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_y, std::experimental::extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y)
+  mdspan<ElementType_x, extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_y, extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y)
 {
   constexpr bool use_custom = is_custom_sym_mat_vec_product_avail<
     decltype(execpolicy_mapper(exec)), decltype(A), Triangle, decltype(x), decltype(y)>::value;
 
-  if constexpr(use_custom) {
+  if constexpr (use_custom) {
     symmetric_matrix_vector_product(execpolicy_mapper(exec), A, t, x, y);
-  } else {
-    symmetric_matrix_vector_product(std::experimental::linalg::impl::inline_exec_t(), A, t, x, y);
+  }
+  else {
+    symmetric_matrix_vector_product(impl::inline_exec_t{}, A, t, x, y);
   }
 }
 
@@ -579,15 +582,15 @@ MDSPAN_TEMPLATE_REQUIRES(
          class SizeType_y, ::std::size_t ext_y,
          class Layout_y,
          class Accessor_y,
-         /* requires */ (Layout_A::template mapping<std::experimental::extents<SizeType_A, numRows_A, numCols_A>>::is_always_unique())
+         /* requires */ (Layout_A::template mapping<extents<SizeType_A, numRows_A, numCols_A>>::is_always_unique())
 )
 void symmetric_matrix_vector_product(
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t,
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_y, std::experimental::extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y)
+  mdspan<ElementType_x, extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_y, extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y)
 {
-  symmetric_matrix_vector_product(std::experimental::linalg::impl::default_exec_t(), A, t, x, y);
+  symmetric_matrix_vector_product(impl::default_exec_t{}, A, t, x, y);
 }
 
 
@@ -616,12 +619,12 @@ MDSPAN_TEMPLATE_REQUIRES(
          /* requires */ (impl::always_unique_mapping_v<Layout_A, Extents_A> && Extents_A::rank() == 2 && Extents_z::rank() == 1)
 )
 void symmetric_matrix_vector_product(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
-  std::experimental::mdspan<ElementType_A, Extents_A, Layout_A, Accessor_A> A,
+  impl::inline_exec_t&& /* exec */,
+  mdspan<ElementType_A, Extents_A, Layout_A, Accessor_A> A,
   Triangle t,
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_y, std::experimental::extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y,
-  std::experimental::mdspan<ElementType_z, Extents_z, Layout_z, Accessor_z> z)
+  mdspan<ElementType_x, extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_y, extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y,
+  mdspan<ElementType_z, Extents_z, Layout_z, Accessor_z> z)
 {
   using size_type = std::common_type_t<
     std::common_type_t<
@@ -674,19 +677,20 @@ template<class ExecutionPolicy,
          class Accessor_z>
 void symmetric_matrix_vector_product(
   ExecutionPolicy&& exec,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t,
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_y, std::experimental::extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y,
-  std::experimental::mdspan<ElementType_z, std::experimental::extents<SizeType_z, ext_z>, Layout_z, Accessor_z> z)
+  mdspan<ElementType_x, extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_y, extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y,
+  mdspan<ElementType_z, extents<SizeType_z, ext_z>, Layout_z, Accessor_z> z)
 {
   constexpr bool use_custom = is_custom_sym_mat_vec_product_with_update_avail<
     decltype(execpolicy_mapper(exec)), decltype(A), Triangle, decltype(x), decltype(y), decltype(z)>::value;
 
-  if constexpr(use_custom) {
+  if constexpr (use_custom) {
     symmetric_matrix_vector_product(execpolicy_mapper(exec), A, t, x, y, z);
-  } else {
-    symmetric_matrix_vector_product(std::experimental::linalg::impl::inline_exec_t(), A, t, x, y, z);
+  }
+  else {
+    symmetric_matrix_vector_product(impl::inline_exec_t{}, A, t, x, y, z);
   }
 }
 
@@ -716,13 +720,13 @@ MDSPAN_TEMPLATE_REQUIRES(
          /* requires */ (impl::always_unique_mapping_v<Layout_A, Extents_A /* extents<SizeType_A, numRows_A, numCols_A> */ > && Extents_A::rank() == 2 && Extents_z::rank() == 1)
 )
 void symmetric_matrix_vector_product(
-  std::experimental::mdspan<ElementType_A,  Extents_A /* std::experimental::extents<SizeType_A, numRows_A, numCols_A> */ , Layout_A, Accessor_A> A,
+  mdspan<ElementType_A,  Extents_A /* extents<SizeType_A, numRows_A, numCols_A> */ , Layout_A, Accessor_A> A,
   Triangle t,
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_y, std::experimental::extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y,
-  std::experimental::mdspan<ElementType_z, Extents_z /* std::experimental::extents<SizeType_z, ext_z> */ , Layout_z, Accessor_z> z)
+  mdspan<ElementType_x, extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_y, extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y,
+  mdspan<ElementType_z, Extents_z /* extents<SizeType_z, ext_z> */ , Layout_z, Accessor_z> z)
 {
-  symmetric_matrix_vector_product(std::experimental::linalg::impl::default_exec_t(), A, t, x, y, z);
+  symmetric_matrix_vector_product(impl::default_exec_t{}, A, t, x, y, z);
 }
 
 
@@ -744,14 +748,14 @@ MDSPAN_TEMPLATE_REQUIRES(
          class SizeType_y, ::std::size_t ext_y,
          class Layout_y,
          class Accessor_y,
-         /* requires */ (Layout_A::template mapping<std::experimental::extents<SizeType_A, numRows_A, numCols_A>>::is_always_unique())
+         /* requires */ (Layout_A::template mapping<extents<SizeType_A, numRows_A, numCols_A>>::is_always_unique())
 )
 void hermitian_matrix_vector_product(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  impl::inline_exec_t&& /* exec */,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t,
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_y, std::experimental::extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y)
+  mdspan<ElementType_x, extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_y, extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y)
 {
   using size_type = std::common_type_t<
       std::common_type_t<SizeType_A, SizeType_x>,
@@ -797,22 +801,23 @@ MDSPAN_TEMPLATE_REQUIRES(
          class SizeType_y, ::std::size_t ext_y,
          class Layout_y,
          class Accessor_y,
-         /* requires */ (Layout_A::template mapping<std::experimental::extents<SizeType_A, numRows_A, numCols_A>>::is_always_unique())
+         /* requires */ (Layout_A::template mapping<extents<SizeType_A, numRows_A, numCols_A>>::is_always_unique())
 )
 void hermitian_matrix_vector_product(
   ExecutionPolicy&& exec,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t,
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_y, std::experimental::extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y)
+  mdspan<ElementType_x, extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_y, extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y)
 {
   constexpr bool use_custom = is_custom_hermitian_mat_vec_product_avail<
     decltype(execpolicy_mapper(exec)), decltype(A), Triangle, decltype(x), decltype(y)>::value;
 
-  if constexpr(use_custom) {
+  if constexpr (use_custom) {
     hermitian_matrix_vector_product(execpolicy_mapper(exec), A, t, x, y);
-  } else {
-    hermitian_matrix_vector_product(std::experimental::linalg::impl::inline_exec_t(), A, t, x, y);
+  }
+  else {
+    hermitian_matrix_vector_product(impl::inline_exec_t{}, A, t, x, y);
   }
 }
 
@@ -831,15 +836,15 @@ MDSPAN_TEMPLATE_REQUIRES(
          class SizeType_y, ::std::size_t ext_y,
          class Layout_y,
          class Accessor_y,
-         /* requires */ (Layout_A::template mapping<std::experimental::extents<SizeType_A, numRows_A, numCols_A>>::is_always_unique())
+         /* requires */ (Layout_A::template mapping<extents<SizeType_A, numRows_A, numCols_A>>::is_always_unique())
 )
 void hermitian_matrix_vector_product(
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t,
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_y, std::experimental::extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y)
+  mdspan<ElementType_x, extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_y, extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y)
 {
-  hermitian_matrix_vector_product(std::experimental::linalg::impl::default_exec_t(), A, t, x, y);
+  hermitian_matrix_vector_product(impl::default_exec_t{}, A, t, x, y);
 }
 
 
@@ -872,12 +877,12 @@ MDSPAN_TEMPLATE_REQUIRES(
          /* requires */ (impl::always_unique_mapping_v<Layout_A, Extents_A /* extents<SizeType_A, numRows_A, numCols_A> */ > && Extents_A::rank() == 2 && Extents_z::rank() == 1)
 )
 void hermitian_matrix_vector_product(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
-  std::experimental::mdspan<ElementType_A, Extents_A /* std::experimental::extents<SizeType_A, numRows_A, numCols_A> */ , Layout_A, Accessor_A> A,
+  impl::inline_exec_t&& /* exec */,
+  mdspan<ElementType_A, Extents_A /* extents<SizeType_A, numRows_A, numCols_A> */ , Layout_A, Accessor_A> A,
   Triangle t,
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_y, std::experimental::extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y,
-  std::experimental::mdspan<ElementType_z, Extents_z /* std::experimental::extents<SizeType_z, ext_z> */ , Layout_z, Accessor_z> z)
+  mdspan<ElementType_x, extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_y, extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y,
+  mdspan<ElementType_z, Extents_z /* extents<SizeType_z, ext_z> */ , Layout_z, Accessor_z> z)
 {
   using size_type = std::common_type_t<
     std::common_type_t<
@@ -930,19 +935,20 @@ template<class ExecutionPolicy,
          class Accessor_z>
 void hermitian_matrix_vector_product(
   ExecutionPolicy&& exec,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t,
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_y, std::experimental::extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y,
-  std::experimental::mdspan<ElementType_z, std::experimental::extents<SizeType_z, ext_z>, Layout_z, Accessor_z> z)
+  mdspan<ElementType_x, extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_y, extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y,
+  mdspan<ElementType_z, extents<SizeType_z, ext_z>, Layout_z, Accessor_z> z)
 {
   constexpr bool use_custom = is_custom_hermitian_mat_vec_product_with_update_avail<
     decltype(execpolicy_mapper(exec)), decltype(A), Triangle, decltype(x), decltype(y), decltype(z)>::value;
 
-  if constexpr(use_custom) {
+  if constexpr (use_custom) {
     hermitian_matrix_vector_product(execpolicy_mapper(exec), A, t, x, y, z);
-  } else {
-    hermitian_matrix_vector_product(std::experimental::linalg::impl::inline_exec_t(), A, t, x, y, z);
+  }
+  else {
+    hermitian_matrix_vector_product(impl::inline_exec_t{}, A, t, x, y, z);
   }
 }
 
@@ -973,13 +979,13 @@ MDSPAN_TEMPLATE_REQUIRES(
          /* requires */ (impl::always_unique_mapping_v<Layout_A, Extents_A /* extents<SizeType_A, numRows_A, numCols_A> */ > && Extents_A::rank() == 2)
 )
 void hermitian_matrix_vector_product(
-  std::experimental::mdspan<ElementType_A, Extents_A /* std::experimental::extents<SizeType_A, numRows_A, numCols_A> */ , Layout_A, Accessor_A> A,
+  mdspan<ElementType_A, Extents_A /* extents<SizeType_A, numRows_A, numCols_A> */ , Layout_A, Accessor_A> A,
   Triangle t,
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_y, std::experimental::extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y,
-  std::experimental::mdspan<ElementType_z, Extents_z /* std::experimental::extents<SizeType_z, ext_z> */ , Layout_z, Accessor_z> z)
+  mdspan<ElementType_x, extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_y, extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y,
+  mdspan<ElementType_z, Extents_z /* extents<SizeType_z, ext_z> */ , Layout_z, Accessor_z> z)
 {
-  hermitian_matrix_vector_product(std::experimental::linalg::impl::default_exec_t(), A, t, x, y, z);
+  hermitian_matrix_vector_product(impl::default_exec_t{}, A, t, x, y, z);
 }
 
 
@@ -1001,15 +1007,15 @@ MDSPAN_TEMPLATE_REQUIRES(
          class SizeType_y, ::std::size_t ext_y,
          class Layout_y,
          class Accessor_y,
-         /* requires */ (Layout_A::template mapping<std::experimental::extents<SizeType_A, numRows_A, numCols_A>>::is_always_unique())
+         /* requires */ (Layout_A::template mapping<extents<SizeType_A, numRows_A, numCols_A>>::is_always_unique())
 )
 void triangular_matrix_vector_product(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  impl::inline_exec_t&& /* exec */,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t,
   DiagonalStorage d,
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_y, std::experimental::extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y)
+  mdspan<ElementType_x, extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_y, extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y)
 {
   using size_type = std::common_type_t<
       std::common_type_t<SizeType_A, SizeType_x>,
@@ -1063,11 +1069,11 @@ template<class ExecutionPolicy,
          class Accessor_y>
 void triangular_matrix_vector_product(
   ExecutionPolicy&& exec,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t,
   DiagonalStorage d,
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_y, std::experimental::extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y)
+  mdspan<ElementType_x, extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_y, extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y)
 {
 
   constexpr bool use_custom = is_custom_tri_mat_vec_product_avail<
@@ -1075,12 +1081,11 @@ void triangular_matrix_vector_product(
     decltype(A), decltype(t), decltype(d), decltype(x), decltype(y)
     >::value;
 
-  if constexpr(use_custom){
+  if constexpr (use_custom) {
     triangular_matrix_vector_product(execpolicy_mapper(exec), A, t, d, x, y);
   }
-  else
-  {
-    triangular_matrix_vector_product(std::experimental::linalg::impl::inline_exec_t(),
+  else {
+    triangular_matrix_vector_product(impl::inline_exec_t{},
 				     A, t, d, x, y);
   }
 }
@@ -1101,16 +1106,16 @@ MDSPAN_TEMPLATE_REQUIRES(
          class SizeType_y, ::std::size_t ext_y,
          class Layout_y,
          class Accessor_y,
-         /* requires */ (Layout_A::template mapping<std::experimental::extents<SizeType_A, numRows_A, numCols_A>>::is_always_unique())
+         /* requires */ (Layout_A::template mapping<extents<SizeType_A, numRows_A, numCols_A>>::is_always_unique())
 )
 void triangular_matrix_vector_product(
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t,
   DiagonalStorage d,
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_y, std::experimental::extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y)
+  mdspan<ElementType_x, extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_y, extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y)
 {
-  triangular_matrix_vector_product(std::experimental::linalg::impl::default_exec_t(), A, t, d, x, y);
+  triangular_matrix_vector_product(impl::default_exec_t{}, A, t, d, x, y);
 }
 
 
@@ -1145,13 +1150,13 @@ MDSPAN_TEMPLATE_REQUIRES(
          /* requires */ (impl::always_unique_mapping_v<Layout_A, Extents_A /* extents<SizeType_A, numRows_A, numCols_A> */ > && Extents_A::rank() == 2)
 )
 void triangular_matrix_vector_product(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
-  std::experimental::mdspan<ElementType_A, Extents_A /* std::experimental::extents<SizeType_A, numRows_A, numCols_A> */ , Layout_A, Accessor_A> A,
+  impl::inline_exec_t&& /* exec */,
+  mdspan<ElementType_A, Extents_A /* extents<SizeType_A, numRows_A, numCols_A> */ , Layout_A, Accessor_A> A,
   Triangle t,
   DiagonalStorage d,
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_y, Extents_y /* std::experimental::extents<SizeType_y, ext_y> */ , Layout_y, Accessor_y> y,
-  std::experimental::mdspan<ElementType_z, Extents_z /* std::experimental::extents<SizeType_z, ext_z> */ , Layout_z, Accessor_z> z)
+  mdspan<ElementType_x, extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_y, Extents_y /* extents<SizeType_y, ext_y> */ , Layout_y, Accessor_y> y,
+  mdspan<ElementType_z, Extents_z /* extents<SizeType_z, ext_z> */ , Layout_z, Accessor_z> z)
 {
   using size_type = std::common_type_t<
     std::common_type_t<
@@ -1213,22 +1218,23 @@ template<class ExecutionPolicy,
          class Accessor_z>
 void triangular_matrix_vector_product(
   ExecutionPolicy&& exec,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t,
   DiagonalStorage d,
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_y, std::experimental::extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y,
-  std::experimental::mdspan<ElementType_z, std::experimental::extents<SizeType_z, ext_z>, Layout_z, Accessor_z> z)
+  mdspan<ElementType_x, extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_y, extents<SizeType_y, ext_y>, Layout_y, Accessor_y> y,
+  mdspan<ElementType_z, extents<SizeType_z, ext_z>, Layout_z, Accessor_z> z)
 {
   constexpr bool use_custom = is_custom_tri_mat_vec_product_with_update_avail<
     decltype(execpolicy_mapper(exec)),
     decltype(A), decltype(t), decltype(d), decltype(x), decltype(y), decltype(z)
     >::value;
 
-  if constexpr(use_custom) {
+  if constexpr (use_custom) {
     triangular_matrix_vector_product(execpolicy_mapper(exec), A, t, d, x, y, z);
-  } else {
-    triangular_matrix_vector_product(std::experimental::linalg::impl::inline_exec_t(), A, t, d, x, y, z);
+  }
+  else {
+    triangular_matrix_vector_product(impl::inline_exec_t{}, A, t, d, x, y, z);
   }
 }
 
@@ -1261,19 +1267,19 @@ MDSPAN_TEMPLATE_REQUIRES(
          /* requires */ (impl::always_unique_mapping_v<Layout_A, Extents_A /* extents<SizeType_A, numRows_A, numCols_A> */ > && Extents_A::rank() == 2)
 )
 void triangular_matrix_vector_product(
-  std::experimental::mdspan<ElementType_A, Extents_A /* std::experimental::extents<SizeType_A, numRows_A, numCols_A> */ , Layout_A, Accessor_A> A,
+  mdspan<ElementType_A, Extents_A /* extents<SizeType_A, numRows_A, numCols_A> */ , Layout_A, Accessor_A> A,
   Triangle t,
   DiagonalStorage d,
-  std::experimental::mdspan<ElementType_x, std::experimental::extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
-  std::experimental::mdspan<ElementType_y, Extents_y /* std::experimental::extents<SizeType_y, ext_y> */ , Layout_y, Accessor_y> y,
-  std::experimental::mdspan<ElementType_z, Extents_z /* std::experimental::extents<SizeType_z, ext_z> */ , Layout_z, Accessor_z> z)
+  mdspan<ElementType_x, extents<SizeType_x, ext_x>, Layout_x, Accessor_x> x,
+  mdspan<ElementType_y, Extents_y /* extents<SizeType_y, ext_y> */ , Layout_y, Accessor_y> y,
+  mdspan<ElementType_z, Extents_z /* extents<SizeType_z, ext_z> */ , Layout_z, Accessor_z> z)
 {
-  triangular_matrix_vector_product(std::experimental::linalg::impl::default_exec_t(), A, t, d, x, y, z);
+  triangular_matrix_vector_product(impl::default_exec_t{}, A, t, d, x, y, z);
 }
 
 } // end namespace linalg
 } // end inline namespace __p1673_version_0
-} // end namespace experimental
-} // end namespace std
+} // end namespace MDSPAN_IMPL_PROPOSED_NAMESPACE
+} // end namespace MDSPAN_IMPL_STANDARD_NAMESPACE
 
 #endif //LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_BLAS2_MATRIX_VECTOR_PRODUCT_HPP_

--- a/include/experimental/__p1673_bits/blas2_matrix_vector_solve.hpp
+++ b/include/experimental/__p1673_bits/blas2_matrix_vector_solve.hpp
@@ -45,8 +45,8 @@
 
 #include <type_traits>
 
-namespace std {
-namespace experimental {
+namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
+namespace MDSPAN_IMPL_PROPOSED_NAMESPACE {
 inline namespace __p1673_version_0 {
 namespace linalg {
 
@@ -68,10 +68,10 @@ template<class ElementType_A,
          class Accessor_X,
          class BinaryDivideOp>
 void trsv_upper_triangular_left_side(
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   DiagonalStorage d,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, ext_B>, Layout_B, Accessor_B> B,
-  std::experimental::mdspan<ElementType_X, std::experimental::extents<SizeType_X, ext_X>, Layout_X, Accessor_X> X,
+  mdspan<ElementType_B, extents<SizeType_B, ext_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_X, extents<SizeType_X, ext_X>, Layout_X, Accessor_X> X,
   BinaryDivideOp divide)
 {
   constexpr bool explicit_diagonal =
@@ -118,10 +118,10 @@ template<class ElementType_A,
          class Layout_X,
          class Accessor_X>
 void trsv_upper_triangular_left_side(
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   DiagonalStorage d,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, ext_B>, Layout_B, Accessor_B> B,
-  std::experimental::mdspan<ElementType_X, std::experimental::extents<SizeType_X, ext_X>, Layout_X, Accessor_X> X)
+  mdspan<ElementType_B, extents<SizeType_B, ext_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_X, extents<SizeType_X, ext_X>, Layout_X, Accessor_X> X)
 {
   auto divide = [](const auto& x, const auto& y) { return x / y; };
   trsv_upper_triangular_left_side(A, d, B, X, divide);
@@ -143,10 +143,10 @@ template<class ElementType_A,
          class Accessor_X,
          class BinaryDivideOp>
 void trsv_lower_triangular_left_side(
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   DiagonalStorage d,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, ext_B>, Layout_B, Accessor_B> B,
-  std::experimental::mdspan<ElementType_X, std::experimental::extents<SizeType_X, ext_X>, Layout_X, Accessor_X> X,
+  mdspan<ElementType_B, extents<SizeType_B, ext_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_X, extents<SizeType_X, ext_X>, Layout_X, Accessor_X> X,
   BinaryDivideOp divide)
 {
   constexpr bool explicit_diagonal =
@@ -190,10 +190,10 @@ template<class ElementType_A,
          class Layout_X,
          class Accessor_X>
 void trsv_lower_triangular_left_side(
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   DiagonalStorage d,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, ext_B>, Layout_B, Accessor_B> B,
-  std::experimental::mdspan<ElementType_X, std::experimental::extents<SizeType_X, ext_X>, Layout_X, Accessor_X> X)
+  mdspan<ElementType_B, extents<SizeType_B, ext_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_X, extents<SizeType_X, ext_X>, Layout_X, Accessor_X> X)
 {
   auto divide = [](const auto& x, const auto& y) { return x / y; };
   trsv_lower_triangular_left_side(A, d, B, X, divide);
@@ -217,7 +217,7 @@ struct is_custom_tri_mat_vec_solve_avail<
 		)
 	       )
       >
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! impl::is_inline_exec_v<Exec>
     >
   >
   : std::true_type{};
@@ -243,12 +243,12 @@ template<class ElementType_A,
          class Accessor_X,
          class BinaryDivideOp>
 void triangular_matrix_vector_solve(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  impl::inline_exec_t&& /* exec */,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t,
   DiagonalStorage d,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, ext_B>, Layout_B, Accessor_B> b,
-  std::experimental::mdspan<ElementType_X, std::experimental::extents<SizeType_X, ext_X>, Layout_X, Accessor_X> x,
+  mdspan<ElementType_B, extents<SizeType_B, ext_B>, Layout_B, Accessor_B> b,
+  mdspan<ElementType_X, extents<SizeType_X, ext_X>, Layout_X, Accessor_X> x,
   BinaryDivideOp divide)
 {
   if constexpr (std::is_same_v<Triangle, lower_triangle_t>) {
@@ -275,15 +275,15 @@ template<class ElementType_A,
          class Layout_X,
          class Accessor_X>
 void triangular_matrix_vector_solve(
-  std::experimental::linalg::impl::inline_exec_t&& exec,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  impl::inline_exec_t&& exec,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t,
   DiagonalStorage d,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, ext_B>, Layout_B, Accessor_B> b,
-  std::experimental::mdspan<ElementType_X, std::experimental::extents<SizeType_X, ext_X>, Layout_X, Accessor_X> x)
+  mdspan<ElementType_B, extents<SizeType_B, ext_B>, Layout_B, Accessor_B> b,
+  mdspan<ElementType_X, extents<SizeType_X, ext_X>, Layout_X, Accessor_X> x)
 {
   auto divide = [](const auto& x, const auto& y) { return x / y; };
-  triangular_matrix_vector_solve(std::forward<std::experimental::linalg::impl::inline_exec_t>(exec), A, t, d, b, x, divide);
+  triangular_matrix_vector_solve(std::forward<impl::inline_exec_t>(exec), A, t, d, b, x, divide);
 }
 
 // Overloads taking an ExecutionPolicy
@@ -307,16 +307,16 @@ template<class ExecutionPolicy,
          class BinaryDivideOp>
 void triangular_matrix_vector_solve(
   ExecutionPolicy&& /* exec */,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t,
   DiagonalStorage d,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, ext_B>, Layout_B, Accessor_B> b,
-  std::experimental::mdspan<ElementType_X, std::experimental::extents<SizeType_X, ext_X>, Layout_X, Accessor_X> x,
+  mdspan<ElementType_B, extents<SizeType_B, ext_B>, Layout_B, Accessor_B> b,
+  mdspan<ElementType_X, extents<SizeType_X, ext_X>, Layout_X, Accessor_X> x,
   BinaryDivideOp divide)
 {
   // FIXME (mfh 2022/06/13) We don't yet have a parallel version
   // that takes a generic divide operator.
-  triangular_matrix_vector_solve(std::experimental::linalg::impl::inline_exec_t{}, A, t, d, b, x, divide);
+  triangular_matrix_vector_solve(impl::inline_exec_t{}, A, t, d, b, x, divide);
 }
   
 template<class ExecutionPolicy,
@@ -337,22 +337,21 @@ template<class ExecutionPolicy,
          class Accessor_X>
 void triangular_matrix_vector_solve(
   ExecutionPolicy&& exec,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t,
   DiagonalStorage d,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, ext_B>, Layout_B, Accessor_B> b,
-  std::experimental::mdspan<ElementType_X, std::experimental::extents<SizeType_X, ext_X>, Layout_X, Accessor_X> x)
+  mdspan<ElementType_B, extents<SizeType_B, ext_B>, Layout_B, Accessor_B> b,
+  mdspan<ElementType_X, extents<SizeType_X, ext_X>, Layout_X, Accessor_X> x)
 {
   constexpr bool use_custom = is_custom_tri_mat_vec_solve_avail<
     decltype(execpolicy_mapper(exec)), decltype(A), decltype(t), decltype(d), decltype(b), decltype(x)
     >::value;
 
-  if constexpr(use_custom){
+  if constexpr (use_custom) {
     triangular_matrix_vector_solve(execpolicy_mapper(exec), A, t, d, b, x);
   }
-  else
-  {
-    triangular_matrix_vector_solve(std::experimental::linalg::impl::inline_exec_t(),
+  else {
+    triangular_matrix_vector_solve(impl::inline_exec_t{},
 				   A, t, d, b, x);
   }
 }
@@ -376,14 +375,14 @@ template<class ElementType_A,
          class Accessor_X,
          class BinaryDivideOp>
 void triangular_matrix_vector_solve(
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t,
   DiagonalStorage d,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, ext_B>, Layout_B, Accessor_B> b,
-  std::experimental::mdspan<ElementType_X, std::experimental::extents<SizeType_X, ext_X>, Layout_X, Accessor_X> x,
+  mdspan<ElementType_B, extents<SizeType_B, ext_B>, Layout_B, Accessor_B> b,
+  mdspan<ElementType_X, extents<SizeType_X, ext_X>, Layout_X, Accessor_X> x,
   BinaryDivideOp divide)
 {
-  triangular_matrix_vector_solve(std::experimental::linalg::impl::default_exec_t(),
+  triangular_matrix_vector_solve(impl::default_exec_t{},
 				 A, t, d, b, x, divide);
 }
   
@@ -403,19 +402,19 @@ template<class ElementType_A,
          class Layout_X,
          class Accessor_X>
 void triangular_matrix_vector_solve(
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t,
   DiagonalStorage d,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, ext_B>, Layout_B, Accessor_B> b,
-  std::experimental::mdspan<ElementType_X, std::experimental::extents<SizeType_X, ext_X>, Layout_X, Accessor_X> x)
+  mdspan<ElementType_B, extents<SizeType_B, ext_B>, Layout_B, Accessor_B> b,
+  mdspan<ElementType_X, extents<SizeType_X, ext_X>, Layout_X, Accessor_X> x)
 {
-  triangular_matrix_vector_solve(std::experimental::linalg::impl::default_exec_t(),
+  triangular_matrix_vector_solve(impl::default_exec_t{},
 				 A, t, d, b, x);
 }
 
 } // end namespace linalg
 } // end inline namespace __p1673_version_0
-} // end namespace experimental
-} // end namespace std
+} // end namespace MDSPAN_IMPL_PROPOSED_NAMESPACE
+} // end namespace MDSPAN_IMPL_STANDARD_NAMESPACE
 
 #endif //LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_BLAS2_MATRIX_VECTOR_SOLVE_HPP_

--- a/include/experimental/__p1673_bits/blas3_matrix_product.hpp
+++ b/include/experimental/__p1673_bits/blas3_matrix_product.hpp
@@ -46,8 +46,8 @@
 #include <cassert>
 #include <optional>
 
-namespace std {
-namespace experimental {
+namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
+namespace MDSPAN_IMPL_PROPOSED_NAMESPACE {
 inline namespace __p1673_version_0 {
 namespace linalg {
 
@@ -382,7 +382,7 @@ struct is_custom_matrix_product_with_update_avail<
 		std::declval<E_t>(),
 		std::declval<C_t>()))
       >
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! impl::is_inline_exec_v<Exec>
     >
   >
   : std::true_type{};
@@ -405,7 +405,7 @@ struct is_custom_triang_mat_left_product_avail<
 		std::declval<B_t>(),
 		std::declval<C_t>()))
       >
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! impl::is_inline_exec_v<Exec>
     >
   >
   : std::true_type{};
@@ -427,7 +427,7 @@ struct is_custom_triang_mat_right_product_avail<
 		std::declval<B_t>(),
 		std::declval<C_t>()))
       >
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! impl::is_inline_exec_v<Exec>
     >
   >
   : std::true_type{};
@@ -448,7 +448,7 @@ struct is_custom_triang_mat_left_product_with_update_avail<
 		std::declval<DiagSt_t>(),
 		std::declval<C_t>()))
       >
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! impl::is_inline_exec_v<Exec>
     >
   >
   : std::true_type{};
@@ -469,7 +469,7 @@ struct is_custom_triang_mat_right_product_with_update_avail<
 		std::declval<DiagSt_t>(),
 		std::declval<C_t>()))
       >
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! impl::is_inline_exec_v<Exec>
     >
   >
   : std::true_type{};
@@ -490,7 +490,7 @@ struct is_custom_sym_matrix_left_product_avail<
 		std::declval<B_t>(),
 		std::declval<C_t>()))
       >
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! impl::is_inline_exec_v<Exec>
     >
   >
   : std::true_type{};
@@ -512,7 +512,7 @@ struct is_custom_sym_matrix_right_product_avail<
 		std::declval<B_t>(),
 		std::declval<C_t>()))
       >
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! impl::is_inline_exec_v<Exec>
     >
   >
   : std::true_type{};
@@ -534,7 +534,7 @@ struct is_custom_sym_matrix_left_product_with_update_avail<
 		std::declval<E_t>(),
 		std::declval<C_t>()))
       >
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! impl::is_inline_exec_v<Exec>
     >
   >
   : std::true_type{};
@@ -556,7 +556,7 @@ struct is_custom_sym_matrix_right_product_with_update_avail<
 		std::declval<E_t>(),
 		std::declval<C_t>()))
       >
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! impl::is_inline_exec_v<Exec>
     >
   >
   : std::true_type{};
@@ -578,7 +578,7 @@ struct is_custom_herm_matrix_left_product_avail<
 		std::declval<B_t>(),
 		std::declval<C_t>()))
       >
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! impl::is_inline_exec_v<Exec>
     >
   >
   : std::true_type{};
@@ -599,7 +599,7 @@ struct is_custom_herm_matrix_right_product_avail<
 		std::declval<B_t>(),
 		std::declval<C_t>()))
       >
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! impl::is_inline_exec_v<Exec>
     >
   >
   : std::true_type{};
@@ -622,7 +622,7 @@ struct is_custom_herm_matrix_left_product_with_update_avail<
 		std::declval<E_t>(),
 		std::declval<C_t>()))
       >
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! impl::is_inline_exec_v<Exec>
     >
   >
   : std::true_type{};
@@ -644,7 +644,7 @@ struct is_custom_herm_matrix_right_product_with_update_avail<
 		std::declval<E_t>(),
 		std::declval<C_t>()))
       >
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! impl::is_inline_exec_v<Exec>
     >
   >
   : std::true_type{};
@@ -665,18 +665,18 @@ template<class ElementType_A,
          class Layout_C,
          class Accessor_C>
 void matrix_product(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
+  impl::inline_exec_t&& /* exec */,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_B, extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
 {
 // FIXME (mfh 2022/06/17) Temporarily disable calling the BLAS,
 // to get PR testing workflow running with mdspan tag.
 #if 0
 #ifdef LINALG_ENABLE_BLAS
-  using in_matrix_1_t = typename std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A>;
-  using in_matrix_2_t = typename std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B>;
-  using out_matrix_t = typename std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C>;
+  using in_matrix_1_t = typename mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A>;
+  using in_matrix_2_t = typename mdspan<ElementType_B, extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B>;
+  using out_matrix_t = typename mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C>;
 
   constexpr bool blas_able =
     matrix_product_dispatch_to_blas<in_matrix_1_t, in_matrix_2_t, out_matrix_t>();
@@ -746,17 +746,18 @@ template<class ExecutionPolicy,
          class Accessor_C>
 void matrix_product(
   ExecutionPolicy&& exec,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_B, extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
 {
   constexpr bool use_custom = is_custom_matrix_product_avail<
     decltype(execpolicy_mapper(exec)), decltype(A), decltype(B), decltype(C)>::value;
 
-  if constexpr(use_custom) {
+  if constexpr (use_custom) {
     matrix_product(execpolicy_mapper(exec), A, B, C);
-  } else {
-    matrix_product(std::experimental::linalg::impl::inline_exec_t(), A, B, C);
+  }
+  else {
+    matrix_product(impl::inline_exec_t{}, A, B, C);
   }
 }
 
@@ -773,11 +774,11 @@ template<class ElementType_A,
          class Layout_C,
          class Accessor_C>
 void matrix_product(
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_B, extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
 {
-  matrix_product(std::experimental::linalg::impl::default_exec_t(), A, B, C);
+  matrix_product(impl::default_exec_t{}, A, B, C);
 }
 
 
@@ -800,11 +801,11 @@ template<class ElementType_A,
          class Layout_C,
          class Accessor_C>
 void matrix_product(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
-  std::experimental::mdspan<ElementType_E, std::experimental::extents<SizeType_E, numRows_E, numCols_E>, Layout_E, Accessor_E> E,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
+  impl::inline_exec_t&& /* exec */,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_B, extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_E, extents<SizeType_E, numRows_E, numCols_E>, Layout_E, Accessor_E> E,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
 {
   using size_type = ::std::common_type_t<SizeType_A, SizeType_B, SizeType_E, SizeType_C>;
 
@@ -837,18 +838,20 @@ template<class ExecutionPolicy,
          class Accessor_C>
 void matrix_product(
   ExecutionPolicy&& exec,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
-  std::experimental::mdspan<ElementType_E, std::experimental::extents<SizeType_E, numRows_E, numCols_E>, Layout_E, Accessor_E> E,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_B, extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_E, extents<SizeType_E, numRows_E, numCols_E>, Layout_E, Accessor_E> E,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
 {
   constexpr bool use_custom = is_custom_matrix_product_with_update_avail<
-    decltype(execpolicy_mapper(exec)), decltype(A), decltype(B), decltype(E), decltype(C)>::value;
+    decltype(execpolicy_mapper(exec)),
+    decltype(A), decltype(B), decltype(E), decltype(C)>::value;
 
-  if constexpr(use_custom) {
+  if constexpr (use_custom) {
     matrix_product(execpolicy_mapper(exec), A, B, E, C);
-  } else {
-    matrix_product(std::experimental::linalg::impl::inline_exec_t(), A, B, E, C);
+  }
+  else {
+    matrix_product(impl::inline_exec_t{}, A, B, E, C);
   }
 }
 
@@ -869,12 +872,12 @@ template<class ElementType_A,
          class Layout_C,
          class Accessor_C>
 void matrix_product(
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
-  std::experimental::mdspan<ElementType_E, std::experimental::extents<SizeType_E, numRows_E, numCols_E>, Layout_E, Accessor_E> E,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_B, extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_E, extents<SizeType_E, numRows_E, numCols_E>, Layout_E, Accessor_E> E,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
 {
-  matrix_product(std::experimental::linalg::impl::default_exec_t(), A, B, E, C);
+  matrix_product(impl::default_exec_t{}, A, B, E, C);
 }
 
 
@@ -895,12 +898,12 @@ template<class ElementType_A,
          class Layout_C,
          class Accessor_C>
 void triangular_matrix_left_product(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  impl::inline_exec_t&& /* exec */,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle /* t */,
   DiagonalStorage /* d */,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
+  mdspan<ElementType_B, extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
 {
   using size_type = ::std::common_type_t<SizeType_A, SizeType_B, SizeType_C>;
   constexpr bool explicitDiagonal =
@@ -953,19 +956,20 @@ template<class ExecutionPolicy,
          class Accessor_C>
 void triangular_matrix_left_product(
   ExecutionPolicy&& exec,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t,
   DiagonalStorage d,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
+  mdspan<ElementType_B, extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
 {
   constexpr bool use_custom = is_custom_triang_mat_left_product_avail<
     decltype(execpolicy_mapper(exec)), decltype(A), Triangle, DiagonalStorage, decltype(B), decltype(C)>::value;
 
-  if constexpr(use_custom) {
+  if constexpr (use_custom) {
     triangular_matrix_left_product(execpolicy_mapper(exec), A, t, d, B, C);
-  } else {
-    triangular_matrix_left_product(std::experimental::linalg::impl::inline_exec_t(), A, t, d, B, C);
+  }
+  else {
+    triangular_matrix_left_product(impl::inline_exec_t{}, A, t, d, B, C);
   }
 }
 
@@ -984,13 +988,13 @@ template<class ElementType_A,
          class Layout_C,
          class Accessor_C>
 void triangular_matrix_left_product(
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t,
   DiagonalStorage d,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
+  mdspan<ElementType_B, extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
 {
-  triangular_matrix_left_product(std::experimental::linalg::impl::default_exec_t(), A, t, d, B, C);
+  triangular_matrix_left_product(impl::default_exec_t{}, A, t, d, B, C);
 }
 
 
@@ -1009,12 +1013,12 @@ template<class ElementType_A,
          class Layout_C,
          class Accessor_C>
 void triangular_matrix_right_product(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  impl::inline_exec_t&& /* exec */,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle /* t */,
   DiagonalStorage /* d */,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
+  mdspan<ElementType_B, extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
 {
   using size_type = ::std::common_type_t<SizeType_A, SizeType_B, SizeType_C>;
   constexpr bool explicitDiagonal =
@@ -1067,19 +1071,21 @@ template<class ExecutionPolicy,
          class Accessor_C>
 void triangular_matrix_right_product(
   ExecutionPolicy&& exec,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t,
   DiagonalStorage d,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
+  mdspan<ElementType_B, extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
 {
   constexpr bool use_custom = is_custom_triang_mat_right_product_avail<
-    decltype(execpolicy_mapper(exec)), decltype(A), Triangle, DiagonalStorage, decltype(B), decltype(C)>::value;
+    decltype(execpolicy_mapper(exec)),
+    decltype(A), Triangle, DiagonalStorage, decltype(B), decltype(C)>::value;
 
-  if constexpr(use_custom) {
+  if constexpr (use_custom) {
     triangular_matrix_right_product(execpolicy_mapper(exec), A, t, d, B, C);
-  } else {
-    triangular_matrix_right_product(std::experimental::linalg::impl::inline_exec_t(), A, t, d, B, C);
+  }
+  else {
+    triangular_matrix_right_product(impl::inline_exec_t{}, A, t, d, B, C);
   }
 }
 
@@ -1098,13 +1104,13 @@ template<class ElementType_A,
          class Layout_C,
          class Accessor_C>
 void triangular_matrix_right_product(
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t,
   DiagonalStorage d ,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
+  mdspan<ElementType_B, extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
 {
-  triangular_matrix_right_product(std::experimental::linalg::impl::default_exec_t(), A, t, d, B, C);
+  triangular_matrix_right_product(impl::default_exec_t{}, A, t, d, B, C);
 }
 
 
@@ -1121,11 +1127,11 @@ template<class ElementType_A,
          class Layout_C,
          class Accessor_C>
 void triangular_matrix_left_product(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  impl::inline_exec_t&& /* exec */,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle /* t */,
   DiagonalStorage /* d */,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
 {
   using size_type = ::std::common_type_t<SizeType_A, SizeType_C>;
   constexpr bool explicitDiagonal =
@@ -1170,18 +1176,19 @@ template<class ExecutionPolicy,
          class Accessor_C>
 void triangular_matrix_left_product(
   ExecutionPolicy&& exec ,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t,
   DiagonalStorage d,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
 {
   constexpr bool use_custom = is_custom_triang_mat_left_product_with_update_avail<
     decltype(execpolicy_mapper(exec)), decltype(A), Triangle, DiagonalStorage, decltype(C)>::value;
 
-  if constexpr(use_custom) {
+  if constexpr (use_custom) {
     triangular_matrix_left_product(execpolicy_mapper(exec), A, t, d, C);
-  } else {
-    triangular_matrix_left_product(std::experimental::linalg::impl::inline_exec_t(), A, t, d, C);
+  }
+  else {
+    triangular_matrix_left_product(impl::inline_exec_t{}, A, t, d, C);
   }
 }
 
@@ -1196,12 +1203,12 @@ template<class ElementType_A,
          class Layout_C,
          class Accessor_C>
 void triangular_matrix_left_product(
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t,
   DiagonalStorage d,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
 {
-  triangular_matrix_left_product(std::experimental::linalg::impl::default_exec_t(), A, t, d, C);
+  triangular_matrix_left_product(impl::default_exec_t{}, A, t, d, C);
 }
 
 template<class ElementType_A,
@@ -1215,11 +1222,11 @@ template<class ElementType_A,
          class Layout_C,
          class Accessor_C>
 void triangular_matrix_right_product(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  impl::inline_exec_t&& /* exec */,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle /* t */,
   DiagonalStorage /* d */,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
 {
   using size_type = ::std::common_type_t<SizeType_A, SizeType_C>;
   constexpr bool explicitDiagonal =
@@ -1268,18 +1275,19 @@ template<class ExecutionPolicy,
          class Accessor_C>
 void triangular_matrix_right_product(
   ExecutionPolicy&& exec ,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t,
   DiagonalStorage d,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
 {
   constexpr bool use_custom = is_custom_triang_mat_right_product_with_update_avail<
     decltype(execpolicy_mapper(exec)), decltype(A), Triangle, DiagonalStorage, decltype(C)>::value;
 
-  if constexpr(use_custom) {
+  if constexpr (use_custom) {
     triangular_matrix_right_product(execpolicy_mapper(exec), A, t, d, C);
-  } else {
-    triangular_matrix_right_product(std::experimental::linalg::impl::inline_exec_t(), A, t, d, C);
+  }
+  else {
+    triangular_matrix_right_product(impl::inline_exec_t{}, A, t, d, C);
   }
 }
 
@@ -1294,12 +1302,12 @@ template<class ElementType_A,
          class Layout_C,
          class Accessor_C>
 void triangular_matrix_right_product(
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t,
   DiagonalStorage d ,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
 {
-  triangular_matrix_right_product(std::experimental::linalg::impl::default_exec_t(), A, t, d, C);
+  triangular_matrix_right_product(impl::default_exec_t{}, A, t, d, C);
 }
 
 
@@ -1319,11 +1327,11 @@ template<class ElementType_A,
          class Layout_C,
          class Accessor_C>
 void symmetric_matrix_left_product(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  impl::inline_exec_t&& /* exec */,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle /* t */,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
+  mdspan<ElementType_B, extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
 {
   using size_type = ::std::common_type_t<SizeType_A, SizeType_B, SizeType_C>;
 
@@ -1367,18 +1375,20 @@ template<class ExecutionPolicy,
          class Accessor_C>
 void symmetric_matrix_left_product(
   ExecutionPolicy&& exec,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
+  mdspan<ElementType_B, extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
 {
   constexpr bool use_custom = is_custom_sym_matrix_left_product_avail<
-    decltype(execpolicy_mapper(exec)), decltype(A), Triangle, decltype(B), decltype(C)>::value;
+    decltype(execpolicy_mapper(exec)),
+    decltype(A), Triangle, decltype(B), decltype(C)>::value;
 
-  if constexpr(use_custom) {
+  if constexpr (use_custom) {
     symmetric_matrix_left_product(execpolicy_mapper(exec), A, t, B, C);
-  } else {
-    symmetric_matrix_left_product(std::experimental::linalg::impl::inline_exec_t(), A, t, B, C);
+  }
+  else {
+    symmetric_matrix_left_product(impl::inline_exec_t{}, A, t, B, C);
   }
 }
 
@@ -1396,12 +1406,12 @@ template<class ElementType_A,
          class Layout_C,
          class Accessor_C>
 void symmetric_matrix_left_product(
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
+  mdspan<ElementType_B, extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
 {
-  symmetric_matrix_left_product(std::experimental::linalg::impl::default_exec_t(), A, t, B, C);
+  symmetric_matrix_left_product(impl::default_exec_t{}, A, t, B, C);
 }
 
 
@@ -1421,11 +1431,11 @@ template<class ElementType_A,
          class Layout_C,
          class Accessor_C>
 void symmetric_matrix_right_product(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  impl::inline_exec_t&& /* exec */,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle /* t */,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
+  mdspan<ElementType_B, extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
 {
   using size_type = ::std::common_type_t<SizeType_A, SizeType_B, SizeType_C>;
 
@@ -1469,18 +1479,20 @@ template<class ExecutionPolicy,
          class Accessor_C>
 void symmetric_matrix_right_product(
   ExecutionPolicy&& exec ,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
+  mdspan<ElementType_B, extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
 {
   constexpr bool use_custom = is_custom_sym_matrix_right_product_avail<
-    decltype(execpolicy_mapper(exec)), decltype(A), Triangle, decltype(B), decltype(C)>::value;
+    decltype(execpolicy_mapper(exec)),
+    decltype(A), Triangle, decltype(B), decltype(C)>::value;
 
-  if constexpr(use_custom) {
+  if constexpr (use_custom) {
     symmetric_matrix_right_product(execpolicy_mapper(exec), A, t, B, C);
-  } else {
-    symmetric_matrix_right_product(std::experimental::linalg::impl::inline_exec_t(), A, t, B, C);
+  }
+  else {
+    symmetric_matrix_right_product(impl::inline_exec_t{}, A, t, B, C);
   }
 }
 
@@ -1498,12 +1510,12 @@ template<class ElementType_A,
          class Layout_C,
          class Accessor_C>
 void symmetric_matrix_right_product(
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t ,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
+  mdspan<ElementType_B, extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
 {
-  symmetric_matrix_right_product(std::experimental::linalg::impl::default_exec_t(), A, t, B, C);
+  symmetric_matrix_right_product(impl::default_exec_t{}, A, t, B, C);
 }
 
 
@@ -1527,12 +1539,12 @@ template<class ElementType_A,
          class Layout_C,
          class Accessor_C>
 void symmetric_matrix_left_product(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  impl::inline_exec_t&& /* exec */,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle /* t */,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
-  std::experimental::mdspan<ElementType_E, std::experimental::extents<SizeType_E, numRows_E, numCols_E>, Layout_E, Accessor_E> E,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
+  mdspan<ElementType_B, extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_E, extents<SizeType_E, numRows_E, numCols_E>, Layout_E, Accessor_E> E,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
 {
   assert(false);
 }
@@ -1557,19 +1569,20 @@ template<class ExecutionPolicy,
          class Accessor_C>
 void symmetric_matrix_left_product(
   ExecutionPolicy&& exec,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
-  std::experimental::mdspan<ElementType_E, std::experimental::extents<SizeType_E, numRows_E, numCols_E>, Layout_E, Accessor_E> E,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
+  mdspan<ElementType_B, extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_E, extents<SizeType_E, numRows_E, numCols_E>, Layout_E, Accessor_E> E,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
 {
   constexpr bool use_custom = is_custom_sym_matrix_left_product_with_update_avail<
     decltype(execpolicy_mapper(exec)), decltype(A), Triangle, decltype(B), decltype(E), decltype(C)>::value;
 
-  if constexpr(use_custom) {
+  if constexpr (use_custom) {
     symmetric_matrix_left_product(execpolicy_mapper(exec), A, t, B, E, C);
-  } else {
-    symmetric_matrix_left_product(std::experimental::linalg::impl::inline_exec_t(), A, t, B, E, C);
+  }
+  else {
+    symmetric_matrix_left_product(impl::inline_exec_t{}, A, t, B, E, C);
   }
 }
 
@@ -1591,13 +1604,13 @@ template<class ElementType_A,
          class Layout_C,
          class Accessor_C>
 void symmetric_matrix_left_product(
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t ,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
-  std::experimental::mdspan<ElementType_E, std::experimental::extents<SizeType_E, numRows_E, numCols_E>, Layout_E, Accessor_E> E,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
+  mdspan<ElementType_B, extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_E, extents<SizeType_E, numRows_E, numCols_E>, Layout_E, Accessor_E> E,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
 {
-  symmetric_matrix_left_product(std::experimental::linalg::impl::default_exec_t(), A, t, B, E, C);
+  symmetric_matrix_left_product(impl::default_exec_t{}, A, t, B, E, C);
 }
 
 
@@ -1621,12 +1634,12 @@ template<class ElementType_A,
          class Layout_C,
          class Accessor_C>
 void symmetric_matrix_right_product(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  impl::inline_exec_t&& /* exec */,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle /* t */,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
-  std::experimental::mdspan<ElementType_E, std::experimental::extents<SizeType_E, numRows_E, numCols_E>, Layout_E, Accessor_E> E,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
+  mdspan<ElementType_B, extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_E, extents<SizeType_E, numRows_E, numCols_E>, Layout_E, Accessor_E> E,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
 {
   assert(false);
 }
@@ -1651,19 +1664,20 @@ template<class ExecutionPolicy,
          class Accessor_C>
 void symmetric_matrix_right_product(
   ExecutionPolicy&& exec ,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
-  std::experimental::mdspan<ElementType_E, std::experimental::extents<SizeType_E, numRows_E, numCols_E>, Layout_E, Accessor_E> E,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
+  mdspan<ElementType_B, extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_E, extents<SizeType_E, numRows_E, numCols_E>, Layout_E, Accessor_E> E,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
 {
   constexpr bool use_custom = is_custom_sym_matrix_right_product_with_update_avail<
     decltype(execpolicy_mapper(exec)), decltype(A), Triangle, decltype(B), decltype(E), decltype(C)>::value;
 
-  if constexpr(use_custom) {
+  if constexpr (use_custom) {
     symmetric_matrix_right_product(execpolicy_mapper(exec), A, t, B, E, C);
-  } else {
-    symmetric_matrix_right_product(std::experimental::linalg::impl::inline_exec_t(), A, t, B, E, C);
+  }
+  else {
+    symmetric_matrix_right_product(impl::inline_exec_t{}, A, t, B, E, C);
   }
 }
 
@@ -1685,13 +1699,13 @@ template<class ElementType_A,
          class Layout_C,
          class Accessor_C>
 void symmetric_matrix_right_product(
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
-  std::experimental::mdspan<ElementType_E, std::experimental::extents<SizeType_E, numRows_E, numCols_E>, Layout_E, Accessor_E> E,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
+  mdspan<ElementType_B, extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_E, extents<SizeType_E, numRows_E, numCols_E>, Layout_E, Accessor_E> E,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
 {
-  symmetric_matrix_right_product(std::experimental::linalg::impl::default_exec_t(), A, t, B, E, C);
+  symmetric_matrix_right_product(impl::default_exec_t{}, A, t, B, E, C);
 }
 
 
@@ -1711,11 +1725,11 @@ template<class ElementType_A,
          class Layout_C,
          class Accessor_C>
 void hermitian_matrix_left_product(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  impl::inline_exec_t&& /* exec */,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle /* t */,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
+  mdspan<ElementType_B, extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
 {
   using size_type = ::std::common_type_t<SizeType_A, SizeType_B, SizeType_C>;
 
@@ -1759,18 +1773,20 @@ template<class ExecutionPolicy,
          class Accessor_C>
 void hermitian_matrix_left_product(
   ExecutionPolicy&& exec ,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
+  mdspan<ElementType_B, extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
 {
   constexpr bool use_custom = is_custom_herm_matrix_left_product_avail<
-    decltype(execpolicy_mapper(exec)), decltype(A), Triangle, decltype(B), decltype(C)>::value;
+    decltype(execpolicy_mapper(exec)),
+    decltype(A), Triangle, decltype(B), decltype(C)>::value;
 
-  if constexpr(use_custom) {
+  if constexpr (use_custom) {
     hermitian_matrix_left_product(execpolicy_mapper(exec), A, t, B, C);
-  } else {
-    hermitian_matrix_left_product(std::experimental::linalg::impl::inline_exec_t(), A, t, B, C);
+  }
+  else {
+    hermitian_matrix_left_product(impl::inline_exec_t{}, A, t, B, C);
   }
 }
 
@@ -1788,12 +1804,12 @@ template<class ElementType_A,
          class Layout_C,
          class Accessor_C>
 void hermitian_matrix_left_product(
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t ,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
+  mdspan<ElementType_B, extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
 {
-  hermitian_matrix_left_product(std::experimental::linalg::impl::default_exec_t(), A, t, B, C);
+  hermitian_matrix_left_product(impl::default_exec_t{}, A, t, B, C);
 }
 
 // Overwriting Hermitian matrix-matrix right product
@@ -1812,11 +1828,11 @@ template<class ElementType_A,
          class Layout_C,
          class Accessor_C>
 void hermitian_matrix_right_product(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  impl::inline_exec_t&& /* exec */,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle /* t */,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
+  mdspan<ElementType_B, extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
 {
   using size_type = ::std::common_type_t<SizeType_A, SizeType_B, SizeType_C>;
 
@@ -1860,18 +1876,20 @@ template<class ExecutionPolicy,
          class Accessor_C>
 void hermitian_matrix_right_product(
   ExecutionPolicy&& exec ,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
+  mdspan<ElementType_B, extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
 {
   constexpr bool use_custom = is_custom_herm_matrix_right_product_avail<
-    decltype(execpolicy_mapper(exec)), decltype(A), Triangle, decltype(B), decltype(C)>::value;
+    decltype(execpolicy_mapper(exec)),
+    decltype(A), Triangle, decltype(B), decltype(C)>::value;
 
-  if constexpr(use_custom) {
+  if constexpr (use_custom) {
     hermitian_matrix_right_product(execpolicy_mapper(exec), A, t, B, C);
-  } else {
-    hermitian_matrix_right_product(std::experimental::linalg::impl::inline_exec_t(), A, t, B, C);
+  }
+  else {
+    hermitian_matrix_right_product(impl::inline_exec_t{}, A, t, B, C);
   }
 }
 
@@ -1889,12 +1907,12 @@ template<class ElementType_A,
          class Layout_C,
          class Accessor_C>
 void hermitian_matrix_right_product(
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t ,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
+  mdspan<ElementType_B, extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
 {
-  hermitian_matrix_right_product(std::experimental::linalg::impl::default_exec_t(), A, t, B, C);
+  hermitian_matrix_right_product(impl::default_exec_t{}, A, t, B, C);
 }
 
 
@@ -1918,12 +1936,12 @@ template<class ElementType_A,
          class Layout_C,
          class Accessor_C>
 void hermitian_matrix_left_product(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  impl::inline_exec_t&& /* exec */,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle /* t */,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
-  std::experimental::mdspan<ElementType_E, std::experimental::extents<SizeType_E, numRows_E, numCols_E>, Layout_E, Accessor_E> E,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
+  mdspan<ElementType_B, extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_E, extents<SizeType_E, numRows_E, numCols_E>, Layout_E, Accessor_E> E,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
 {
   assert(false);
 }
@@ -1948,19 +1966,20 @@ template<class ExecutionPolicy,
          class Accessor_C>
 void hermitian_matrix_left_product(
   ExecutionPolicy&& exec ,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
-  std::experimental::mdspan<ElementType_E, std::experimental::extents<SizeType_E, numRows_E, numCols_E>, Layout_E, Accessor_E> E,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
+  mdspan<ElementType_B, extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_E, extents<SizeType_E, numRows_E, numCols_E>, Layout_E, Accessor_E> E,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
 {
   constexpr bool use_custom = is_custom_herm_matrix_left_product_with_update_avail<
     decltype(execpolicy_mapper(exec)), decltype(A), Triangle, decltype(B), decltype(E), decltype(C)>::value;
 
-  if constexpr(use_custom) {
+  if constexpr (use_custom) {
     hermitian_matrix_left_product(execpolicy_mapper(exec), A, t, B, E, C);
-  } else {
-    hermitian_matrix_left_product(std::experimental::linalg::impl::inline_exec_t(), A, t, B, E, C);
+  }
+  else {
+    hermitian_matrix_left_product(impl::inline_exec_t{}, A, t, B, E, C);
   }
 }
 
@@ -1982,13 +2001,13 @@ template<class ElementType_A,
          class Layout_C,
          class Accessor_C>
 void hermitian_matrix_left_product(
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t ,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
-  std::experimental::mdspan<ElementType_E, std::experimental::extents<SizeType_E, numRows_E, numCols_E>, Layout_E, Accessor_E> E,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
+  mdspan<ElementType_B, extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_E, extents<SizeType_E, numRows_E, numCols_E>, Layout_E, Accessor_E> E,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
 {
-  hermitian_matrix_left_product(std::experimental::linalg::impl::default_exec_t(), A, t, B, E, C);
+  hermitian_matrix_left_product(impl::default_exec_t{}, A, t, B, E, C);
 }
 
 
@@ -2012,12 +2031,12 @@ template<class ElementType_A,
          class Layout_C,
          class Accessor_C>
 void hermitian_matrix_right_product(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  impl::inline_exec_t&& /* exec */,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle /* t */,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
-  std::experimental::mdspan<ElementType_E, std::experimental::extents<SizeType_E, numRows_E, numCols_E>, Layout_E, Accessor_E> E,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
+  mdspan<ElementType_B, extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_E, extents<SizeType_E, numRows_E, numCols_E>, Layout_E, Accessor_E> E,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
 {
   assert(false);
 }
@@ -2042,19 +2061,20 @@ template<class ExecutionPolicy,
          class Accessor_C>
 void hermitian_matrix_right_product(
   ExecutionPolicy&& exec ,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
-  std::experimental::mdspan<ElementType_E, std::experimental::extents<SizeType_E, numRows_E, numCols_E>, Layout_E, Accessor_E> E,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
+  mdspan<ElementType_B, extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_E, extents<SizeType_E, numRows_E, numCols_E>, Layout_E, Accessor_E> E,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
 {
   constexpr bool use_custom = is_custom_herm_matrix_right_product_with_update_avail<
     decltype(execpolicy_mapper(exec)), decltype(A), Triangle, decltype(B), decltype(E), decltype(C)>::value;
 
-  if constexpr(use_custom) {
+  if constexpr (use_custom) {
     hermitian_matrix_right_product(execpolicy_mapper(exec), A, t, B, E, C);
-  } else {
-    hermitian_matrix_right_product(std::experimental::linalg::impl::inline_exec_t(), A, t, B, E, C);
+  }
+  else {
+    hermitian_matrix_right_product(impl::inline_exec_t{}, A, t, B, E, C);
   }
 }
 
@@ -2076,13 +2096,13 @@ template<class ElementType_A,
          class Layout_C,
          class Accessor_C>
 void hermitian_matrix_right_product(
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
   Triangle t ,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
-  std::experimental::mdspan<ElementType_E, std::experimental::extents<SizeType_E, numRows_E, numCols_E>, Layout_E, Accessor_E> E,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
+  mdspan<ElementType_B, extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_E, extents<SizeType_E, numRows_E, numCols_E>, Layout_E, Accessor_E> E,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
 {
-  hermitian_matrix_right_product(std::experimental::linalg::impl::default_exec_t(), A, t, B, E, C);
+  hermitian_matrix_right_product(impl::default_exec_t{}, A, t, B, E, C);
 }
 
 template <class Exec, class A_t, class B_t, class C_t>
@@ -2091,34 +2111,34 @@ struct is_custom_matrix_product_avail<
   std::enable_if_t<
     std::is_void_v<
       decltype(
-	      matrix_product(
+        matrix_product(
           std::declval<Exec>(),
           std::declval<A_t>(),
-		      std::declval<B_t>(),
-		      std::declval<C_t>()))
+          std::declval<B_t>(),
+          std::declval<C_t>()))
       >
-    && !std::is_same_v< // see #218
+    && ! std::is_same_v< // see #218
       decltype(
-        std::experimental::linalg::matrix_product(
+        :: MDSPAN_IMPL_STANDARD_NAMESPACE :: MDSPAN_IMPL_PROPOSED_NAMESPACE :: linalg::matrix_product(
           std::declval<Exec>(),
           std::declval<A_t>(),
-		      std::declval<B_t>(),
-		      std::declval<C_t>())),
+          std::declval<B_t>(),
+          std::declval<C_t>())),
       decltype(
         matrix_product(
           std::declval<Exec>(),
           std::declval<A_t>(),
-		      std::declval<B_t>(),
-		      std::declval<C_t>()))
+          std::declval<B_t>(),
+          std::declval<C_t>()))
       >
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! impl::is_inline_exec_v<Exec>
     >
   >
   : std::true_type{};
 
 } // end namespace linalg
 } // end inline namespace __p1673_version_0
-} // end namespace experimental
-} // end namespace std
+} // end namespace MDSPAN_IMPL_PROPOSED_NAMESPACE
+} // end namespace MDSPAN_IMPL_STANDARD_NAMESPACE
 
 #endif //LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_BLAS3_MATRIX_PRODUCT_HPP_

--- a/include/experimental/__p1673_bits/blas3_matrix_product.hpp
+++ b/include/experimental/__p1673_bits/blas3_matrix_product.hpp
@@ -190,10 +190,10 @@ constexpr bool valid_input_blas_accessor()
   using acc_type = typename in_matrix_t::accessor_type;
 
   using def_acc_type = default_accessor<elt_type>;
-  using conj_def_acc_type = accessor_conjugate<def_acc_type>;
+  using conj_def_acc_type = conjugated_accessor<def_acc_type>;
   using scal_def_acc_type = accessor_scaled<val_type, def_acc_type>;
   using scal_conj_acc_type = accessor_scaled<val_type, conj_def_acc_type>;
-  using conj_scal_acc_type = accessor_conjugate<scal_def_acc_type>;
+  using conj_scal_acc_type = conjugated_accessor<scal_def_acc_type>;
 
   // The two matrices' accessor types need not be the same.
   // Input matrices may be scaled or transposed.
@@ -296,10 +296,10 @@ static constexpr bool is_compatible_accessor_scaled_v<
     std::is_same_v<typename accessor_scaled<ScalingFactor, NestedAccessor>::value_type, ValueType>;
 
 template<class Accessor>
-static constexpr bool is_accessor_conjugate_v = false;
+static constexpr bool is_conjugated_accessor_v = false;
 
 template<class NestedAccessor>
-static constexpr bool is_accessor_conjugate_v<accessor_conjugate<NestedAccessor>> = true;
+static constexpr bool is_conjugated_accessor_v<conjugated_accessor<NestedAccessor>> = true;
 
 template<class in_matrix_t>
 typename in_matrix_t::value_type
@@ -311,7 +311,7 @@ extractScalingFactor(in_matrix_t A,
 
   if constexpr (is_compatible_accessor_scaled_v<acc_t, val_t>) {
     return A.accessor.scale_factor();
-  } else if constexpr (is_accessor_conjugate_v<acc_t>) {
+  } else if constexpr (is_conjugated_accessor_v<acc_t>) {
     // conjugated(scaled(alpha, A)) means that both alpha and A are conjugated.
     using nested_acc_t = decltype(A.accessor().nested_accessor());
     if constexpr (is_compatible_accessor_scaled_v<nested_acc_t>) {
@@ -344,7 +344,7 @@ constexpr bool extractConjImpl(Accessor a)
   using elt_t = typename Accessor::element_type;
 
   using def_acc_t = default_accessor<elt_t>;
-  using conj_def_acc_t = accessor_conjugate<def_acc_t>;
+  using conj_def_acc_t = conjugated_accessor<def_acc_t>;
   if constexpr (std::is_same_v<Accessor, def_acc_t>) {
     return false;
   } else if constexpr (std::is_same_v<Accessor, conj_def_acc_t>) {

--- a/include/experimental/__p1673_bits/blas3_matrix_rank_2k_update.hpp
+++ b/include/experimental/__p1673_bits/blas3_matrix_rank_2k_update.hpp
@@ -43,8 +43,8 @@
 #ifndef LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_BLAS3_MATRIX_RANK_2K_UPDATE_HPP_
 #define LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_BLAS3_MATRIX_RANK_2K_UPDATE_HPP_
 
-namespace std {
-namespace experimental {
+namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
+namespace MDSPAN_IMPL_PROPOSED_NAMESPACE {
 inline namespace __p1673_version_0 {
 namespace linalg {
 
@@ -64,7 +64,7 @@ struct is_custom_sym_mat_rank_2k_update_avail<
 					       std::declval<C_t>(),
 					       std::declval<Tr_t>()))
       >
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! impl::is_inline_exec_v<Exec>
     >
   >
   : std::true_type{};
@@ -83,7 +83,7 @@ struct is_custom_herm_mat_rank_2k_update_avail<
 					       std::declval<C_t>(),
 					       std::declval<Tr_t>()))
       >
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! impl::is_inline_exec_v<Exec>
     >
   >
   : std::true_type{};
@@ -106,10 +106,10 @@ template<class ElementType_A,
          class Accessor_C,
          class Triangle>
 void symmetric_matrix_rank_2k_update(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C,
+  impl::inline_exec_t&& /* exec */,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_B, extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C,
   Triangle /* t */)
 {
   constexpr bool lower_tri =
@@ -143,19 +143,20 @@ template<class ExecutionPolicy,
          class Triangle>
 void symmetric_matrix_rank_2k_update(
   ExecutionPolicy&& exec ,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_B, extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C,
   Triangle t)
 {
   constexpr bool use_custom = is_custom_sym_mat_rank_2k_update_avail<
     decltype(execpolicy_mapper(exec)), decltype(A), decltype(B), decltype(C), Triangle
     >::value;
 
-  if constexpr(use_custom) {
+  if constexpr (use_custom) {
     symmetric_matrix_rank_2k_update(execpolicy_mapper(exec), A, B, C, t);
-  } else {
-    symmetric_matrix_rank_2k_update(std::experimental::linalg::impl::inline_exec_t(), A, B, C, t);
+  }
+  else {
+    symmetric_matrix_rank_2k_update(impl::inline_exec_t{}, A, B, C, t);
   }
 }
 
@@ -173,12 +174,12 @@ template<class ElementType_A,
          class Accessor_C,
          class Triangle>
 void symmetric_matrix_rank_2k_update(
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_B, extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C,
   Triangle t )
 {
-  symmetric_matrix_rank_2k_update(std::experimental::linalg::impl::default_exec_t(), A, B, C, t);
+  symmetric_matrix_rank_2k_update(impl::default_exec_t{}, A, B, C, t);
 }
 
 
@@ -198,10 +199,10 @@ template<class ElementType_A,
          class Accessor_C,
          class Triangle>
 void hermitian_matrix_rank_2k_update(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C,
+  impl::inline_exec_t&& /* exec */,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_B, extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C,
   Triangle /* t */)
 {
   constexpr bool lower_tri =
@@ -235,19 +236,20 @@ template<class ExecutionPolicy,
          class Triangle>
 void hermitian_matrix_rank_2k_update(
   ExecutionPolicy&& exec,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_B, extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C,
   Triangle t)
 {
   constexpr bool use_custom = is_custom_herm_mat_rank_2k_update_avail<
     decltype(execpolicy_mapper(exec)), decltype(A), decltype(B), decltype(C), Triangle
     >::value;
 
-  if constexpr(use_custom) {
+  if constexpr (use_custom) {
     hermitian_matrix_rank_2k_update(execpolicy_mapper(exec), A, B, C, t);
-  } else {
-    hermitian_matrix_rank_2k_update(std::experimental::linalg::impl::inline_exec_t(), A, B, C, t);
+  }
+  else {
+    hermitian_matrix_rank_2k_update(impl::inline_exec_t{}, A, B, C, t);
   }
 }
 
@@ -265,17 +267,17 @@ template<class ElementType_A,
          class Accessor_C,
          class Triangle>
 void hermitian_matrix_rank_2k_update(
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
-  std::experimental::mdspan<ElementType_B, std::experimental::extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_B, extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C,
   Triangle t )
 {
-  hermitian_matrix_rank_2k_update(std::experimental::linalg::impl::default_exec_t(), A, B, C, t);
+  hermitian_matrix_rank_2k_update(impl::default_exec_t{}, A, B, C, t);
 }
 
 } // end namespace linalg
 } // end inline namespace __p1673_version_0
-} // end namespace experimental
-} // end namespace std
+} // end namespace MDSPAN_IMPL_PROPOSED_NAMESPACE
+} // end namespace MDSPAN_IMPL_STANDARD_NAMESPACE
 
 #endif //LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_BLAS3_MATRIX_RANK_2K_UPDATE_HPP_

--- a/include/experimental/__p1673_bits/blas3_matrix_rank_k_update.hpp
+++ b/include/experimental/__p1673_bits/blas3_matrix_rank_k_update.hpp
@@ -43,8 +43,8 @@
 #ifndef LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_BLAS3_MATRIX_RANK_K_UPDATE_HPP_
 #define LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_BLAS3_MATRIX_RANK_K_UPDATE_HPP_
 
-namespace std {
-namespace experimental {
+namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
+namespace MDSPAN_IMPL_PROPOSED_NAMESPACE {
 inline namespace __p1673_version_0 {
 namespace linalg {
 
@@ -64,7 +64,7 @@ struct is_custom_sym_mat_rank_k_update_avail<
 					      std::declval<C_t>(),
 					      std::declval<Tr_t>()))
       >
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! impl::is_inline_exec_v<Exec>
     >
   >
   : std::true_type{};
@@ -80,7 +80,7 @@ struct is_custom_sym_mat_rank_k_update_avail<
 					      std::declval<C_t>(),
 					      std::declval<Tr_t>()))
       >
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! impl::is_inline_exec_v<Exec>
     >
   >
   : std::true_type{};
@@ -99,7 +99,7 @@ struct is_custom_herm_mat_rank_k_update_avail<
 					      std::declval<C_t>(),
 					      std::declval<Tr_t>()))
       >
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! impl::is_inline_exec_v<Exec>
     >
   >
   : std::true_type{};
@@ -115,7 +115,7 @@ struct is_custom_herm_mat_rank_k_update_avail<
 					      std::declval<C_t>(),
 					      std::declval<Tr_t>()))
       >
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! impl::is_inline_exec_v<Exec>
     >
   >
   : std::true_type{};
@@ -141,10 +141,10 @@ MDSPAN_TEMPLATE_REQUIRES(
   )
 )
 void symmetric_matrix_rank_k_update(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
+  impl::inline_exec_t&& /* exec */,
   ScaleFactorType alpha,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C,
   Triangle /* t */)
 {
   using size_type = std::common_type_t<SizeType_A, SizeType_C>;
@@ -200,18 +200,19 @@ MDSPAN_TEMPLATE_REQUIRES(
 void symmetric_matrix_rank_k_update(
   ExecutionPolicy&& exec,
   ScaleFactorType alpha,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C,
   Triangle t)
 {
   constexpr bool use_custom = is_custom_sym_mat_rank_k_update_avail<
-    decltype(execpolicy_mapper(exec)), ScaleFactorType, decltype(A), decltype(C), Triangle
-    >::value;
+    decltype(execpolicy_mapper(exec)),
+    ScaleFactorType, decltype(A), decltype(C), Triangle>::value;
 
   if constexpr (use_custom) {
     symmetric_matrix_rank_k_update(execpolicy_mapper(exec), alpha, A, C, t);
-  } else {
-    symmetric_matrix_rank_k_update(std::experimental::linalg::impl::inline_exec_t(), alpha, A, C, t);
+  }
+  else {
+    symmetric_matrix_rank_k_update(impl::inline_exec_t{}, alpha, A, C, t);
   }
 }
 
@@ -234,11 +235,11 @@ MDSPAN_TEMPLATE_REQUIRES(
 )
 void symmetric_matrix_rank_k_update(
   ScaleFactorType alpha,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C,
   Triangle t)
 {
-  symmetric_matrix_rank_k_update(std::experimental::linalg::impl::default_exec_t(), alpha, A, C, t);
+  symmetric_matrix_rank_k_update(impl::default_exec_t{}, alpha, A, C, t);
 }
 
 // Rank-k update of a symmetric matrix without scaling factor alpha
@@ -259,9 +260,9 @@ MDSPAN_TEMPLATE_REQUIRES(
   )
 )
 void symmetric_matrix_rank_k_update(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C,
+  impl::inline_exec_t&& /* exec */,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C,
   Triangle /* t */)
 {
   using size_type = std::common_type_t<SizeType_A, SizeType_C>;
@@ -315,18 +316,19 @@ MDSPAN_TEMPLATE_REQUIRES(
 )
 void symmetric_matrix_rank_k_update(
   ExecutionPolicy&& exec,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C,
   Triangle t)
 {
   constexpr bool use_custom = is_custom_sym_mat_rank_k_update_avail<
     decltype(execpolicy_mapper(exec)), void, decltype(A), decltype(C), Triangle
     >::value;
 
-  if constexpr(use_custom) {
+  if constexpr (use_custom) {
     symmetric_matrix_rank_k_update(execpolicy_mapper(exec), A, C, t);
-  } else {
-    symmetric_matrix_rank_k_update(std::experimental::linalg::impl::inline_exec_t(), A, C, t);
+  }
+  else {
+    symmetric_matrix_rank_k_update(impl::inline_exec_t{}, A, C, t);
   }
 }
 
@@ -346,11 +348,11 @@ MDSPAN_TEMPLATE_REQUIRES(
   )
 )
 void symmetric_matrix_rank_k_update(
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C,
   Triangle t)
 {
-  symmetric_matrix_rank_k_update(std::experimental::linalg::impl::default_exec_t(), A, C, t);
+  symmetric_matrix_rank_k_update(impl::default_exec_t{}, A, C, t);
 }
 
 // Rank-k update of a Hermitian matrix
@@ -374,10 +376,10 @@ MDSPAN_TEMPLATE_REQUIRES(
   )
 )
 void hermitian_matrix_rank_k_update(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
+  impl::inline_exec_t&& /* exec */,
   ScaleFactorType alpha,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C,
   Triangle /* t */)
 {
   using size_type = std::common_type_t<SizeType_A, SizeType_C>;
@@ -433,18 +435,19 @@ MDSPAN_TEMPLATE_REQUIRES(
 void hermitian_matrix_rank_k_update(
   ExecutionPolicy&& exec,
   ScaleFactorType alpha,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C,
   Triangle t)
 {
   constexpr bool use_custom = is_custom_herm_mat_rank_k_update_avail<
-    decltype(execpolicy_mapper(exec)), ScaleFactorType, decltype(A), decltype(C), Triangle
-    >::value;
+    decltype(execpolicy_mapper(exec)),
+    ScaleFactorType, decltype(A), decltype(C), Triangle>::value;
 
-  if constexpr(use_custom) {
+  if constexpr (use_custom) {
     hermitian_matrix_rank_k_update(execpolicy_mapper(exec), alpha, A, C, t);
-  } else {
-    hermitian_matrix_rank_k_update(std::experimental::linalg::impl::inline_exec_t(), alpha, A, C, t);
+  }
+  else {
+    hermitian_matrix_rank_k_update(impl::inline_exec_t{}, alpha, A, C, t);
   }
 }
 
@@ -467,11 +470,11 @@ MDSPAN_TEMPLATE_REQUIRES(
 )
 void hermitian_matrix_rank_k_update(
   ScaleFactorType alpha,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C,
   Triangle t)
 {
-  hermitian_matrix_rank_k_update(std::experimental::linalg::impl::default_exec_t(), alpha, A, C, t);
+  hermitian_matrix_rank_k_update(impl::default_exec_t{}, alpha, A, C, t);
 }
 
 // Rank-k update of a Hermitian matrix without scaling factor alpha
@@ -492,9 +495,9 @@ MDSPAN_TEMPLATE_REQUIRES(
   )
 )
 void hermitian_matrix_rank_k_update(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C,
+  impl::inline_exec_t&& /* exec */,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C,
   Triangle /* t */)
 {
   using size_type = std::common_type_t<SizeType_A, SizeType_C>;
@@ -548,18 +551,19 @@ MDSPAN_TEMPLATE_REQUIRES(
 )
 void hermitian_matrix_rank_k_update(
   ExecutionPolicy&& exec,
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C,
   Triangle t)
 {
   constexpr bool use_custom = is_custom_herm_mat_rank_k_update_avail<
-    decltype(execpolicy_mapper(exec)), void, decltype(A), decltype(C), Triangle
-    >::value;
+    decltype(execpolicy_mapper(exec)),
+    void, decltype(A), decltype(C), Triangle>::value;
 
-  if constexpr(use_custom) {
+  if constexpr (use_custom) {
     hermitian_matrix_rank_k_update(execpolicy_mapper(exec), A, C, t);
-  } else {
-    hermitian_matrix_rank_k_update(std::experimental::linalg::impl::inline_exec_t(), A, C, t);
+  }
+  else {
+    hermitian_matrix_rank_k_update(impl::inline_exec_t{}, A, C, t);
   }
 }
 
@@ -579,16 +583,16 @@ MDSPAN_TEMPLATE_REQUIRES(
   )
 )
 void hermitian_matrix_rank_k_update(
-  std::experimental::mdspan<ElementType_A, std::experimental::extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
-  std::experimental::mdspan<ElementType_C, std::experimental::extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C,
   Triangle t)
 {
-  hermitian_matrix_rank_k_update(std::experimental::linalg::impl::default_exec_t(), A, C, t);
+  hermitian_matrix_rank_k_update(impl::default_exec_t{}, A, C, t);
 }
 
 } // end namespace linalg
 } // end inline namespace __p1673_version_0
-} // end namespace experimental
-} // end namespace std
+} // end namespace MDSPAN_IMPL_PROPOSED_NAMESPACE
+} // end namespace MDSPAN_IMPL_STANDARD_NAMESPACE
 
 #endif //LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_BLAS3_MATRIX_RANK_K_UPDATE_HPP_

--- a/include/experimental/__p1673_bits/blas3_triangular_matrix_matrix_solve.hpp
+++ b/include/experimental/__p1673_bits/blas3_triangular_matrix_matrix_solve.hpp
@@ -43,8 +43,8 @@
 #ifndef LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_BLAS3_TRIANGULAR_MATRIX_MATRIX_SOLVE_HPP_
 #define LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_BLAS3_TRIANGULAR_MATRIX_MATRIX_SOLVE_HPP_
 
-namespace std {
-namespace experimental {
+namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
+namespace MDSPAN_IMPL_PROPOSED_NAMESPACE {
 inline namespace __p1673_version_0 {
 namespace linalg {
 
@@ -223,7 +223,7 @@ struct is_custom_tri_matrix_matrix_left_solve_avail<
 		)
 	       )
       >
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! impl::is_inline_exec_v<Exec>
     >
   >
   : std::true_type{};
@@ -246,7 +246,7 @@ struct is_custom_tri_matrix_matrix_right_solve_avail<
 		)
 	       )
       >
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! impl::is_inline_exec_v<Exec>
     >
   >
   : std::true_type{};
@@ -270,7 +270,7 @@ struct is_custom_tri_matrix_matrix_solve_avail<
 		)
 	       )
       >
-    && !linalg::impl::is_inline_exec_v<Exec>
+    && ! impl::is_inline_exec_v<Exec>
     >
   >
   : std::true_type{};
@@ -287,7 +287,7 @@ template<
   P1673_MATRIX_TEMPLATE_PARAMETERS( X )
 >
 void triangular_matrix_matrix_left_solve(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
+  impl::inline_exec_t&& /* exec */,
   P1673_MATRIX_PARAMETER( A ),
   Triangle /* t */,
   DiagonalStorage d,
@@ -319,12 +319,14 @@ void triangular_matrix_matrix_left_solve(
   P1673_MATRIX_PARAMETER( X ))
 {
   constexpr bool use_custom = is_custom_tri_matrix_matrix_left_solve_avail<
-    decltype(execpolicy_mapper(exec)), decltype(A), Triangle, DiagonalStorage, decltype(B), decltype(X)>::value;
+    decltype(execpolicy_mapper(exec)),
+    decltype(A), Triangle, DiagonalStorage, decltype(B), decltype(X)>::value;
 
-  if constexpr(use_custom) {
+  if constexpr (use_custom) {
     triangular_matrix_matrix_left_solve(execpolicy_mapper(exec), A, t, d, B, X);
-  } else {
-    triangular_matrix_matrix_left_solve(std::experimental::linalg::impl::inline_exec_t(), A, t, d, B, X);
+  }
+  else {
+    triangular_matrix_matrix_left_solve(impl::inline_exec_t{}, A, t, d, B, X);
   }
 }
 
@@ -342,7 +344,7 @@ void triangular_matrix_matrix_left_solve(
   P1673_MATRIX_PARAMETER( B ),
   P1673_MATRIX_PARAMETER( X ))
 {
-  triangular_matrix_matrix_left_solve(std::experimental::linalg::impl::default_exec_t(), A, t, d, B, X);
+  triangular_matrix_matrix_left_solve(impl::default_exec_t{}, A, t, d, B, X);
 }
 
 // triangular_matrix_matrix_right_solve
@@ -355,7 +357,7 @@ template<
   P1673_MATRIX_TEMPLATE_PARAMETERS( X )
 >
 void triangular_matrix_matrix_right_solve(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
+  impl::inline_exec_t&& /* exec */,
   P1673_MATRIX_PARAMETER( A ),
   Triangle /* t */,
   DiagonalStorage d,
@@ -387,12 +389,14 @@ void triangular_matrix_matrix_right_solve(
   P1673_MATRIX_PARAMETER( X ))
 {
   constexpr bool use_custom = is_custom_tri_matrix_matrix_right_solve_avail<
-    decltype(execpolicy_mapper(exec)), decltype(A), Triangle, DiagonalStorage, decltype(B), decltype(X)>::value;
+    decltype(execpolicy_mapper(exec)),
+    decltype(A), Triangle, DiagonalStorage, decltype(B), decltype(X)>::value;
 
-  if constexpr(use_custom) {
+  if constexpr (use_custom) {
     triangular_matrix_matrix_right_solve(execpolicy_mapper(exec), A, t, d, B, X);
-  } else {
-    triangular_matrix_matrix_right_solve(std::experimental::linalg::impl::inline_exec_t(), A, t, d, B, X);
+  }
+  else {
+    triangular_matrix_matrix_right_solve(impl::inline_exec_t{}, A, t, d, B, X);
   }
 }
 
@@ -410,7 +414,7 @@ void triangular_matrix_matrix_right_solve(
   P1673_MATRIX_PARAMETER( B ),
   P1673_MATRIX_PARAMETER( X ))
 {
-  triangular_matrix_matrix_right_solve(std::experimental::linalg::impl::default_exec_t(), A, t, d, B, X);
+  triangular_matrix_matrix_right_solve(impl::default_exec_t{}, A, t, d, B, X);
 }
 
 // triangular_matrix_matrix_solve
@@ -424,7 +428,7 @@ template<
   P1673_MATRIX_TEMPLATE_PARAMETERS( X )
 >
 void triangular_matrix_matrix_solve(
-  std::experimental::linalg::impl::inline_exec_t&& /* exec */,
+  impl::inline_exec_t&& /* exec */,
   P1673_MATRIX_PARAMETER( A ),
   Triangle t,
   DiagonalStorage d,
@@ -461,10 +465,11 @@ void triangular_matrix_matrix_solve(
   constexpr bool use_custom = is_custom_tri_matrix_matrix_solve_avail<
     decltype(execpolicy_mapper(exec)), decltype(A), Triangle, DiagonalStorage, Side, decltype(B), decltype(X)>::value;
 
-  if constexpr(use_custom) {
+  if constexpr (use_custom) {
     triangular_matrix_matrix_solve(execpolicy_mapper(exec), A, t, d, s, B, X);
-  } else {
-    triangular_matrix_matrix_solve(std::experimental::linalg::impl::inline_exec_t(), A, t, d, s, B, X);
+  }
+  else {
+    triangular_matrix_matrix_solve(impl::inline_exec_t{}, A, t, d, s, B, X);
   }
 }
 
@@ -484,13 +489,13 @@ void triangular_matrix_matrix_solve(
   P1673_MATRIX_PARAMETER( B ),
   P1673_MATRIX_PARAMETER( X ))
 {
-  triangular_matrix_matrix_solve(std::experimental::linalg::impl::default_exec_t(), A, t, d, s, B, X);
+  triangular_matrix_matrix_solve(impl::default_exec_t{}, A, t, d, s, B, X);
 }
 
 
 } // end namespace linalg
 } // end inline namespace __p1673_version_0
-} // end namespace experimental
-} // end namespace std
+} // end namespace MDSPAN_IMPL_PROPOSED_NAMESPACE
+} // end namespace MDSPAN_IMPL_STANDARD_NAMESPACE
 
 #endif //LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_BLAS3_TRIANGULAR_MATRIX_MATRIX_SOLVE_HPP_

--- a/include/experimental/__p1673_bits/conjugate_if_needed.hpp
+++ b/include/experimental/__p1673_bits/conjugate_if_needed.hpp
@@ -46,11 +46,11 @@
 #include <complex>
 #include <type_traits>
 
-namespace std {
-namespace experimental {
+namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
+namespace MDSPAN_IMPL_PROPOSED_NAMESPACE {
 inline namespace __p1673_version_0 {
 namespace linalg {
-namespace impl{
+namespace impl {
 
 template<class T> struct is_complex : std::false_type{};
 
@@ -94,7 +94,7 @@ constexpr inline auto conj_if_needed = [](const auto& t)
 } // end namespace impl
 } // end namespace linalg
 } // end inline namespace __p1673_version_0
-} // end namespace experimental
-} // end namespace std
+} // end namespace MDSPAN_IMPL_PROPOSED_NAMESPACE
+} // end namespace MDSPAN_IMPL_STANDARD_NAMESPACE
 
 #endif //LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_CONJUGATE_TRANSPOSED_HPP_

--- a/include/experimental/__p1673_bits/conjugate_transposed.hpp
+++ b/include/experimental/__p1673_bits/conjugate_transposed.hpp
@@ -46,8 +46,8 @@
 #include "conjugated.hpp"
 #include "transposed.hpp"
 
-namespace std {
-namespace experimental {
+namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
+namespace MDSPAN_IMPL_PROPOSED_NAMESPACE {
 inline namespace __p1673_version_0 {
 namespace linalg {
 
@@ -59,7 +59,7 @@ auto conjugate_transposed(mdspan<ElementType, Extents, Layout, Accessor> a)
 
 } // end namespace linalg
 } // end inline namespace __p1673_version_0
-} // end namespace experimental
-} // end namespace std
+} // end namespace MDSPAN_IMPL_PROPOSED_NAMESPACE
+} // end namespace MDSPAN_IMPL_STANDARD_NAMESPACE
 
 #endif //LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_CONJUGATE_TRANSPOSED_HPP_

--- a/include/experimental/__p1673_bits/conjugated.hpp
+++ b/include/experimental/__p1673_bits/conjugated.hpp
@@ -50,84 +50,45 @@ namespace MDSPAN_IMPL_PROPOSED_NAMESPACE {
 inline namespace __p1673_version_0 {
 namespace linalg {
 
-template<class Accessor>
-class accessor_conjugate;
-
-namespace impl {
-  template<
-    class Accessor,
-    bool is_arith =
-      std::is_arithmetic_v<
-        std::remove_cv_t<typename Accessor::element_type>
-    >
-  >
-  struct accessor_conjugate_aliases {};
-
-  template<class Accessor>
-  struct accessor_conjugate_aliases<Accessor, true>
-  {
-    using reference = typename Accessor::reference;
-    using element_type =
-      std::add_const_t<typename Accessor::element_type>;
-    using data_handle_type = typename Accessor::data_handle_type;
-    using offset_policy = typename Accessor::offset_policy;
-  };
-
-  template<class Accessor>
-  struct accessor_conjugate_aliases<Accessor, false>
-  {
-  private:
-    using accessor_value_type =
-      std::remove_cv_t<typename Accessor::element_type>;
-  public:
-     using reference =
-       conjugated_scalar<typename Accessor::reference,
-			 accessor_value_type>;
-    using element_type =
-      std::add_const_t<typename reference::value_type>;
-    using data_handle_type = typename Accessor::data_handle_type;
-    using offset_policy =
-      accessor_conjugate<typename Accessor::offset_policy>;
-  };
-
-} // namespace impl
-
-template<class Accessor>
-class accessor_conjugate {
+template<class NestedAccessor>
+class conjugated_accessor {
 private:
-  Accessor accessor_;
-  using aliases = impl::accessor_conjugate_aliases<Accessor>;
-
+  using nested_element_type = typename NestedAccessor::element_type;
+  using nc_result_type = decltype(impl::conj_if_needed(std::declval<nested_element_type>()));
 public:
-  using reference        = typename aliases::reference;
-  using element_type     = typename aliases::element_type;
-  using data_handle_type = typename aliases::data_handle_type;
-  using offset_policy    = typename aliases::offset_policy;
+  using element_type = std::add_const_t<nc_result_type>;
+  using reference = std::remove_const_t<element_type>;
+  using data_handle_type = typename NestedAccessor::data_handle_type;
+  using offset_policy =
+    conjugated_accessor<typename NestedAccessor::offset_policy>;
 
-  accessor_conjugate(Accessor accessor) : accessor_(accessor) {}
+  constexpr conjugated_accessor() = default;
+  constexpr conjugated_accessor(const NestedAccessor& acc) : nested_accessor_(acc) {}
 
   MDSPAN_TEMPLATE_REQUIRES(
-    class OtherElementType,
-    /* requires */ (std::is_convertible_v<
-      typename default_accessor<OtherElementType>::element_type(*)[],
-      typename Accessor::element_type(*)[]
-    >)
+    class OtherNestedAccessor,
+    /* requires */ (std::is_convertible_v<NestedAccessor, const OtherNestedAccessor&>)
   )
-  accessor_conjugate(default_accessor<OtherElementType> accessor) : accessor_(accessor) {}
+  constexpr conjugated_accessor(const conjugated_accessor<OtherNestedAccessor>& other)
+    : nested_accessor_(other.nested_accessor())
+  {}
 
-  reference access(data_handle_type p, ::std::size_t i) const
-    noexcept(noexcept(reference(accessor_.access(p, i))))
+  constexpr reference
+    access(data_handle_type p, ::std::size_t i) const noexcept
   {
-    return reference(accessor_.access(p, i));
+    return impl::conj_if_needed(nested_element_type(nested_accessor_.access(p, i)));
   }
 
-  typename offset_policy::data_handle_type offset(data_handle_type p, ::std::size_t i) const
-    noexcept(noexcept(accessor_.offset(p, i)))
+  constexpr typename offset_policy::data_handle_type
+    offset(data_handle_type p, ::std::size_t i) const noexcept
   {
-    return accessor_.offset(p, i);
+    return nested_accessor_.offset(p, i);
   }
 
-  Accessor nested_accessor() const { return accessor_; }
+  const NestedAccessor& nested_accessor() const noexcept { return nested_accessor_; }
+
+private:
+  NestedAccessor nested_accessor_;
 };
 
 template<class ElementType, class Extents, class Layout, class Accessor>
@@ -138,8 +99,8 @@ auto conjugated(mdspan<ElementType, Extents, Layout, Accessor> a)
       (a.data_handle(), a.mapping(), a.accessor());
   } else {
     using return_element_type =
-      typename accessor_conjugate<Accessor>::element_type;
-    using return_accessor_type = accessor_conjugate<Accessor>;
+      typename conjugated_accessor<Accessor>::element_type;
+    using return_accessor_type = conjugated_accessor<Accessor>;
     return mdspan<return_element_type, Extents, Layout, return_accessor_type>
       (a.data_handle(), a.mapping(), return_accessor_type(a.accessor()));
   }
@@ -148,7 +109,7 @@ auto conjugated(mdspan<ElementType, Extents, Layout, Accessor> a)
 // Conjugation is self-annihilating
 template<class ElementType, class Extents, class Layout, class NestedAccessor>
 auto conjugated(
-  mdspan<ElementType, Extents, Layout, accessor_conjugate<NestedAccessor>> a)
+  mdspan<ElementType, Extents, Layout, conjugated_accessor<NestedAccessor>> a)
 {
   using return_element_type = typename NestedAccessor::element_type;
   using return_accessor_type = NestedAccessor;

--- a/include/experimental/__p1673_bits/conjugated.hpp
+++ b/include/experimental/__p1673_bits/conjugated.hpp
@@ -43,10 +43,10 @@
 #ifndef LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_CONJUGATED_HPP_
 #define LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_CONJUGATED_HPP_
 
-#include <experimental/mdspan>
+#include <mdspan/mdspan.hpp>
 
-namespace std {
-namespace experimental {
+namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
+namespace MDSPAN_IMPL_PROPOSED_NAMESPACE {
 inline namespace __p1673_version_0 {
 namespace linalg {
 
@@ -158,7 +158,7 @@ auto conjugated(
 
 } // end namespace linalg
 } // end inline namespace __p1673_version_0
-} // end namespace experimental
-} // end namespace std
+} // end namespace MDSPAN_IMPL_PROPOSED_NAMESPACE
+} // end namespace MDSPAN_IMPL_STANDARD_NAMESPACE
 
 #endif //LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_CONJUGATED_HPP_

--- a/include/experimental/__p1673_bits/layout_blas_general.hpp
+++ b/include/experimental/__p1673_bits/layout_blas_general.hpp
@@ -47,8 +47,8 @@
 #include "maybe_static_size.hpp"
 #include "layout_tags.hpp"
 
-namespace std {
-namespace experimental {
+namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
+namespace MDSPAN_IMPL_PROPOSED_NAMESPACE {
 inline namespace __p1673_version_0 {
 namespace linalg {
 
@@ -97,8 +97,9 @@ public:
   // TODO noexcept specification
   // TODO throw if rhs is dynamic LDA and doesn't match static lhs
   MDSPAN_TEMPLATE_REQUIRES(
-    class OtherExtents, ::std::size_t OtherLDA, /* requires */ (
-      _MDSPAN_TRAIT(is_convertible, OtherExtents, __extents_type)
+    class OtherExtents, ::std::size_t OtherLDA,
+    /* requires */ (
+      _MDSPAN_TRAIT(std::is_convertible, OtherExtents, __extents_type)
       && (
         !__layout_blas_impl<OtherExtents, OtherLDA>::__lda_t::is_static
         || !__lda_t::is_static
@@ -118,7 +119,7 @@ public:
   MDSPAN_TEMPLATE_REQUIRES(
     class OtherExtents, ::std::size_t OtherLDA,
     /* requires */ (
-      _MDSPAN_TRAIT(is_convertible, OtherExtents, __extents_type)
+      _MDSPAN_TRAIT(std::is_convertible, OtherExtents, __extents_type)
       && (
         !__layout_blas_impl<OtherExtents, OtherLDA>::__lda_t::is_static
           || !__lda_t::is_static
@@ -201,8 +202,8 @@ class layout_blas_general<row_major_t> {
 
 } // end namespace linalg
 } // end inline namespace __p1673_version_0
-} // end namespace experimental
-} // end namespace std
+} // end namespace MDSPAN_IMPL_PROPOSED_NAMESPACE
+} // end namespace MDSPAN_IMPL_STANDARD_NAMESPACE
 
 
 #endif //LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_LAYOUT_BLAS_GENERAL_HPP_

--- a/include/experimental/__p1673_bits/layout_tags.hpp
+++ b/include/experimental/__p1673_bits/layout_tags.hpp
@@ -44,10 +44,10 @@
 #ifndef LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_LAYOUT_TAGS_HPP_
 #define LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_LAYOUT_TAGS_HPP_
 
-#include <experimental/mdspan>
+#include <mdspan/mdspan.hpp>
 
-namespace std {
-namespace experimental {
+namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
+namespace MDSPAN_IMPL_PROPOSED_NAMESPACE {
 inline namespace __p1673_version_0 {
 namespace linalg {
 
@@ -75,8 +75,8 @@ _MDSPAN_INLINE_VARIABLE constexpr auto right_side = right_side_t{};
 
 } // end namespace linalg
 } // end inline namespace __p1673_version_0
-} // end namespace experimental
-} // end namespace std
+} // end namespace MDSPAN_IMPL_PROPOSED_NAMESPACE
+} // end namespace MDSPAN_IMPL_STANDARD_NAMESPACE
 
 
 #endif //LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_LAYOUT_TAGS_HPP_

--- a/include/experimental/__p1673_bits/layout_triangle.hpp
+++ b/include/experimental/__p1673_bits/layout_triangle.hpp
@@ -49,8 +49,8 @@
 #include <type_traits>
 #include <cstdint>
 
-namespace std {
-namespace experimental {
+namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
+namespace MDSPAN_IMPL_PROPOSED_NAMESPACE {
 inline namespace __p1673_version_0 {
 namespace linalg {
 
@@ -68,7 +68,7 @@ template <
   size_t... ExtIdxs, size_t... ExtMinus2Idxs
 >
 struct __lower_triangle_layout_impl<
-  std::experimental::extents<Exts..., ExtLast, ExtLast>,
+  extents<Exts..., ExtLast, ExtLast>,
   BaseMap, LastTwoMap,
   std::integer_sequence<size_t, ExtIdxs...>,
   std::integer_sequence<size_t, ExtMinus2Idxs...>
@@ -110,7 +110,7 @@ class layout_blas_packed;
 
 } // end namespace linalg
 } // end inline namespace __p1673_version_0
-} // end namespace experimental
-} // end namespace std
+} // end namespace MDSPAN_IMPL_PROPOSED_NAMESPACE
+} // end namespace MDSPAN_IMPL_STANDARD_NAMESPACE
 
 #endif //LINALG_INCLUDE_EXPERIMENTAL_BITS_LAYOUT_TRIANGLE_HPP_

--- a/include/experimental/__p1673_bits/linalg_execpolicy_mapper.hpp
+++ b/include/experimental/__p1673_bits/linalg_execpolicy_mapper.hpp
@@ -6,8 +6,8 @@
 
 #include <type_traits>
 
-namespace std {
-namespace experimental {
+namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
+namespace MDSPAN_IMPL_PROPOSED_NAMESPACE {
 inline namespace __p1673_version_0 {
 namespace linalg {
 namespace impl {
@@ -53,20 +53,20 @@ inline constexpr bool is_linalg_execution_policy_other_than_inline_v =
 } // namespace impl
 } // namespace linalg
 } // inline namespace __p1673_version_0
-} // namespace experimental
-} // namespace std
+} // namespace MDSPAN_IMPL_PROPOSED_NAMESPACE
+} // namespace MDSPAN_IMPL_STANDARD_NAMESPACE
 
 #if defined(LINALG_ENABLE_KOKKOS)
 #include <experimental/__p1673_bits/kokkos-kernels/exec_policy_wrapper_kk.hpp>
 #endif
 
 
-namespace std {
-namespace experimental {
+namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
+namespace MDSPAN_IMPL_PROPOSED_NAMESPACE {
 inline namespace __p1673_version_0 {
 namespace linalg {
 template<class T>
-auto execpolicy_mapper(T) { return std::experimental::linalg::impl::inline_exec_t(); }
+auto execpolicy_mapper(T) { return impl::inline_exec_t(); }
 }
 }
 }

--- a/include/experimental/__p1673_bits/macros.hpp
+++ b/include/experimental/__p1673_bits/macros.hpp
@@ -55,14 +55,14 @@
     class Accessor_ ## MATRIX_NAME
 
 #define P1673_MATRIX_EXTENTS_PARAMETER( MATRIX_NAME ) \
-  ::std::experimental::extents< \
+  extents< \
     SizeType_ ## MATRIX_NAME , \
     numRows_ ## MATRIX_NAME , \
     numCols_ ## MATRIX_NAME \
   >
 
 #define P1673_MATRIX_PARAMETER( MATRIX_NAME ) \
-  ::std::experimental::mdspan< \
+  mdspan< \
     ElementType_ ## MATRIX_NAME , \
     P1673_MATRIX_EXTENTS_PARAMETER( MATRIX_NAME ), \
     Layout_ ## MATRIX_NAME , \

--- a/include/experimental/__p1673_bits/maybe_static_size.hpp
+++ b/include/experimental/__p1673_bits/maybe_static_size.hpp
@@ -43,10 +43,10 @@
 #ifndef LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_MAYBE_STATIC_SIZE_HPP_
 #define LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_MAYBE_STATIC_SIZE_HPP_
 
-#include <experimental/mdspan>
+#include <mdspan/mdspan.hpp>
 
-namespace std {
-namespace experimental {
+namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
+namespace MDSPAN_IMPL_PROPOSED_NAMESPACE {
 inline namespace __p1673_version_0 {
 namespace linalg {
 namespace detail {
@@ -79,7 +79,7 @@ struct __maybe_static_value {
 
 template <class T, T DynSentinel>
 struct __maybe_static_value<T, DynSentinel, DynSentinel> {
-  T value = { };
+  T value{};
   static constexpr auto is_static = false;
   static constexpr auto value_static = DynSentinel;
 };
@@ -90,7 +90,7 @@ using __maybe_static_extent = __maybe_static_value<::std::size_t, StaticSize, Se
 } // end namespace detail
 } // end namespace linalg
 } // end inline namespace __p1673_version_0
-} // end namespace experimental
-} // end namespace std
+} // end namespace MDSPAN_IMPL_PROPOSED_NAMESPACE
+} // end namespace MDSPAN_IMPL_STANDARD_NAMESPACE
 
 #endif //LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_MAYBE_STATIC_SIZE_HPP_

--- a/include/experimental/__p1673_bits/packed_layout.hpp
+++ b/include/experimental/__p1673_bits/packed_layout.hpp
@@ -43,11 +43,11 @@
 #ifndef LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_PACKED_LAYOUT_HPP_
 #define LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_PACKED_LAYOUT_HPP_
 
-#include <experimental/mdspan>
+#include <mdspan/mdspan.hpp>
 #include "layout_triangle.hpp"
 
-namespace std {
-namespace experimental {
+namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
+namespace MDSPAN_IMPL_PROPOSED_NAMESPACE {
 inline namespace __p1673_version_0 {
 namespace linalg {
 
@@ -75,7 +75,7 @@ packed(
 
 } // end namespace linalg
 } // end inline namespace __p1673_version_0
-} // end namespace experimental
-} // end namespace std
+} // end namespace MDSPAN_IMPL_PROPOSED_NAMESPACE
+} // end namespace MDSPAN_IMPL_STANDARD_NAMESPACE
 
 #endif //LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_PACKED_LAYOUT_HPP_

--- a/include/experimental/__p1673_bits/proxy_reference.hpp
+++ b/include/experimental/__p1673_bits/proxy_reference.hpp
@@ -53,8 +53,8 @@
 #include <cstdint>
 #include <type_traits>
 
-namespace std {
-namespace experimental {
+namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
+namespace MDSPAN_IMPL_PROPOSED_NAMESPACE {
 inline namespace __p1673_version_0 {
 namespace linalg {
 namespace impl {
@@ -324,7 +324,7 @@ public:
 
 } // end namespace linalg
 } // end inline namespace __p1673_version_0
-} // end namespace experimental
-} // end namespace std
+} // end namespace MDSPAN_IMPL_PROPOSED_NAMESPACE
+} // end namespace MDSPAN_IMPL_STANDARD_NAMESPACE
 
 #endif //LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_PROXY_REFERENCE_HPP_

--- a/include/experimental/__p1673_bits/scaled.hpp
+++ b/include/experimental/__p1673_bits/scaled.hpp
@@ -43,10 +43,10 @@
 #ifndef LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_SCALED_HPP_
 #define LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_SCALED_HPP_
 
-#include <experimental/mdspan>
+#include <mdspan/mdspan.hpp>
 
-namespace std {
-namespace experimental {
+namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
+namespace MDSPAN_IMPL_PROPOSED_NAMESPACE {
 inline namespace __p1673_version_0 {
 namespace linalg {
 
@@ -126,7 +126,7 @@ scaled(ScalingFactor scaling_factor,
 
 } // end namespace linalg
 } // end inline namespace __p1673_version_0
-} // end namespace experimental
-} // end namespace std
+} // end namespace MDSPAN_IMPL_PROPOSED_NAMESPACE
+} // end namespace MDSPAN_IMPL_STANDARD_NAMESPACE
 
 #endif //LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_SCALED_HPP_

--- a/include/experimental/__p1673_bits/transposed.hpp
+++ b/include/experimental/__p1673_bits/transposed.hpp
@@ -43,10 +43,10 @@
 #ifndef LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_TRANSPOSED_HPP_
 #define LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_TRANSPOSED_HPP_
 
-#include <experimental/mdspan>
+#include <mdspan/mdspan.hpp>
 
-namespace std {
-namespace experimental {
+namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
+namespace MDSPAN_IMPL_PROPOSED_NAMESPACE {
 inline namespace __p1673_version_0 {
 namespace linalg {
 
@@ -327,7 +327,7 @@ auto transposed(mdspan<ElementType, Extents, Layout, Accessor> a)
 
 } // end namespace linalg
 } // end inline namespace __p1673_version_0
-} // end namespace experimental
-} // end namespace std
+} // end namespace MDSPAN_IMPL_PROPOSED_NAMESPACE
+} // end namespace MDSPAN_IMPL_STANDARD_NAMESPACE
 
 #endif //LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_TRANSPOSED_HPP_

--- a/include/experimental/__p1673_bits/transposed.hpp
+++ b/include/experimental/__p1673_bits/transposed.hpp
@@ -59,7 +59,7 @@ namespace impl {
   )
   struct transpose_extents_t_impl
   {
-    using type = extents<typename Extents::size_type, Extents::static_extent(1), Extents::static_extent(0)>;
+    using type = extents<typename Extents::index_type, Extents::static_extent(1), Extents::static_extent(0)>;
   };
 
   template<class Extents>
@@ -72,8 +72,8 @@ namespace impl {
   transpose_extents_t<Extents> transpose_extents(const Extents& e)
   {
     static_assert(std::is_same_v<
-      typename transpose_extents_t<Extents>::size_type,
-      typename Extents::size_type>, "Please fix transpose_extents_t to account "
+      typename transpose_extents_t<Extents>::index_type,
+      typename Extents::index_type>, "Please fix transpose_extents_t to account "
       "for P2553, which adds a template parameter SizeType to extents.");
 
     constexpr size_t ext0 = Extents::static_extent(0);
@@ -98,83 +98,78 @@ namespace impl {
 template<class Layout>
 class layout_transpose {
 public:
+  using nested_layout_type = Layout;
+  
   template<class Extents>
   struct mapping {
   private:
     using nested_mapping_type =
       typename Layout::template mapping<impl::transpose_extents_t<Extents>>;
-    nested_mapping_type nested_mapping_;
 
   public:
     using extents_type = Extents;
+    using index_type = typename extents_type::index_type;
     using size_type = typename extents_type::size_type;
+    using rank_type = typename extents_type::rank_type;
     using layout_type = layout_transpose;
 
     constexpr explicit mapping(const nested_mapping_type& map)
-      : nested_mapping_(map) {}
+      : nested_mapping_(map),
+        extents_(impl::transpose_extents(map.extents()))
+    {}
 
-    constexpr extents_type extents() const
-      noexcept(noexcept(nested_mapping_.extents()))
+    constexpr const extents_type& extents() const noexcept
     {
-      return impl::transpose_extents(nested_mapping_.extents());
+      return extents_;
     }
 
-    constexpr size_type required_span_size() const
+    constexpr index_type required_span_size() const
       noexcept(noexcept(nested_mapping_.required_span_size()))
     {
       return nested_mapping_.required_span_size();
     }
 
-    template<class IndexType, class... Indices>
-    typename Extents::size_type operator() (Indices... rest, IndexType i, IndexType j) const
-      noexcept(noexcept(nested_mapping_(rest..., j, i)))
+    template<class IndexType0, class IndexType1>
+      requires(std::is_convertible_v<IndexType0, index_type> &&
+               std::is_convertible_v<IndexType1, index_type>)
+    index_type operator() (IndexType0 i, IndexType1 j) const
     {
-      return nested_mapping_(rest..., j, i);
+      return nested_mapping_(j, i);
     }
 
-    nested_mapping_type nested_mapping() const
+    const nested_mapping_type& nested_mapping() const
     {
       return nested_mapping_;
     }
 
-    static constexpr bool is_always_unique() {
+    static constexpr bool is_always_unique() noexcept {
       return nested_mapping_type::is_always_unique();
     }
-    static constexpr bool is_always_contiguous() {
+    static constexpr bool is_always_exhaustive() noexcept {
       return nested_mapping_type::is_always_contiguous();
     }
-    static constexpr bool is_always_strided() {
+    static constexpr bool is_always_strided() noexcept {
       return nested_mapping_type::is_always_strided();
     }
 
     constexpr bool is_unique() const
-      noexcept(noexcept(nested_mapping_.is_unique()))
     {
       return nested_mapping_.is_unique();
     }
-    constexpr bool is_contiguous() const
-      noexcept(noexcept(nested_mapping_.is_contiguous()))
+    constexpr bool is_exhaustive() const
     {
-      return nested_mapping_.is_contiguous();
+      return nested_mapping_.is_exhaustive();
     }
     constexpr bool is_strided() const
-      noexcept(noexcept(nested_mapping_.is_strided()))
     {
       return nested_mapping_.is_strided();
     }
 
-    constexpr size_type stride(size_t r) const
-      noexcept(noexcept(nested_mapping_.stride(r)))
+    constexpr index_type stride(size_t r) const
     {
-      if (r == extents_type::rank() - 1) {
-	return nested_mapping_.stride(extents_type::rank() - 2);
-      }
-      else if (r == extents_type::rank() - 2) {
-	return nested_mapping_.stride(extents_type::rank() - 1);
-      }
-      else {
-	return nested_mapping_.stride(r);
-      }
+      assert(this->is_strided());
+      assert(r < extents_type::rank());
+      return nested_mapping_.stride(r == 0 ? 1 : 0);
     }
 
     template<class OtherExtents>
@@ -183,6 +178,10 @@ public:
     {
       return lhs.nested_mapping_ == rhs.nested_mapping_;
     }
+
+  private:
+    nested_mapping_type nested_mapping_;
+    extents_type extents_;
   };
 };
 
@@ -260,7 +259,7 @@ namespace impl {
       // https://github.com/kokkos/stdBLAS/issues/242
       return return_mapping_type{
 	transpose_extents(orig_map.extents()),
-	std::array<typename extents_type::size_type, OriginalExtents::rank() /* orig_map.rank() */ >{
+	std::array<typename extents_type::index_type, OriginalExtents::rank() /* orig_map.rank() */ >{
 	  orig_map.stride(1),
 	  orig_map.stride(0)}};
     }

--- a/tests/native/abs_sum.cpp
+++ b/tests/native/abs_sum.cpp
@@ -1,13 +1,8 @@
-#include "gtest/gtest.h"
-#include "gtest_fixtures.hpp"
-
-#include <experimental/linalg>
-#include <experimental/mdspan>
-#include <vector>
+#include "./gtest_fixtures.hpp"
 
 namespace {
 
-  using std::experimental::linalg::vector_abs_sum;
+  using LinearAlgebra::vector_abs_sum;
 
   TEST_F(unsigned_double_vector, abs_sum)
   {

--- a/tests/native/add.cpp
+++ b/tests/native/add.cpp
@@ -1,11 +1,7 @@
 #include "./gtest_fixtures.hpp"
 
-#include <experimental/linalg>
-#include <array>
-#include <vector>
-
 namespace {
-  using std::experimental::linalg::add;
+  using LinearAlgebra::add;
 
   TEST(BLAS1_add, vector_double)
   {

--- a/tests/native/conjugate_transposed.cpp
+++ b/tests/native/conjugate_transposed.cpp
@@ -1,9 +1,7 @@
 #include "./gtest_fixtures.hpp"
 
-#include <experimental/linalg>
-
 namespace {
-  using std::experimental::linalg::conjugate_transposed;
+  using LinearAlgebra::conjugate_transposed;
 
   TEST(conjugate_transposed, mdspan_complex_double)
   {

--- a/tests/native/conjugated.cpp
+++ b/tests/native/conjugated.cpp
@@ -1,16 +1,14 @@
 #include "./gtest_fixtures.hpp"
 
-#include <experimental/linalg>
-
 namespace {
-  using std::experimental::linalg::conjugated;
+  using LinearAlgebra::conjugated;
+  using LinearAlgebra::accessor_conjugate;
 
   template<class ValueType>
   void test_accessor_conjugate_element_constification()
   {
-    using std::experimental::linalg::accessor_conjugate;
-    using std::experimental::default_accessor;
-    using std::experimental::linalg::conjugated_scalar;
+    using LinearAlgebra::conjugated_scalar;
+    using MDSPAN_IMPL_STANDARD_NAMESPACE :: default_accessor;
     using value_type = std::remove_cv_t<ValueType>;
     constexpr bool is_arith = std::is_arithmetic_v<value_type>;
 
@@ -73,7 +71,6 @@ namespace {
     // Make sure that accessor_conjugate compiles
     {
       using accessor_t = vector_t::accessor_type;
-      using std::experimental::linalg::accessor_conjugate;
       using accessor_conj_t = accessor_conjugate<accessor_t>;
       accessor_conj_t acc{y.accessor()};
     }

--- a/tests/native/conjugated.cpp
+++ b/tests/native/conjugated.cpp
@@ -2,50 +2,310 @@
 
 namespace {
   using LinearAlgebra::conjugated;
-  using LinearAlgebra::accessor_conjugate;
+  using LinearAlgebra::conjugated_accessor;
 
-  template<class ValueType>
-  void test_accessor_conjugate_element_constification()
+  // A clone of default_accessor, which we use to test the return type of conjugated.
+  template<class ElementType>
+  class nondefault_accessor {
+  public:
+    using reference        = ElementType&;
+    using element_type     = ElementType;
+    using data_handle_type = ElementType*;
+    using offset_policy    = nondefault_accessor<ElementType>;
+
+    constexpr nondefault_accessor() noexcept = default;
+    MDSPAN_TEMPLATE_REQUIRES(
+      class OtherElementType,
+      /* requires */ (std::is_convertible_v<OtherElementType(*)[], element_type(*)[]>)
+    )
+    nondefault_accessor(nondefault_accessor<OtherElementType> /* accessor */) noexcept
+    {}
+
+    reference access(data_handle_type p, ::std::size_t i) const noexcept
+    {
+      return p[i];
+    }
+
+    typename offset_policy::data_handle_type
+      offset(data_handle_type p, ::std::size_t i) const noexcept
+    {
+      return p + i;
+    }
+  };
+
+  TEST(conjugated, real_default_accessor)
   {
-    using LinearAlgebra::conjugated_scalar;
-    using MDSPAN_IMPL_STANDARD_NAMESPACE :: default_accessor;
-    using value_type = std::remove_cv_t<ValueType>;
-    constexpr bool is_arith = std::is_arithmetic_v<value_type>;
+    std::array<float, 3> x_storage{};
+    using extents_type = extents<int, 3>;
+    using layout_type = layout_right;
 
-    using nc_def_acc_type = default_accessor<value_type>;
-    using c_def_acc_type = default_accessor<const value_type>;
-    nc_def_acc_type nc_acc;
-    c_def_acc_type c_acc;
-
-    using aj_nc_type = accessor_conjugate<nc_def_acc_type>;
-    using expected_nc_ref =
-      std::conditional_t<is_arith, value_type&,
-			 conjugated_scalar<value_type&, value_type>>;
-    static_assert(std::is_same_v<expected_nc_ref, typename aj_nc_type::reference>);
-    using expected_nc_elt = std::add_const_t<std::conditional_t<is_arith, value_type, typename conjugated_scalar<value_type&, value_type>::value_type>>;
-    static_assert(std::is_same_v<expected_nc_elt, typename aj_nc_type::element_type>);
-    static_assert(std::is_same_v<typename aj_nc_type::data_handle_type, value_type*>);
-
-    using aj_c_type = accessor_conjugate<c_def_acc_type>;
-    using expected_c_ref = std::conditional_t<is_arith, const value_type&, conjugated_scalar<const value_type&, value_type>>;
-    static_assert(std::is_same_v<expected_c_ref, typename aj_c_type::reference>);
-    using expected_c_elt = std::add_const_t<std::conditional_t<is_arith, const value_type, typename conjugated_scalar<const value_type&, value_type>::value_type>>;
-    static_assert(std::is_same_v<expected_c_elt, typename aj_c_type::element_type>);
-    static_assert(std::is_same_v<typename aj_c_type::data_handle_type, const value_type*>);
-
-    aj_nc_type acc_conj_nc(nc_acc);
-    aj_c_type acc_conj_c0(c_acc);
-
-    // Test element_type constification (converting) constructor
-    aj_c_type acc_conj_c1(nc_acc);
+    {
+      using input_accessor_type = default_accessor<float>;
+      using expected_accessor_type = default_accessor<float>;
+      mdspan<float, extents_type, layout_type, input_accessor_type> x_nc{x_storage.data()};
+      auto x_nc_conj = conjugated(x_nc);
+      static_assert(std::is_same_v<decltype(x_nc_conj),
+                    mdspan<float, extents_type, layout_type, expected_accessor_type>>);
+      EXPECT_EQ(x_nc_conj.mapping(), x_nc.mapping());
+    }
+    {
+      using input_accessor_type = default_accessor<const float>;
+      using expected_accessor_type = default_accessor<const float>;
+      mdspan<const float, extents_type, layout_type, input_accessor_type> x_c{x_storage.data()};
+      auto x_c_conj = conjugated(x_c);
+      static_assert(std::is_same_v<decltype(x_c_conj),
+                    mdspan<const float, extents_type, layout_type, expected_accessor_type>>);
+      EXPECT_EQ(x_c_conj.mapping(), x_c.mapping());
+    }
   }
 
-  TEST(accessor_conjugate, element_constification)
+  TEST(conjugated, real_nondefault_accessor)
   {
-    test_accessor_conjugate_element_constification<double>();
-    test_accessor_conjugate_element_constification<int>();
-    test_accessor_conjugate_element_constification<std::complex<double>>();
-    test_accessor_conjugate_element_constification<std::complex<float>>();
+    std::array<float, 3> x_storage{};
+    using extents_type = extents<int, 3>;
+    using layout_type = layout_right;
+
+    {
+      using input_accessor_type = nondefault_accessor<float>;
+      // Implementation currently is more like P3050R0 than P1673R13.
+      using expected_accessor_type = nondefault_accessor<float>;
+      mdspan<float, extents_type, layout_type, input_accessor_type> x_nc{x_storage.data()};
+      auto x_nc_conj = conjugated(x_nc);
+      static_assert(std::is_same_v<decltype(x_nc_conj),
+                    mdspan<float, extents_type, layout_type, expected_accessor_type>>);
+      EXPECT_EQ(x_nc_conj.mapping(), x_nc.mapping());
+    }
+    {
+      using input_accessor_type = nondefault_accessor<const float>;
+      // Implementation currently is more like P3050R0 than P1673R13.
+      using expected_accessor_type = nondefault_accessor<const float>;
+      mdspan<const float, extents_type, layout_type, input_accessor_type> x_c{x_storage.data()};
+      auto x_c_conj = conjugated(x_c);
+      static_assert(std::is_same_v<decltype(x_c_conj),
+                    mdspan<const float, extents_type, layout_type, expected_accessor_type>>);
+      EXPECT_EQ(x_c_conj.mapping(), x_c.mapping());
+    }
+  }
+
+  struct nonarithmetic_real {};
+
+  // P3050 changes the behavior of conjugated for nonarithmetic "real" types.
+  // "Real" means "types T for which conj<std::declval<T>()) is not ADL-findable."
+  TEST(conjugated, nonarithmetic_real_default_accessor)
+  {
+    using value_type = nonarithmetic_real;
+    std::array<value_type, 3> x_storage{};
+    using extents_type = extents<int, 3>;
+    using layout_type = layout_right;
+
+    {
+      using input_accessor_type = default_accessor<value_type>;
+      mdspan<value_type, extents_type, layout_type, input_accessor_type> x_nc{x_storage.data()};
+      auto x_nc_conj = conjugated(x_nc);
+
+      using expected_accessor_type = conjugated_accessor<default_accessor<value_type>>;
+      using expected_element_type = std::add_const_t<value_type>;
+      static_assert(std::is_same_v<decltype(x_nc_conj),
+                    mdspan<expected_element_type, extents_type, layout_type, expected_accessor_type>>);
+      EXPECT_EQ(x_nc_conj.mapping(), x_nc.mapping());
+    }
+    {
+      using input_accessor_type = default_accessor<const value_type>;
+      mdspan<const value_type, extents_type, layout_type, input_accessor_type> x_c{x_storage.data()};
+      auto x_c_conj = conjugated(x_c);
+
+      using expected_accessor_type = conjugated_accessor<default_accessor<const value_type>>;
+      using expected_element_type = std::add_const_t<value_type>;
+      static_assert(std::is_same_v<decltype(x_c_conj),
+                    mdspan<expected_element_type, extents_type, layout_type, expected_accessor_type>>);
+      EXPECT_EQ(x_c_conj.mapping(), x_c.mapping());
+    }
+  }
+
+  // P3050 changes the behavior of conjugated for nonarithmetic "real" types.
+  // "Real" means "types T for which conj<std::declval<T>()) is not ADL-findable."
+  TEST(conjugated, nonarithmetic_real_nondefault_accessor)
+  {
+    using value_type = nonarithmetic_real;
+    std::array<value_type, 3> x_storage{};
+    using extents_type = extents<int, 3>;
+    using layout_type = layout_right;
+
+    {
+      using input_accessor_type = nondefault_accessor<value_type>;
+      mdspan<value_type, extents_type, layout_type, input_accessor_type> x_nc{x_storage.data()};
+      auto x_nc_conj = conjugated(x_nc);
+
+      using expected_accessor_type = conjugated_accessor<nondefault_accessor<value_type>>;
+      using expected_element_type = std::add_const_t<value_type>;
+      static_assert(std::is_same_v<decltype(x_nc_conj),
+                    mdspan<expected_element_type, extents_type, layout_type, expected_accessor_type>>);
+      EXPECT_EQ(x_nc_conj.mapping(), x_nc.mapping());
+    }
+    {
+      using input_accessor_type = nondefault_accessor<const value_type>;
+      mdspan<const value_type, extents_type, layout_type, input_accessor_type> x_c{x_storage.data()};
+      auto x_c_conj = conjugated(x_c);
+
+      using expected_accessor_type = conjugated_accessor<nondefault_accessor<const value_type>>;
+      using expected_element_type = std::add_const_t<value_type>;
+      static_assert(std::is_same_v<decltype(x_c_conj),
+                    mdspan<expected_element_type, extents_type, layout_type, expected_accessor_type>>);
+      EXPECT_EQ(x_c_conj.mapping(), x_c.mapping());
+    }
+  }
+
+  TEST(conjugated, complex_default_accessor)
+  {
+    using value_type = std::complex<double>;
+    std::array<value_type, 3> x_storage{};
+    using extents_type = extents<int, 3>;
+    using layout_type = layout_right;
+
+    {
+      using input_accessor_type = default_accessor<value_type>;
+      mdspan<value_type, extents_type, layout_type, input_accessor_type> x_nc{x_storage.data()};
+      auto x_nc_conj = conjugated(x_nc);
+
+      using expected_accessor_type = conjugated_accessor<default_accessor<value_type>>;
+      using expected_element_type = std::add_const_t<value_type>;
+      static_assert(std::is_same_v<decltype(x_nc_conj),
+        mdspan<expected_element_type, extents_type, layout_type, expected_accessor_type>>);
+      EXPECT_EQ(x_nc_conj.mapping(), x_nc.mapping());
+      static_assert(std::is_same_v<decltype(x_nc_conj.accessor().nested_accessor()), const input_accessor_type&>);
+    }
+    {
+      using input_accessor_type = default_accessor<const value_type>;
+      mdspan<const value_type, extents_type, layout_type, input_accessor_type> x_c{x_storage.data()};
+      auto x_c_conj = conjugated(x_c);
+
+      using expected_accessor_type = conjugated_accessor<default_accessor<const value_type>>;
+      using expected_element_type = std::add_const_t<value_type>;
+      static_assert(std::is_same_v<decltype(x_c_conj),
+        mdspan<expected_element_type, extents_type, layout_type, expected_accessor_type>>);
+      EXPECT_EQ(x_c_conj.mapping(), x_c.mapping());
+      static_assert(std::is_same_v<decltype(x_c_conj.accessor().nested_accessor()), const input_accessor_type&>);
+    }
+  }
+
+  TEST(conjugated, complex_nondefault_accessor)
+  {
+    using value_type = std::complex<double>;
+    std::array<value_type, 3> x_storage{};
+    using extents_type = extents<int, 3>;
+    using layout_type = layout_right;
+
+    {
+      using input_accessor_type = nondefault_accessor<value_type>;
+      mdspan<value_type, extents_type, layout_type, input_accessor_type> x_nc{x_storage.data()};
+      auto x_nc_conj = conjugated(x_nc);
+
+      using expected_accessor_type = conjugated_accessor<nondefault_accessor<value_type>>;
+      using expected_element_type = std::add_const_t<value_type>;
+      static_assert(std::is_same_v<decltype(x_nc_conj),
+        mdspan<expected_element_type, extents_type, layout_type, expected_accessor_type>>);
+      EXPECT_EQ(x_nc_conj.mapping(), x_nc.mapping());
+      static_assert(std::is_same_v<decltype(x_nc_conj.accessor().nested_accessor()), const input_accessor_type&>);
+    }
+    {
+      using input_accessor_type = nondefault_accessor<const value_type>;
+      mdspan<const value_type, extents_type, layout_type, input_accessor_type> x_c{x_storage.data()};
+      auto x_c_conj = conjugated(x_c);
+
+      using expected_accessor_type = conjugated_accessor<nondefault_accessor<const value_type>>;
+      using expected_element_type = std::add_const_t<value_type>;
+      static_assert(std::is_same_v<decltype(x_c_conj),
+        mdspan<expected_element_type, extents_type, layout_type, expected_accessor_type>>);
+      EXPECT_EQ(x_c_conj.mapping(), x_c.mapping());
+      static_assert(std::is_same_v<decltype(x_c_conj.accessor().nested_accessor()), const input_accessor_type&>);
+    }
+  }
+
+  struct custom_complex {
+    friend custom_complex conj(const custom_complex& z) {
+      return z;
+    }
+  };
+
+  TEST(conjugated, impl_has_conj)
+  {
+    using MDSPAN_IMPL_STANDARD_NAMESPACE :: MDSPAN_IMPL_PROPOSED_NAMESPACE :: linalg::impl::has_conj;
+
+    static_assert(! has_conj<int>::value);
+    static_assert(! has_conj< ::std::size_t>::value);
+    static_assert(! has_conj<float>::value);
+    static_assert(! has_conj<double>::value);
+    static_assert(! has_conj<nonarithmetic_real>::value);
+
+    static_assert(has_conj<std::complex<float>>::value);
+    static_assert(has_conj<std::complex<double>>::value);
+    static_assert(has_conj<custom_complex>::value);
+  }
+
+  TEST(conjugated, custom_complex_default_accessor)
+  {
+    using value_type = custom_complex;
+    std::array<value_type, 3> x_storage{};
+    using extents_type = extents<int, 3>;
+    using layout_type = layout_right;
+
+    {
+      using input_accessor_type = default_accessor<value_type>;
+      mdspan<value_type, extents_type, layout_type, input_accessor_type> x_nc{x_storage.data()};
+      auto x_nc_conj = conjugated(x_nc);
+
+      using expected_accessor_type = conjugated_accessor<default_accessor<value_type>>;
+      using expected_element_type = std::add_const_t<value_type>;
+      static_assert(std::is_same_v<decltype(x_nc_conj),
+        mdspan<expected_element_type, extents_type, layout_type, expected_accessor_type>>);
+      EXPECT_EQ(x_nc_conj.mapping(), x_nc.mapping());
+      static_assert(std::is_same_v<decltype(x_nc_conj.accessor().nested_accessor()), const input_accessor_type&>);
+    }
+    {
+      using input_accessor_type = default_accessor<const value_type>;
+      mdspan<const value_type, extents_type, layout_type, input_accessor_type> x_c{x_storage.data()};
+      auto x_c_conj = conjugated(x_c);
+
+      using expected_accessor_type = conjugated_accessor<default_accessor<const value_type>>;
+      using expected_element_type = std::add_const_t<value_type>;
+      static_assert(std::is_same_v<decltype(x_c_conj),
+        mdspan<expected_element_type, extents_type, layout_type, expected_accessor_type>>);
+      EXPECT_EQ(x_c_conj.mapping(), x_c.mapping());
+      static_assert(std::is_same_v<decltype(x_c_conj.accessor().nested_accessor()), const input_accessor_type&>);
+    }
+  }
+
+  TEST(conjugated, custom_complex_nondefault_accessor)
+  {
+    using value_type = custom_complex;
+    std::array<value_type, 3> x_storage{};
+    using extents_type = extents<int, 3>;
+    using layout_type = layout_right;
+
+    {
+      using input_accessor_type = nondefault_accessor<value_type>;
+      mdspan<value_type, extents_type, layout_type, input_accessor_type> x_nc{x_storage.data()};
+      auto x_nc_conj = conjugated(x_nc);
+
+      using expected_accessor_type = conjugated_accessor<nondefault_accessor<value_type>>;
+      using expected_element_type = std::add_const_t<value_type>;
+      static_assert(std::is_same_v<decltype(x_nc_conj),
+        mdspan<expected_element_type, extents_type, layout_type, expected_accessor_type>>);
+      EXPECT_EQ(x_nc_conj.mapping(), x_nc.mapping());
+      static_assert(std::is_same_v<decltype(x_nc_conj.accessor().nested_accessor()), const input_accessor_type&>);
+    }
+    {
+      using input_accessor_type = nondefault_accessor<const value_type>;
+      mdspan<const value_type, extents_type, layout_type, input_accessor_type> x_c{x_storage.data()};
+      auto x_c_conj = conjugated(x_c);
+
+      using expected_accessor_type = conjugated_accessor<nondefault_accessor<const value_type>>;
+      using expected_element_type = std::add_const_t<value_type>;
+      static_assert(std::is_same_v<decltype(x_c_conj),
+        mdspan<expected_element_type, extents_type, layout_type, expected_accessor_type>>);
+      EXPECT_EQ(x_c_conj.mapping(), x_c.mapping());
+      static_assert(std::is_same_v<decltype(x_c_conj.accessor().nested_accessor()), const input_accessor_type&>);
+    }
   }
 
   TEST(conjugated, mdspan_complex_double)
@@ -68,10 +328,10 @@ namespace {
       y(k) = y_k;
     }
 
-    // Make sure that accessor_conjugate compiles
+    // Make sure that conjugated_accessor compiles
     {
       using accessor_t = vector_t::accessor_type;
-      using accessor_conj_t = accessor_conjugate<accessor_t>;
+      using accessor_conj_t = conjugated_accessor<accessor_t>;
       accessor_conj_t acc{y.accessor()};
     }
 

--- a/tests/native/copy.cpp
+++ b/tests/native/copy.cpp
@@ -1,9 +1,7 @@
 #include "./gtest_fixtures.hpp"
 
-#include <experimental/linalg>
-
 namespace {
-  using std::experimental::linalg::copy;
+  using LinearAlgebra::copy;
 
   template<class Real>
   struct MakeVectorValues {

--- a/tests/native/dot.cpp
+++ b/tests/native/dot.cpp
@@ -1,7 +1,5 @@
 #include "./gtest_fixtures.hpp"
 
-#include <experimental/linalg>
-
 // FIXME (mfh 2022/06/17) Temporarily disable calling the BLAS,
 // to get PR testing workflow running with mdspan tag.
 #if 0
@@ -20,8 +18,8 @@ double ddot_wrapper (const int N, const double* DX,
 #endif // 0
 
 namespace {
-  using std::experimental::linalg::dot;
-  using std::experimental::linalg::dotc;
+  using LinearAlgebra::dot;
+  using LinearAlgebra::dotc;  
 
   TEST(BLAS1_dot, mdspan_double)
   {
@@ -69,9 +67,9 @@ namespace {
     const scalar_t conjDotResult = dotc(x, y, scalar_t{});
     EXPECT_EQ( conjDotResult, expectedDotResult );
 
-    // scalar_t dotResultPar {};
+    // scalar_t dotResultPar{};
     // See note above.
-    //std::experimental::dot (std::execution::par, x, y, dotResultPar);
+    // LinearAlgebra::dot(std::execution::par, x, y, dotResultPar);
 
     // This is noncomforming, but I need some way to test the executor overloads.
     //using fake_executor_t = int;
@@ -122,7 +120,7 @@ namespace {
 
     //scalar_t dotResultPar {};
     // See note above.
-    //std::experimental::dot (std::execution::par, x, y, dotResultPar);
+    //dot (std::execution::par, x, y, dotResultPar);
 
     // This is noncomforming, but I need some way to test the executor overloads.
     //using fake_executor_t = int;

--- a/tests/native/gemm.cpp
+++ b/tests/native/gemm.cpp
@@ -1,16 +1,14 @@
 #include "./gtest_fixtures.hpp"
-
-#include <experimental/linalg>
 #include <iostream>
 
 namespace {
-  using std::experimental::linalg::explicit_diagonal;
-  using std::experimental::linalg::implicit_unit_diagonal;
-  using std::experimental::linalg::lower_triangle;
-  using std::experimental::linalg::matrix_product;
-  using std::experimental::linalg::scaled;
-  using std::experimental::linalg::transposed;
-  using std::experimental::linalg::upper_triangle;
+  using LinearAlgebra::explicit_diagonal;
+  using LinearAlgebra::implicit_unit_diagonal;
+  using LinearAlgebra::lower_triangle;
+  using LinearAlgebra::matrix_product;
+  using LinearAlgebra::scaled;
+  using LinearAlgebra::transposed;
+  using LinearAlgebra::upper_triangle;
   using std::cout;
   using std::endl;
 

--- a/tests/native/gemv.cpp
+++ b/tests/native/gemv.cpp
@@ -1,11 +1,9 @@
 #include "./gtest_fixtures.hpp"
-
-#include <experimental/linalg>
 #include <iostream>
 
 namespace {
-  using std::experimental::linalg::matrix_vector_product;
-  using std::experimental::linalg::transposed;
+  using LinearAlgebra::matrix_vector_product;
+  using LinearAlgebra::transposed;
   using std::cout;
   using std::endl;
 

--- a/tests/native/gemv_no_ambig.cpp
+++ b/tests/native/gemv_no_ambig.cpp
@@ -1,6 +1,4 @@
 #include "./gtest_fixtures.hpp"
-
-#include <experimental/linalg>
 #include <iostream>
 
 #if (! defined(__GNUC__)) || (__GNUC__ > 9)
@@ -12,8 +10,8 @@
 
 namespace {
 
-using std::experimental::linalg::matrix_vector_product;
-using std::experimental::linalg::scaled;
+using LinearAlgebra::matrix_vector_product;
+using LinearAlgebra::scaled;
 
 TEST(gemv, no_ambiguity)
 {
@@ -24,16 +22,20 @@ TEST(gemv, no_ambiguity)
     std::vector<double> x_vec(M);
     std::vector<double> y_vec(N);
 
-    mdspan<double, extents<std::size_t, dynamic_extent,dynamic_extent>> A(A_vec.data(),N,M);
-    mdspan<double, extents<std::size_t, dynamic_extent>> x(x_vec.data(),M);
-    mdspan<double, extents<std::size_t, dynamic_extent>> y(y_vec.data(),N);
-    for(int i=0; i<A.extent(0); i++)
-      for(int j=0; j<A.extent(1); j++)
-        A(i,j) = 100.0*i+j;
-    for(int i=0; i<x.extent(0); i++)
-      x(i) = 1. * i;
-    for(int i=0; i<y.extent(0); i++)
-      y(i) = -1. * i;
+    mdspan<double, extents<std::size_t, dynamic_extent,dynamic_extent>> A(A_vec.data(), N, M);
+    mdspan<double, extents<std::size_t, dynamic_extent>> x(x_vec.data(), M);
+    mdspan<double, extents<std::size_t, dynamic_extent>> y(y_vec.data(), N);
+    for (int i = 0; i < A.extent(0); ++i) {
+      for (int j = 0; j < A.extent(1); ++j) {
+        A(i,j) = 100.0 * i + j;
+      }
+    }
+    for(int i = 0; i < x.extent(0); ++i) {
+      x(i) = 1.0 * i;
+    }
+    for(int i = 0; i < y.extent(0); ++i) {
+      y(i) = -1.0 * i;
+    }
 
     matrix_vector_product(A, x, y);
     // The following is an ambiguous call unless the implementation

--- a/tests/native/givens.cpp
+++ b/tests/native/givens.cpp
@@ -1,11 +1,9 @@
 #include "./gtest_fixtures.hpp"
-
-#include <experimental/linalg>
 #include <limits>
 
 namespace {
-  using std::experimental::linalg::givens_rotation_setup;
-  using std::experimental::linalg::givens_rotation_apply;
+  using LinearAlgebra::givens_rotation_setup;
+  using LinearAlgebra::givens_rotation_apply;
 
   TEST(givens_rotation_setup, complex_double)
   {

--- a/tests/native/gtest_fixtures.hpp
+++ b/tests/native/gtest_fixtures.hpp
@@ -51,99 +51,109 @@
 // This must be defined before including any mdspan headers.
 #define MDSPAN_USE_PAREN_OPERATOR 1
 
-#include <experimental/mdspan>
+#include <mdspan/mdspan.hpp>
 #include "experimental/__p2630_bits/submdspan.hpp"
-
+#include <experimental/linalg>
+#include <array>
 #include <complex>
 #include <vector>
 
-  using std::experimental::default_accessor;
-  using std::dextents; // not in experimental namespace
+namespace KokkosStd = MDSPAN_IMPL_STANDARD_NAMESPACE;
+namespace KokkosEx = MDSPAN_IMPL_STANDARD_NAMESPACE :: MDSPAN_IMPL_PROPOSED_NAMESPACE;
+
+namespace MdSpan = MDSPAN_IMPL_STANDARD_NAMESPACE;
+namespace MdSpanEx = MDSPAN_IMPL_STANDARD_NAMESPACE :: MDSPAN_IMPL_PROPOSED_NAMESPACE;
+namespace LinearAlgebra = MDSPAN_IMPL_STANDARD_NAMESPACE :: MDSPAN_IMPL_PROPOSED_NAMESPACE :: linalg;
+
+using MdSpan::default_accessor;
+using MdSpan::dextents; // not in experimental namespace
 #if defined(__cpp_lib_span)
 #include <span>
-  using std::dynamic_extent;
+using std::dynamic_extent;
 #else
-  using std::experimental::dynamic_extent;
+using MdSpan::dynamic_extent;
 #endif
-  using std::experimental::extents;
-  using std::full_extent; // not in experimental namespace
-  using std::experimental::layout_left;
-  using std::experimental::layout_right;
-  using std::experimental::layout_stride;
-  using std::experimental::mdspan;
+using MdSpan::extents;
+using MdSpan::full_extent; // not in experimental namespace
+using MdSpan::layout_left;
+using MdSpan::layout_right;
+using MdSpan::layout_stride;
+using MdSpan::mdspan;
+using MdSpan::submdspan;
 
-  using MDSPAN_IMPL_STANDARD_NAMESPACE :: submdspan;
+using MdSpanEx::layout_left_padded;
+using MdSpanEx::layout_right_padded;
 
-  using dbl_vector_t = mdspan<double, extents<std::size_t, dynamic_extent>>;
-  using cpx_vector_t = mdspan<std::complex<double>, extents<std::size_t, dynamic_extent>>;
-  constexpr ptrdiff_t NROWS(10);
+using dbl_vector_t = mdspan<double, extents<std::size_t, dynamic_extent>>;
+using cpx_vector_t = mdspan<std::complex<double>, extents<std::size_t, dynamic_extent>>;
+constexpr ptrdiff_t NROWS = 10u;
 
-  // 1-norm:   4.6
-  // inf-norm: 0.9
-  class unsigned_double_vector : public ::testing::Test {
-    protected:
-      unsigned_double_vector() :
-        storage(10),
-        v(storage.data(), 10)
-      {
-        v(0) = 0.5;
-        v(1) = 0.2;
-        v(2) = 0.1;
-        v(3) = 0.4;
-        v(4) = 0.8;
-        v(5) = 0.7;
-        v(6) = 0.3;
-        v(7) = 0.5;
-        v(8) = 0.2;
-        v(9) = 0.9;
-      }
+// 1-norm:   4.6
+// inf-norm: 0.9
+class unsigned_double_vector : public ::testing::Test {
+protected:
+  unsigned_double_vector() :
+    storage(10),
+    v(storage.data(), 10)
+  {
+    v(0) = 0.5;
+    v(1) = 0.2;
+    v(2) = 0.1;
+    v(3) = 0.4;
+    v(4) = 0.8;
+    v(5) = 0.7;
+    v(6) = 0.3;
+    v(7) = 0.5;
+    v(8) = 0.2;
+    v(9) = 0.9;
+  }
 
-      std::vector<double> storage;
-      dbl_vector_t v;
-  }; // end class unsigned_double_vector
+  std::vector<double> storage;
+  dbl_vector_t v;
+}; // end class unsigned_double_vector
 
-  // 1-norm:   4.6
-  // inf-norm: 0.9
-  class signed_double_vector : public ::testing::Test {
-    protected:
-      signed_double_vector() :
-        storage(10),
-        v(storage.data(), 10)
-      {
-        v(0) =  0.5;
-        v(1) =  0.2;
-        v(2) =  0.1;
-        v(3) =  0.4;
-        v(4) = -0.8;
-        v(5) = -0.7;
-        v(6) = -0.3;
-        v(7) =  0.5;
-        v(8) =  0.2;
-        v(9) = -0.9;
-      }
+// 1-norm:   4.6
+// inf-norm: 0.9
+class signed_double_vector : public ::testing::Test {
+protected:
+  signed_double_vector() :
+    storage(10),
+    v(storage.data(), 10)
+  {
+    v(0) =  0.5;
+    v(1) =  0.2;
+    v(2) =  0.1;
+    v(3) =  0.4;
+    v(4) = -0.8;
+    v(5) = -0.7;
+    v(6) = -0.3;
+    v(7) =  0.5;
+    v(8) =  0.2;
+    v(9) = -0.9;
+  }
 
-      std::vector<double> storage;
-      dbl_vector_t v;
-  }; // end class signed_double_vector
+  std::vector<double> storage;
+  dbl_vector_t v;
+}; // end class signed_double_vector
 
-  // 1-norm:   3.5188912597625004
-  // 2-norm:   1.6673332000533068
-  // inf-norm: 1.063014581273465
-  class signed_complex_vector : public ::testing::Test {
-    protected:
-      signed_complex_vector() :
-        storage(5),
-        v(storage.data(), 5)
-      {
-        v(0) = std::complex<double>( 0.5,  0.2);
-        v(1) = std::complex<double>( 0.1,  0.4);
-        v(2) = std::complex<double>(-0.8, -0.7);
-        v(3) = std::complex<double>(-0.3,  0.5);
-        v(4) = std::complex<double>( 0.2, -0.9);
-      }
+// 1-norm:   3.5188912597625004
+// 2-norm:   1.6673332000533068
+// inf-norm: 1.063014581273465
+class signed_complex_vector : public ::testing::Test {
+protected:
+  signed_complex_vector() :
+    storage(5),
+    v(storage.data(), 5)
+  {
+    v(0) = std::complex<double>( 0.5,  0.2);
+    v(1) = std::complex<double>( 0.1,  0.4);
+    v(2) = std::complex<double>(-0.8, -0.7);
+    v(3) = std::complex<double>(-0.3,  0.5);
+    v(4) = std::complex<double>( 0.2, -0.9);
+  }
 
-      std::vector<std::complex<double>> storage;
-      cpx_vector_t v;
-  }; // end class signed_double_vector
+  std::vector<std::complex<double>> storage;
+  cpx_vector_t v;
+}; // end class signed_double_vector
 
 #endif //LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_FIXTURES_HPP_

--- a/tests/native/hemm.cpp
+++ b/tests/native/hemm.cpp
@@ -1,15 +1,13 @@
 #include "./gtest_fixtures.hpp"
-
-#include <experimental/linalg>
 #include <iostream>
 
 namespace {
-  using std::experimental::linalg::explicit_diagonal;
-  using std::experimental::linalg::implicit_unit_diagonal;
-  using std::experimental::linalg::lower_triangle;
-  using std::experimental::linalg::matrix_product;
-  using std::experimental::linalg::transposed;
-  using std::experimental::linalg::upper_triangle;
+  using LinearAlgebra::explicit_diagonal;
+  using LinearAlgebra::implicit_unit_diagonal;
+  using LinearAlgebra::lower_triangle;
+  using LinearAlgebra::matrix_product;
+  using LinearAlgebra::transposed;
+  using LinearAlgebra::upper_triangle;
   using std::complex;
   using std::cout;
   using std::endl;

--- a/tests/native/her.cpp
+++ b/tests/native/her.cpp
@@ -1,16 +1,9 @@
 #include "./gtest_fixtures.hpp"
 
-#include <experimental/linalg>
-#include <array>
-#include <complex>
-
 namespace {
-  using std::experimental::linalg::lower_triangle;
-  using std::experimental::linalg::hermitian_matrix_rank_1_update;
-  using std::experimental::linalg::upper_triangle;
-  using std::extents;
-  using std::layout_right;
-  using std::mdspan;
+  using LinearAlgebra::lower_triangle;
+  using LinearAlgebra::hermitian_matrix_rank_1_update;
+  using LinearAlgebra::upper_triangle;
 
   // Regression test for ambiguous overloads of
   // hermitian_matrix_rank_1_update (related to

--- a/tests/native/herk.cpp
+++ b/tests/native/herk.cpp
@@ -1,15 +1,9 @@
 #include "./gtest_fixtures.hpp"
 
-#include <experimental/linalg>
-#include <array>
-
 namespace {
-  using std::experimental::linalg::symmetric_matrix_rank_k_update;
-  using std::experimental::linalg::transposed;
-  using std::experimental::linalg::upper_triangle;
-  using std::extents;
-  using std::layout_left;
-  using std::mdspan;
+  using LinearAlgebra::symmetric_matrix_rank_k_update;
+  using LinearAlgebra::transposed;
+  using LinearAlgebra::upper_triangle;
 
   // This is a regression test that follows on from
   // https://github.com/kokkos/stdBLAS/issues/261 .

--- a/tests/native/idx_abs_max.cpp
+++ b/tests/native/idx_abs_max.cpp
@@ -1,10 +1,8 @@
 #include "./gtest_fixtures.hpp"
 
-#include <experimental/linalg>
-
 namespace {
 
-  using std::experimental::linalg::idx_abs_max;
+  using LinearAlgebra::idx_abs_max;
 
   TEST_F(unsigned_double_vector, idx_abs_max)
   {

--- a/tests/native/iterator.cpp
+++ b/tests/native/iterator.cpp
@@ -1,6 +1,4 @@
 #include "./gtest_fixtures.hpp"
-
-#include <experimental/linalg>
 #include <algorithm>
 #include <iterator>
 #include <limits>

--- a/tests/native/matrix_inf_norm.cpp
+++ b/tests/native/matrix_inf_norm.cpp
@@ -1,11 +1,9 @@
 #include "./gtest_fixtures.hpp"
-
-#include <experimental/linalg>
 #include <iostream>
 #include <limits>
 
 namespace {
-  using std::experimental::linalg::matrix_inf_norm;
+  using LinearAlgebra::matrix_inf_norm;
   using std::cout;
   using std::endl;
 

--- a/tests/native/matrix_one_norm.cpp
+++ b/tests/native/matrix_one_norm.cpp
@@ -1,11 +1,9 @@
 #include "./gtest_fixtures.hpp"
-
-#include <experimental/linalg>
 #include <iostream>
 #include <limits>
 
 namespace {
-  using std::experimental::linalg::matrix_one_norm;
+  using LinearAlgebra::matrix_one_norm;
   using std::cout;
   using std::endl;
 

--- a/tests/native/norm2.cpp
+++ b/tests/native/norm2.cpp
@@ -1,6 +1,4 @@
 #include "./gtest_fixtures.hpp"
-
-#include <experimental/linalg>
 #include <type_traits>
 
 // FIXME (mfh 2022/06/17) Temporarily disable calling the BLAS,
@@ -19,7 +17,7 @@ double dnrm2_wrapper(const int N, const double* X, const int INCX)
 #endif // 0
 
 namespace {
-  using std::experimental::linalg::vector_norm2;
+  using LinearAlgebra::vector_norm2;
 
   TEST(BLAS1_norm2, mdspan_zero)
   {

--- a/tests/native/proxy_refs.cpp
+++ b/tests/native/proxy_refs.cpp
@@ -1,18 +1,6 @@
-// To try using subscript operator comment in macro below
-// the header will by default also check for the feature macro, and enable it
-// defining the macro to 0 will overwrite the automatic setting
-// x86-64 clang (experimental auto NSDMI) supports the operator, but you need
-// to explicitly comment in below macro
-//#define MDSPAN_USE_BRACKET_OPERATOR 1
-
-// To force enable operator() comment in the macro below
-// You can enable both at the same time. 
-//#define MDSPAN_USE_PAREN_OPERATOR 0
-
 #define P1673_CONJUGATED_SCALAR_ARITHMETIC_OPERATORS_REFERENCE_OVERLOADS 1
 
-#include "gtest/gtest.h"
-#include <experimental/linalg>
+#include "./gtest_fixtures.hpp"
 
 ///////////////////////////////////////////////////////////
 // Custom real number type for tests
@@ -224,7 +212,7 @@ auto imag(const FakeComplex& z) { return z.imag; }
 template<class Real>
 void test_real_conj_if_needed()
 {
-  using std::experimental::linalg::impl::conj_if_needed;
+  using LinearAlgebra::impl::conj_if_needed;
 
   Real z(2.0);
   const Real z_conj_expected(2.0);
@@ -237,7 +225,7 @@ void test_real_conj_if_needed()
 template<class Real>
 void test_complex_conj_if_needed()
 {
-  using std::experimental::linalg::impl::conj_if_needed;
+  using LinearAlgebra::impl::conj_if_needed;
   
   std::complex<Real> z(2.0, -3.0);
   const std::complex<Real> z_conj_expected(2.0, 3.0);
@@ -273,8 +261,8 @@ template<class Reference, class Value>
 void test_conjugated_scalar_from_reference(Reference zd, Value zd_orig)
 {
   using test_helpers::is_atomic_ref_not_arithmetic_v;
-  using std::experimental::linalg::impl::conj_if_needed;
-  using std::experimental::linalg::conjugated_scalar;  
+  using LinearAlgebra::impl::conj_if_needed;
+  using LinearAlgebra::conjugated_scalar;  
   using value_type = typename std::remove_cv_t<Value>;
 
 #ifdef P1673_CONJUGATED_SCALAR_ARITHMETIC_OPERATORS_REFERENCE_OVERLOADS
@@ -587,7 +575,7 @@ void test_complex_conjugated_scalar()
   {
     using value_type = std::complex<Real>;
     using inner_reference_type = value_type&;
-    using std::experimental::linalg::scaled_scalar;
+    using LinearAlgebra::scaled_scalar;
     using reference_type = scaled_scalar<Real, inner_reference_type, value_type>;
 
     const Real scalingFactor = 3.0;
@@ -653,8 +641,8 @@ void test_scaled_scalar_from_reference(
 {
   std::cerr << "test_scaled_scalar_from_reference" << std::endl;
 
-  using std::experimental::linalg::impl::conj_if_needed;  
-  using std::experimental::linalg::scaled_scalar;
+  using LinearAlgebra::impl::conj_if_needed;  
+  using LinearAlgebra::scaled_scalar;
   using value_type = typename std::remove_cv_t<Value>;
   constexpr bool is_atomic_ref_not_arithmetic =
     test_helpers::is_atomic_ref_not_arithmetic_v<Reference>;
@@ -941,7 +929,7 @@ void test_two_scaled_scalars_from_reference(
 	    << scalingFactorName << ", " << referenceName
 	    << ", " << valueName << ">" << std::endl;
 
-  using std::experimental::linalg::scaled_scalar;  
+  using LinearAlgebra::scaled_scalar;  
   using value_type = typename std::remove_cv_t<Value>;
   constexpr bool is_atomic_ref_not_arithmetic =
     test_helpers::is_atomic_ref_not_arithmetic_v<Reference>;
@@ -1097,7 +1085,7 @@ namespace {
   template<class R>
   void test_imag_part_complex()
   {
-    using std::experimental::linalg::impl::imag_part;
+    using LinearAlgebra::impl::imag_part;
     std::complex<R> z{R(3.0), R(4.0)};
     auto z_imag = imag_part(z);
     EXPECT_EQ(z_imag, R(4.0));
@@ -1106,7 +1094,7 @@ namespace {
   template<class T>
   void test_imag_part_floating_point()
   {
-    using std::experimental::linalg::impl::imag_part;
+    using LinearAlgebra::impl::imag_part;
     T x = 9.0;
     auto x_imag = imag_part(x);
     EXPECT_EQ(x_imag, T(0.0));
@@ -1115,7 +1103,7 @@ namespace {
   template<class T>
   void test_imag_part_integral()
   {
-    using std::experimental::linalg::impl::imag_part;
+    using LinearAlgebra::impl::imag_part;
     T x = 3;
     auto x_imag = imag_part(x);
     EXPECT_EQ(x_imag, T(0));
@@ -1142,14 +1130,14 @@ namespace {
     test_imag_part_integral<uint64_t>();    
 
     {
-      using std::experimental::linalg::impl::imag_part;
+      using LinearAlgebra::impl::imag_part;
       FakeComplex z{3.0, 4.0};
       auto z_imag = imag_part(z);
       EXPECT_EQ(z_imag, 4.0);
       static_assert(std::is_same_v<decltype(z_imag), decltype(z.imag)>);
     }
     {
-      using std::experimental::linalg::impl::imag_part;
+      using LinearAlgebra::impl::imag_part;
       FakeRealNumber x{3.0};
       auto x_imag = imag_part(x);
       EXPECT_EQ(x_imag, FakeRealNumber{});
@@ -1160,7 +1148,7 @@ namespace {
   template<class R>
   void test_real_part_complex()
   {
-    using std::experimental::linalg::impl::real_part;
+    using LinearAlgebra::impl::real_part;
     std::complex<R> z{R(3.0), R(4.0)};
     auto z_imag = real_part(z);
     EXPECT_EQ(z_imag, R(3.0));
@@ -1169,7 +1157,7 @@ namespace {
   template<class T>
   void test_real_part_floating_point()
   {
-    using std::experimental::linalg::impl::real_part;
+    using LinearAlgebra::impl::real_part;
     T x = 9.0;
     auto x_imag = real_part(x);
     EXPECT_EQ(x_imag, T(9.0));
@@ -1178,7 +1166,7 @@ namespace {
   template<class T>
   void test_real_part_integral()
   {
-    using std::experimental::linalg::impl::real_part;
+    using LinearAlgebra::impl::real_part;
     T x = 3;
     auto x_imag = real_part(x);
     EXPECT_EQ(x_imag, T(3));
@@ -1205,14 +1193,14 @@ namespace {
     test_real_part_integral<uint64_t>();    
 
     {
-      using std::experimental::linalg::impl::real_part;
+      using LinearAlgebra::impl::real_part;
       FakeComplex z{3.0, 4.0};
       auto z_imag = real_part(z);
       EXPECT_EQ(z_imag, 3.0);
       static_assert(std::is_same_v<decltype(z_imag), decltype(z.imag)>);
     }
     {
-      using std::experimental::linalg::impl::real_part;
+      using LinearAlgebra::impl::real_part;
       FakeRealNumber x{3.0};
       auto x_real = real_part(x);
       EXPECT_EQ(x_real, FakeRealNumber{3.0});
@@ -1238,7 +1226,7 @@ namespace {
     test_FakeComplex_conjugated_scalar();
 
     FakeRealNumber fn{4.2};
-    using std::experimental::linalg::conjugated_scalar;
+    using LinearAlgebra::conjugated_scalar;
     conjugated_scalar<FakeRealNumber&, FakeRealNumber> fncs(fn);
     EXPECT_EQ(fn, FakeRealNumber(fncs));
   }

--- a/tests/native/scale.cpp
+++ b/tests/native/scale.cpp
@@ -1,9 +1,7 @@
 #include "./gtest_fixtures.hpp"
 
-#include <experimental/linalg>
-
 namespace {
-  using std::experimental::linalg::scale;
+  using LinearAlgebra::scale;
 
   TEST(BLAS1_scale, mdspan_double)
   {

--- a/tests/native/scaled.cpp
+++ b/tests/native/scaled.cpp
@@ -1,16 +1,14 @@
 #include "./gtest_fixtures.hpp"
-
-#include <experimental/linalg>
 #include <type_traits>
 
 namespace {
-  using std::experimental::linalg::scaled;
+  using LinearAlgebra::scaled;
 
   template<class ScalingFactor, class OriginalValueType>
   void test_accessor_scaled_element_constification()
   {
-    using std::experimental::linalg::accessor_scaled;
-    using std::experimental::linalg::scaled_scalar;
+    using LinearAlgebra::accessor_scaled;
+    using LinearAlgebra::scaled_scalar;
 
     using nc_def_acc_type = default_accessor<OriginalValueType>;
     using c_def_acc_type =
@@ -84,7 +82,7 @@ namespace {
     // Make sure that accessor_scaled compiles
     {
       using accessor_t = vector_t::accessor_type;
-      using std::experimental::linalg::accessor_scaled;
+      using LinearAlgebra::accessor_scaled;
       using scaled_accessor_t =
         accessor_scaled<scaling_factor_type, accessor_t>;
       scaled_accessor_t accessor0{scalingFactor, y.accessor()};

--- a/tests/native/swap.cpp
+++ b/tests/native/swap.cpp
@@ -1,9 +1,7 @@
 #include "./gtest_fixtures.hpp"
 
-#include <experimental/linalg>
-
 namespace {
-  using std::experimental::linalg::swap_elements;
+  using LinearAlgebra::swap_elements;
 
   TEST(BLAS1_swap, mdspan_double)
   {

--- a/tests/native/symm.cpp
+++ b/tests/native/symm.cpp
@@ -1,15 +1,13 @@
 #include "./gtest_fixtures.hpp"
-
-#include <experimental/linalg>
 #include <iostream>
 
 namespace {
-  using std::experimental::linalg::explicit_diagonal;
-  using std::experimental::linalg::implicit_unit_diagonal;
-  using std::experimental::linalg::lower_triangle;
-  using std::experimental::linalg::matrix_product;
-  using std::experimental::linalg::transposed;
-  using std::experimental::linalg::upper_triangle;
+  using LinearAlgebra::explicit_diagonal;
+  using LinearAlgebra::implicit_unit_diagonal;
+  using LinearAlgebra::lower_triangle;
+  using LinearAlgebra::matrix_product;
+  using LinearAlgebra::transposed;
+  using LinearAlgebra::upper_triangle;
   using std::complex;
   using std::cout;
   using std::endl;

--- a/tests/native/syr.cpp
+++ b/tests/native/syr.cpp
@@ -1,15 +1,9 @@
 #include "./gtest_fixtures.hpp"
 
-#include <experimental/linalg>
-#include <array>
-
 namespace {
-  using std::experimental::linalg::lower_triangle;
-  using std::experimental::linalg::symmetric_matrix_rank_1_update;
-  using std::experimental::linalg::upper_triangle;
-  using std::extents;
-  using std::layout_right;
-  using std::mdspan;
+  using LinearAlgebra::lower_triangle;
+  using LinearAlgebra::symmetric_matrix_rank_1_update;
+  using LinearAlgebra::upper_triangle;
 
   // Regression test for ambiguous overloads of
   // symmetric_matrix_rank_1_update (related to

--- a/tests/native/syrk.cpp
+++ b/tests/native/syrk.cpp
@@ -1,15 +1,9 @@
 #include "./gtest_fixtures.hpp"
 
-#include <experimental/linalg>
-#include <array>
-
 namespace {
-  using std::experimental::linalg::symmetric_matrix_rank_k_update;
-  using std::experimental::linalg::transposed;
-  using std::experimental::linalg::upper_triangle;
-  using std::extents;
-  using std::layout_left;
-  using std::mdspan;
+  using LinearAlgebra::symmetric_matrix_rank_k_update;
+  using LinearAlgebra::transposed;
+  using LinearAlgebra::upper_triangle;
 
   // Regression test for https://github.com/kokkos/stdBLAS/issues/261
   //

--- a/tests/native/transposed.cpp
+++ b/tests/native/transposed.cpp
@@ -83,6 +83,124 @@ namespace {
     test_layout_transpose<dynamic_extent, dynamic_extent>();
   }
 
+  template<class InputLayoutMapping, class ExpectedLayoutMapping>
+  void test_transposed_layout(const InputLayoutMapping& in,
+                              const ExpectedLayoutMapping& out_expected,
+                              std::vector<char>& fake_storage)
+  {
+    using std::experimental::linalg::impl::transpose_extents_t;
+    using std::experimental::linalg::impl::transpose_extents;
+
+    ASSERT_EQ(in.extents().rank(), 2u);
+    ASSERT_EQ(out_expected.extents().rank(), 2u);
+
+    const size_t required_bytes = in.required_span_size();
+    if (fake_storage.size() < required_bytes) {
+      fake_storage.resize(required_bytes);
+    }
+    mdspan in_md{fake_storage.data(), in};
+
+    auto out_md = transposed(in_md);
+    auto out = out_md.mapping();
+    static_assert(std::is_same_v<decltype(out), ExpectedLayoutMapping>);
+    EXPECT_EQ(out.extents(), out_expected.extents());
+    EXPECT_EQ(out.is_exhaustive(), out_expected.is_exhaustive());
+    EXPECT_EQ(out.is_unique(), out_expected.is_unique());
+    ASSERT_EQ(out.is_strided(), out_expected.is_strided());
+    if (out_expected.is_strided()) {
+      for (size_t r = 0; r < 2u; ++r) {
+        out.stride(r) == out_expected.stride(r);
+      }
+    }
+  }
+
+  TEST(transposed_layout, layout_left)
+  {
+    auto test_one = [] (auto in_exts, auto out_exts, std::vector<char>& fake_storage) {
+      layout_left::mapping in_map{in_exts};
+      layout_right::mapping out_map{out_exts};
+      test_transposed_layout(in_map, out_map, fake_storage);
+    };
+
+    std::vector<char> storage;
+    {
+      using in_extents_type = extents<int, 3, 4>;
+      using out_extents_type = extents<int, 4, 3>;
+      test_one(in_extents_type{}, out_extents_type{}, storage);
+    }
+    {
+      using in_extents_type = extents<int, 3, dynamic_extent>;
+      using out_extents_type = extents<int, dynamic_extent, 3>;
+      test_one(in_extents_type{4}, out_extents_type{4}, storage);
+    }
+    {
+      using in_extents_type = extents<int, dynamic_extent, dynamic_extent>;
+      using out_extents_type = extents<int, dynamic_extent, dynamic_extent>;
+      test_one(in_extents_type{3, 4}, out_extents_type{4, 3}, storage);
+    }
+  }
+
+  TEST(transposed_layout, layout_right)
+  {
+    auto test_one = [] (auto in_exts, auto out_exts, std::vector<char>& fake_storage) {
+      layout_right::mapping in_map{in_exts};
+      layout_left::mapping out_map{out_exts};
+      test_transposed_layout(in_map, out_map, fake_storage);
+    };
+
+    std::vector<char> storage;
+    {
+      using in_extents_type = extents<int, 3, 4>;
+      using out_extents_type = extents<int, 4, 3>;
+      test_one(in_extents_type{}, out_extents_type{}, storage);
+    }
+    {
+      using in_extents_type = extents<int, 3, dynamic_extent>;
+      using out_extents_type = extents<int, dynamic_extent, 3>;
+      test_one(in_extents_type{4}, out_extents_type{4}, storage);
+    }
+    {
+      using in_extents_type = extents<int, dynamic_extent, dynamic_extent>;
+      using out_extents_type = extents<int, dynamic_extent, dynamic_extent>;
+      test_one(in_extents_type{3, 4}, out_extents_type{4, 3}, storage);
+    }
+  }
+
+  TEST(transposed_layout, layout_stride)
+  {
+    auto test_one = [] (auto in_exts, auto out_exts, std::vector<char>& fake_storage) {
+      using index_type = decltype(in_exts.extent(0));
+      const std::array<index_type, 2> in_strides{
+        static_cast<index_type>(2),
+        static_cast<index_type>((in_exts.extent(0) + 1) * 2)
+      };
+      const std::array<index_type, 2> out_strides{
+        in_strides[1],
+        in_strides[0]
+      };
+      layout_stride::mapping in_map{in_exts, in_strides};
+      layout_stride::mapping out_map{out_exts, out_strides};
+      test_transposed_layout(in_map, out_map, fake_storage);
+    };
+
+    std::vector<char> storage;
+    {
+      using in_extents_type = extents<int, 3, 4>;
+      using out_extents_type = extents<int, 4, 3>;
+      test_one(in_extents_type{}, out_extents_type{}, storage);
+    }
+    {
+      using in_extents_type = extents<int, 3, dynamic_extent>;
+      using out_extents_type = extents<int, dynamic_extent, 3>;
+      test_one(in_extents_type{4}, out_extents_type{4}, storage);
+    }
+    {
+      using in_extents_type = extents<int, dynamic_extent, dynamic_extent>;
+      using out_extents_type = extents<int, dynamic_extent, dynamic_extent>;
+      test_one(in_extents_type{3, 4}, out_extents_type{4, 3}, storage);
+    }
+  }
+
   TEST(transposed, mdspan_double)
   {
     using real_t = double;

--- a/tests/native/transposed.cpp
+++ b/tests/native/transposed.cpp
@@ -1,20 +1,18 @@
 #include "./gtest_fixtures.hpp"
-
-#include <experimental/linalg>
 #include <type_traits>
 
 namespace {
-  using std::experimental::linalg::layout_transpose;
-  using std::experimental::linalg::transposed;
-  using std::experimental::layout_left;
-  using std::experimental::layout_right;
-  using std::experimental::layout_stride;
+  using LinearAlgebra::layout_transpose;
+  using LinearAlgebra::transposed;
+  using MdSpan::layout_left;
+  using MdSpan::layout_right;
+  using MdSpan::layout_stride;
 
   template<std::size_t ext0, std::size_t ext1>
   void test_transpose_extents()
   {
-    using std::experimental::linalg::impl::transpose_extents_t;
-    using std::experimental::linalg::impl::transpose_extents;
+    using LinearAlgebra::impl::transpose_extents_t;
+    using LinearAlgebra::impl::transpose_extents;
 
     using extents_type = extents<std::size_t, ext0, ext1>;
     using expected_transpose_extents_type = extents<std::size_t, ext1, ext0>;
@@ -88,8 +86,8 @@ namespace {
                               const ExpectedLayoutMapping& out_expected,
                               std::vector<char>& fake_storage)
   {
-    using std::experimental::linalg::impl::transpose_extents_t;
-    using std::experimental::linalg::impl::transpose_extents;
+    using LinearAlgebra::impl::transpose_extents_t;
+    using LinearAlgebra::impl::transpose_extents;
 
     ASSERT_EQ(in.extents().rank(), 2u);
     ASSERT_EQ(out_expected.extents().rank(), 2u);

--- a/tests/native/trmm.cpp
+++ b/tests/native/trmm.cpp
@@ -1,15 +1,13 @@
 #include "./gtest_fixtures.hpp"
-
-#include <experimental/linalg>
 #include <iostream>
 
 namespace {
-  using std::experimental::linalg::explicit_diagonal;
-  using std::experimental::linalg::implicit_unit_diagonal;
-  using std::experimental::linalg::lower_triangle;
-  using std::experimental::linalg::matrix_product;
-  using std::experimental::linalg::transposed;
-  using std::experimental::linalg::upper_triangle;
+  using LinearAlgebra::explicit_diagonal;
+  using LinearAlgebra::implicit_unit_diagonal;
+  using LinearAlgebra::lower_triangle;
+  using LinearAlgebra::matrix_product;
+  using LinearAlgebra::transposed;
+  using LinearAlgebra::upper_triangle;
   using std::cout;
   using std::endl;
 

--- a/tests/native/trsm.cpp
+++ b/tests/native/trsm.cpp
@@ -1,6 +1,4 @@
 #include "./gtest_fixtures.hpp"
-
-#include <experimental/linalg>
 #include <iostream>
 
 namespace {
@@ -62,10 +60,10 @@ namespace {
     fill_from_layout_right_storage<IndexType, Layout>(B_nonconst, storage_B, num_rows_B, num_cols_B);
     mdspan<const double, dextents<IndexType, 2>, Layout> B = B_nonconst;
 
-    using ::std::experimental::linalg::explicit_diagonal;
-    using ::std::experimental::linalg::lower_triangle;
-    using ::std::experimental::linalg::right_side;
-    using ::std::experimental::linalg::triangular_matrix_matrix_solve;
+    using LinearAlgebra::explicit_diagonal;
+    using LinearAlgebra::lower_triangle;
+    using LinearAlgebra::right_side;
+    using LinearAlgebra::triangular_matrix_matrix_solve;
     triangular_matrix_matrix_solve(A, lower_triangle, explicit_diagonal, right_side, B, X);
 
     mdspan<const double, dextents<IndexType, 2>, layout_right>


### PR DESCRIPTION
This fixes the build, which is currently broken, thus blocking any new features.

1. Change this repository so that it no longer uses or depends on `std::experimental`.

2. Fix `layout_transpose` to conform with the Standard.  It had implemented an older version of `mdspan` that used `size_type` instead of `index_type`.

3. Rename `accessor_conjugate` to `conjugated_accessor` and otherwise bring it in line with the Standard.  Improve tests for `conjugated`.

This is rebased atop https://github.com/kokkos/stdBLAS/pull/264 which I submitted in January but hasn't yet been merged.  Please either merge that one first, or close that one and merge this one.