### PR TITLE
Add RandomAccessIteror member functions for MdspanRandomAccessIterator

### DIFF
--- a/tests/native/iterator.cpp
+++ b/tests/native/iterator.cpp
@@ -68,13 +68,19 @@ namespace {
       return iterator (x_, current_index_ + n);
     }
 
+    iterator& operator+=(difference_type n) {
+      current_index_ += n;
+      return *this;
+    }
+
     iterator operator-(difference_type n) const {
       return iterator (x_, current_index_ - n);
     }
 
-    // iterator operator+(iterator it) const {
-    //   return iterator (x_, current_index_ + it.current_index_);
-    // }
+    iterator& operator-=(difference_type n) {
+      current_index_ -= n;
+      return *this;
+    }
 
     difference_type operator-(iterator it) const {
       return current_index_ - it.current_index_;
@@ -92,6 +98,18 @@ namespace {
 
     bool operator<(iterator other) const {
       return current_index_ < other.current_index_;
+    }
+
+    bool operator<=(iterator other) const {
+      return current_index_ <= other.current_index_;
+    }
+
+    bool operator> (iterator other) const {
+      return current_index_ > other.current_index_;
+    }
+
+    bool operator>= (iterator other) const {
+      return current_index_ >= other.current_index_;
     }
 
     reference operator*() const {

--- a/tests/native/transposed.cpp
+++ b/tests/native/transposed.cpp
@@ -107,7 +107,7 @@ namespace {
     ASSERT_EQ(out.is_strided(), out_expected.is_strided());
     if (out_expected.is_strided()) {
       for (size_t r = 0; r < 2u; ++r) {
-        out.stride(r) == out_expected.stride(r);
+        ASSERT_EQ(out.stride(r), out_expected.stride(r));
       }
     }
   }


### PR DESCRIPTION
I need the first commit adding some `RandomAccessIteror` member functions for `MdspanRandomAccessIterator` to compile the tests. The second commit fixes an apparent oversight in not trying to check the result of a comparison in the transposed test file.