### PR TITLE
removal of adding constness by transposed call

### DIFF
--- a/include/experimental/__p1673_bits/transposed.hpp
+++ b/include/experimental/__p1673_bits/transposed.hpp
@@ -200,7 +200,7 @@ namespace impl {
   struct transposed_element_accessor<
     ElementType, default_accessor<ElementType>>
   {
-    using element_type = std::add_const_t<ElementType>;
+    using element_type = ElementType;
     using accessor_type = default_accessor<element_type>;
 
     static accessor_type accessor(const default_accessor<ElementType>& a) { return accessor_type(a); }


### PR DESCRIPTION
there is no reason to add constness by transposed().
P1673 specs does not require adding const either.

Unless fixed, that usage is broken:
```
    linalg::symmetric_matrix_left_product(linalg::scaled(alpha, mdspan{A.data(), m, m}), linalg::lower_triangle,
        linalg::transposed(mdspan{B.data(), n, m}), linalg::transposed(mdspan(C.data(), n, m)));
```