### PR TITLE
Fix rank_k implementation

### DIFF
--- a/include/experimental/__p1673_bits/blas3_matrix_rank_k_update.hpp
+++ b/include/experimental/__p1673_bits/blas3_matrix_rank_k_update.hpp
@@ -147,8 +147,6 @@ void symmetric_matrix_rank_k_update(
   mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C,
   Triangle /* t */)
 {
-  using size_type = std::common_type_t<SizeType_A, SizeType_C>;
-
   constexpr bool lower_tri =
     std::is_same_v<Triangle, lower_triangle_t>;
   using size_type = std::common_type_t<SizeType_A, SizeType_C>;

--- a/include/experimental/__p1673_bits/blas3_matrix_rank_k_update.hpp
+++ b/include/experimental/__p1673_bits/blas3_matrix_rank_k_update.hpp
@@ -149,31 +149,16 @@ void symmetric_matrix_rank_k_update(
 {
   using size_type = std::common_type_t<SizeType_A, SizeType_C>;
 
-  if constexpr (std::is_same_v<Triangle, upper_triangle_t>) {
-    // [A_00  A_01  A_02]   [A_00            ]
-    // [      A_11  A_12] * [A_01  A_11      ]
-    // [            A_22]   [A_02  A_12  A_22]
-    for (size_type row = 0; row < C.extent(0); ++row) {
-      for (size_type col = 0; col < C.extent(1); ++col) {
-        const size_type lower = row < col ? col : row; // max
-        const size_type upper = A.extent(0);
-        for (size_type k = lower; k < upper; ++k) {
-          C(row, col) += alpha * A(row, k) * A(col, k);
-        }
-      }
-    }
-  }
-  else {
-    // [A_00            ]   [A_00  A_10  A_20]
-    // [A_10  A_11      ] * [      A_11  A_21]
-    // [A_20  A_21  A_22]   [            A_22]
-    for (size_type row = 0; row < C.extent(0); ++row) {
-      for (size_type col = 0; col < C.extent(1); ++col) {
-        const size_type lower = 0;
-        const size_type upper = row < col ? row : col; // min
-        for (size_type k = lower; k < upper; ++k) {
-          C(row, col) += alpha * A(row, k) * A(col, k);
-        }
+  constexpr bool lower_tri =
+    std::is_same_v<Triangle, lower_triangle_t>;
+  using size_type = std::common_type_t<SizeType_A, SizeType_C>;
+
+  for (size_type j = 0; j < C.extent(1); ++j) {
+    const size_type i_lower = lower_tri ? j : size_type(0);
+    const size_type i_upper = lower_tri ? C.extent(0) : j+1;
+    for (size_type i = i_lower; i < i_upper; ++i) {
+      for (size_type k = 0; k < A.extent(1); ++k) {
+          C(i, j) += alpha * A(i, k) * A(j, k);
       }
     }
   }
@@ -265,33 +250,16 @@ void symmetric_matrix_rank_k_update(
   mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C,
   Triangle /* t */)
 {
+  constexpr bool lower_tri =
+    std::is_same_v<Triangle, lower_triangle_t>;
   using size_type = std::common_type_t<SizeType_A, SizeType_C>;
 
-  if constexpr (std::is_same_v<Triangle, upper_triangle_t>) {
-    // [A_00  A_01  A_02]   [A_00            ]
-    // [      A_11  A_12] * [A_01  A_11      ]
-    // [            A_22]   [A_02  A_12  A_22]
-    for (size_type row = 0; row < C.extent(0); ++row) {
-      for (size_type col = 0; col < C.extent(1); ++col) {
-        const size_type lower = row < col ? col : row; // max
-        const size_type upper = A.extent(0);
-        for (size_type k = lower; k < upper; ++k) {
-          C(row, col) += A(row, k) * A(col, k);
-        }
-      }
-    }
-  }
-  else {
-    // [A_00            ]   [A_00  A_10  A_20]
-    // [A_10  A_11      ] * [      A_11  A_21]
-    // [A_20  A_21  A_22]   [            A_22]
-    for (size_type row = 0; row < C.extent(0); ++row) {
-      for (size_type col = 0; col < C.extent(1); ++col) {
-        const size_type lower = 0;
-        const size_type upper = row < col ? row : col; // min
-        for (size_type k = lower; k < upper; ++k) {
-          C(row, col) += A(row, k) * A(col, k);
-        }
+  for (size_type j = 0; j < C.extent(1); ++j) {
+    const size_type i_lower = lower_tri ? j : size_type(0);
+    const size_type i_upper = lower_tri ? C.extent(0) : j+1;
+    for (size_type i = i_lower; i < i_upper; ++i) {
+      for (size_type k = 0; k < A.extent(1); ++k) {
+          C(i, j) += A(i, k) * A(j, k);
       }
     }
   }
@@ -384,31 +352,16 @@ void hermitian_matrix_rank_k_update(
 {
   using size_type = std::common_type_t<SizeType_A, SizeType_C>;
 
-  if constexpr (std::is_same_v<Triangle, upper_triangle_t>) {
-    // [A_00  A_01  A_02]   [A_00            ]
-    // [      A_11  A_12] * [A_01  A_11      ]
-    // [            A_22]   [A_02  A_12  A_22]
-    for (size_type row = 0; row < C.extent(0); ++row) {
-      for (size_type col = 0; col < C.extent(1); ++col) {
-        const size_type lower = row < col ? col : row; // max
-        const size_type upper = A.extent(0);
-        for (size_type k = lower; k < upper; ++k) {
-          C(row, col) += alpha * A(row, k) * impl::conj_if_needed(A(col, k));
-        }
-      }
-    }
-  }
-  else {
-    // [A_00            ]   [A_00  A_10  A_20]
-    // [A_10  A_11      ] * [      A_11  A_21]
-    // [A_20  A_21  A_22]   [            A_22]
-    for (size_type row = 0; row < C.extent(0); ++row) {
-      for (size_type col = 0; col < C.extent(1); ++col) {
-        const size_type lower = 0;
-        const size_type upper = row < col ? row : col; // min
-        for (size_type k = lower; k < upper; ++k) {
-          C(row, col) += alpha * A(row, k) * impl::conj_if_needed(A(col, k));
-        }
+  constexpr bool lower_tri =
+    std::is_same_v<Triangle, lower_triangle_t>;
+  using size_type = std::common_type_t<SizeType_A, SizeType_C>;
+
+  for (size_type j = 0; j < C.extent(1); ++j) {
+    const size_type i_lower = lower_tri ? j : size_type(0);
+    const size_type i_upper = lower_tri ? C.extent(0) : j+1;
+    for (size_type i = i_lower; i < i_upper; ++i) {
+      for (size_type k = 0; k < A.extent(1); ++k) {
+          C(i, j) += alpha * A(i, k) * impl::conj_if_needed(A(j, k));
       }
     }
   }
@@ -502,31 +455,16 @@ void hermitian_matrix_rank_k_update(
 {
   using size_type = std::common_type_t<SizeType_A, SizeType_C>;
 
-  if constexpr (std::is_same_v<Triangle, upper_triangle_t>) {
-    // [A_00  A_01  A_02]   [A_00            ]
-    // [      A_11  A_12] * [A_01  A_11      ]
-    // [            A_22]   [A_02  A_12  A_22]
-    for (size_type row = 0; row < C.extent(0); ++row) {
-      for (size_type col = 0; col < C.extent(1); ++col) {
-        const size_type lower = row < col ? col : row; // max
-        const size_type upper = A.extent(0);
-        for (size_type k = lower; k < upper; ++k) {
-          C(row, col) += A(row, k) * impl::conj_if_needed(A(col, k));
-        }
-      }
-    }
-  }
-  else {
-    // [A_00            ]   [A_00  A_10  A_20]
-    // [A_10  A_11      ] * [      A_11  A_21]
-    // [A_20  A_21  A_22]   [            A_22]
-    for (size_type row = 0; row < C.extent(0); ++row) {
-      for (size_type col = 0; col < C.extent(1); ++col) {
-        const size_type lower = 0;
-        const size_type upper = row < col ? row : col; // min
-        for (size_type k = lower; k < upper; ++k) {
-          C(row, col) += A(row, k) * impl::conj_if_needed(A(col, k));
-        }
+  constexpr bool lower_tri =
+    std::is_same_v<Triangle, lower_triangle_t>;
+  using size_type = std::common_type_t<SizeType_A, SizeType_C>;
+
+  for (size_type j = 0; j < C.extent(1); ++j) {
+    const size_type i_lower = lower_tri ? j : size_type(0);
+    const size_type i_upper = lower_tri ? C.extent(0) : j+1;
+    for (size_type i = i_lower; i < i_upper; ++i) {
+      for (size_type k = 0; k < A.extent(1); ++k) {
+          C(i, j) += A(i, k) * impl::conj_if_needed(A(j, k));
       }
     }
   }

--- a/tests/native/herk.cpp
+++ b/tests/native/herk.cpp
@@ -16,30 +16,30 @@ namespace {
     constexpr auto map_C = layout_left::mapping{extents<std::size_t,3,3>{}};
     constexpr auto map_expected = map_C;
 
-    // [1.0   1.0   2.0]
-    // [      1.0   2.0]
-    // [            2.0]
-    //
     // Fill in the "empty spots" with a large negative value.
     // The algorithm should never see it, but if it does,
     // then the results will be wrong in an obvious way.
     constexpr double flag = -1000.0;
     constexpr std::array<double, 9> WA_original{
-      1.0, flag, flag, 1.0, 1.0, flag, 2.0, 2.0, 2.0};
-    // [1.0   2.0   3.0]
-    // [2.0   4.0   5.0]
-    // [3.0   5.0   6.0]
+      1.0, 2.0, 3.0, 3.0, 5.0, 6.0};
+    // [1.0   3.0]
+    // [2.0   5.0]
+    // [3.0   6.0]
     constexpr std::array<double, 9> WC_original{
-      1.0, 2.0, 3.0, 2.0, 4.0, 5.0, 3.0, 5.0, 6.0};
-    // [1.0   1.0   2.0]   [1.0            ]   [6.0  5.0  4.0]
-    // [      1.0   2.0] * [1.0   1.0      ] = [5.0  5.0  4.0]
-    // [            2.0]   [2.0   2.0   2.0]   [4.0  4.0  4.0]
+      1.0, flag, flag, 3.0, 4.0, flag, 2.0, 5.0, 7.0};
+    // [1.0   3.0   2.0]
+    // [***   4.0   5.0]
+    // [***   ***   7.0]
+
+    // [1.0   3.0]   [1.0   2.0   3.0]   [10.0  17.0  21.0]
+    // [2.0   5.0] * [3.0   5.0   6.0] = [17.0  29.0  36.0]
+    // [3.0   6.0]                       [21.0  36.0  45.0]
     //
-    // [6.0   5.0   4.0]   [1.0   2.0   3.0]   [7.0  7.0  7.0]
-    // [5.0   5.0   4.0] + [2.0   4.0   5.0] = [7.0  9.0  9.0]
-    // [4.0   4.0   4.0]   [3.0   5.0   6.0]   [7.0  9.0 10.0]
+    // [1.0   3.0   2.0]   [10.0  17.0  21.0]   [11.0  20.0  23.0]
+    // [***   4.0   5.0] + [17.0  29.0  36.0] = [ ***  33.0  41.0]
+    // [***   ***   7.0]   [21.0  36.0  45.0]   [ ***   ***  52.0]
     constexpr std::array<double, 9> expected_storage_original{
-      7.0, 7.0, 7.0, 7.0, 9.0, 9.0, 7.0, 9.0, 10.0};
+      11.0, flag, flag, 20.0, 33.0, flag, 23.0, 41.0, 52.0};
 
     std::array<double, 9> WC = WC_original;
     mdspan C{WC.data(), map_C};

--- a/tests/native/syrk.cpp
+++ b/tests/native/syrk.cpp
@@ -15,30 +15,30 @@ namespace {
     constexpr auto map_C = layout_left::mapping{extents<std::size_t,3,3>{}};
     constexpr auto map_expected = map_C;
 
-    // [1.0   1.0   2.0]
-    // [      1.0   2.0]
-    // [            2.0]
-    //
     // Fill in the "empty spots" with a large negative value.
     // The algorithm should never see it, but if it does,
     // then the results will be wrong in an obvious way.
     constexpr double flag = -1000.0;
     constexpr std::array<double, 9> WA_original{
-      1.0, flag, flag, 1.0, 1.0, flag, 2.0, 2.0, 2.0};
-    // [1.0   2.0   3.0]
-    // [2.0   4.0   5.0]
-    // [3.0   5.0   6.0]
+      1.0, 2.0, 3.0, 3.0, 5.0, 6.0};
+    // [1.0   3.0]
+    // [2.0   5.0]
+    // [3.0   6.0]
     constexpr std::array<double, 9> WC_original{
-      1.0, 2.0, 3.0, 2.0, 4.0, 5.0, 3.0, 5.0, 6.0};
-    // [1.0   1.0   2.0]   [1.0            ]   [6.0  5.0  4.0]
-    // [      1.0   2.0] * [1.0   1.0      ] = [5.0  5.0  4.0]
-    // [            2.0]   [2.0   2.0   2.0]   [4.0  4.0  4.0]
+      1.0, flag, flag, 3.0, 4.0, flag, 2.0, 5.0, 7.0};
+    // [1.0   3.0   2.0]
+    // [***   4.0   5.0]
+    // [***   ***   7.0]
+
+    // [1.0   3.0]   [1.0   2.0   3.0]   [10.0  17.0  21.0]
+    // [2.0   5.0] * [3.0   5.0   6.0] = [17.0  29.0  36.0]
+    // [3.0   6.0]                       [21.0  36.0  45.0]
     //
-    // [6.0   5.0   4.0]   [1.0   2.0   3.0]   [7.0  7.0  7.0]
-    // [5.0   5.0   4.0] + [2.0   4.0   5.0] = [7.0  9.0  9.0]
-    // [4.0   4.0   4.0]   [3.0   5.0   6.0]   [7.0  9.0 10.0]
+    // [1.0   3.0   2.0]   [10.0  17.0  21.0]   [11.0  20.0  23.0]
+    // [***   4.0   5.0] + [17.0  29.0  36.0] = [ ***  33.0  41.0]
+    // [***   ***   7.0]   [21.0  36.0  45.0]   [ ***   ***  52.0]
     constexpr std::array<double, 9> expected_storage_original{
-      7.0, 7.0, 7.0, 7.0, 9.0, 9.0, 7.0, 9.0, 10.0};
+      11.0, flag, flag, 20.0, 33.0, flag, 23.0, 41.0, 52.0};
 
     std::array<double, 9> WC = WC_original;
     mdspan C{WC.data(), map_C};

--- a/tests/native/transposed.cpp
+++ b/tests/native/transposed.cpp
@@ -259,7 +259,7 @@ namespace {
     constexpr std::size_t subdim = 4;
     const std::pair<std::size_t, std::size_t> sub(0, subdim);
     auto A_sub = submdspan(A, sub, sub);
-    static_assert(std::is_same_v<decltype(A_sub)::layout_type, layout_stride>);
+    static_assert(std::is_same_v<decltype(A_sub)::layout_type, layout_right_padded<dynamic_extent>>);
     ASSERT_EQ( A_sub.rank(), std::size_t(2) );
     ASSERT_EQ( A_sub.extent(0), subdim );
     ASSERT_EQ( A_sub.extent(1), subdim );


### PR DESCRIPTION
The implementation of `symmetric_matrix_rank_k_update` and `hermitian_matrix_rank_k_update` are wrong.

See xSYRK or xHERK for reference.
(E.g. [DSYRK](https://netlib.org/lapack/explore-html-3.6.1/d1/d54/group__double__blas__level3_gae0ba56279ae3fa27c75fefbc4cc73ddf.html))

Fixes #272 