### PR TITLE
read only real part from the diagonal of the hermitian matrix (part 2)

### DIFF
--- a/include/experimental/__p1673_bits/blas3_matrix_product.hpp
+++ b/include/experimental/__p1673_bits/blas3_matrix_product.hpp
@@ -1737,9 +1737,12 @@ void hermitian_matrix_left_product(
     for (size_type j = 0; j < C.extent(1); ++j) {
       for (size_type i = 0; i < C.extent(0); ++i) {
         C(i,j) = ElementType_C{};
-        for (size_type k = 0; k < A.extent(1); ++k){
-          ElementType_A aik = i <= k ? impl::conj_if_needed(A(k,i)) : A(i,k);
-          C(i,j) += aik * B(k,j);
+        for (size_type k = 0; k < i; ++k){
+          C(i,j) += A(i,k) * B(k,j);
+        }
+        C(i,j) += impl::real_part(A(i,i)) * B(i,j);
+        for (size_type k = i+1; k < A.extent(0); ++k){
+          C(i,j) += impl::conj_if_needed(A(k,i)) * B(k,j);
         }
       }
     }
@@ -1748,9 +1751,12 @@ void hermitian_matrix_left_product(
     for (size_type j = 0; j < C.extent(1); ++j) {
       for (size_type i = 0; i < C.extent(0); ++i) {
         C(i,j) = ElementType_C{};
-        for (size_type k = 0; k < A.extent(1); ++k) {
-          ElementType_A aik = i >= k ? impl::conj_if_needed(A(k,i)) : A(i,k);
-          C(i,j) += aik * B(k,j);
+        for (size_type k = 0; k < i; ++k) {
+          C(i,j) += impl::conj_if_needed(A(k,i)) * B(k,j);
+        }
+        C(i,j) += impl::real_part(A(i,i)) * B(i,j);
+        for (size_type k = i+1; k < A.extent(1); ++k) {
+          C(i,j) += A(i,k) * B(k,j);
         }
       }
     }


### PR DESCRIPTION
Another PR (https://github.com/kokkos/stdBLAS/pull/278) fixed (among other things) reading only real part of the diagonal for hermitian matrix-vector product.

This PR fixes the same thing for the matrix-matrix product.