### PR TITLE
added missing header to example

### DIFF
--- a/examples/01_scale.cpp
+++ b/examples/01_scale.cpp
@@ -8,6 +8,7 @@
 #include "experimental/__p2630_bits/submdspan.hpp"
 #include <experimental/linalg>
 #include <iostream>
+#include <vector>
 
 #if (! defined(__GNUC__)) || (__GNUC__ > 9)
 #  define MDSPAN_EXAMPLES_USE_EXECUTION_POLICIES 1

--- a/examples/02_matrix_vector_product_basic.cpp
+++ b/examples/02_matrix_vector_product_basic.cpp
@@ -7,6 +7,7 @@
 #include <mdspan/mdspan.hpp>
 #include <experimental/linalg>
 #include <iostream>
+#include <vector>
 
 #if (! defined(__GNUC__)) || (__GNUC__ > 9)
 #  define MDSPAN_EXAMPLES_USE_EXECUTION_POLICIES 1

--- a/examples/03_matrix_vector_product_mixedprec.cpp
+++ b/examples/03_matrix_vector_product_mixedprec.cpp
@@ -8,6 +8,7 @@
 #include "experimental/__p2630_bits/submdspan.hpp"
 #include <experimental/linalg>
 #include <iostream>
+#include <vector>
 
 namespace MdSpan = MDSPAN_IMPL_STANDARD_NAMESPACE;
 namespace LinearAlgebra = MDSPAN_IMPL_STANDARD_NAMESPACE :: MDSPAN_IMPL_PROPOSED_NAMESPACE :: linalg;


### PR DESCRIPTION
I have those examples not compiling with gcc because of missing header for std::vector

```
"/.../stdBLAS/examples/01_scale.cpp", line 37: error: namespace "std" has no member "vector"
      std::vector<double> x_vec(N);
           ^
```