### PR TITLE
aligned vector_abs_sum implementation with spec

### DIFF
--- a/include/experimental/__p1673_bits/abs_if_needed.hpp
+++ b/include/experimental/__p1673_bits/abs_if_needed.hpp
@@ -40,9 +40,10 @@
 //@HEADER
 */
 
-#ifndef LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_CONJUGATE_IF_NEEDED_HPP_
-#define LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_CONJUGATE_IF_NEEDED_HPP_
+#ifndef LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_ABS_IF_NEEDED_HPP_
+#define LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_ABS_IF_NEEDED_HPP_
 
+#include <cmath>
 #include <complex>
 #include <type_traits>
 
@@ -52,43 +53,29 @@ inline namespace __p1673_version_0 {
 namespace linalg {
 namespace impl {
 
-template<class T> struct is_complex : std::false_type{};
-
-template<> struct is_complex<std::complex<float>> : std::true_type{};
-template<> struct is_complex<std::complex<double>> : std::true_type{};
-template<> struct is_complex<std::complex<long double>> : std::true_type{};
-
-template<class T> inline constexpr bool is_complex_v = is_complex<T>::value;
-
-template<class T, class = void>
-struct has_conj : std::false_type {};
-
-// If I can find unqualified conj via overload resolution,
-// then assume that conj(t) returns the conjugate of t.
-template<class T>
-struct has_conj<T, decltype(conj(std::declval<T>()), void())> : std::true_type {};
-
-template<class T>
-T conj_if_needed_impl(const T& t, std::false_type)
-{
-  return t;
-}
-
-template<class T>
-auto conj_if_needed_impl(const T& t, std::true_type)
-{
-  if constexpr (std::is_arithmetic_v<T>) {
-    return t;
-  } else {
-    return conj(t);
-  }
-}
+// E if T is an unsigned integer;
+//
+// (1.2) otherwise, std::abs(E) if T is an arithmetic type,
+//
+// (1.3) otherwise, abs(E), if that expression is valid, with overload
+//   resolution performed in a context that includes the declaration
+//   template<class T> T abs(T) = delete;. If the function selected by
+//   overload resolution does not return the absolute value of its
+//   input, the program is ill-formed, no diagnostic required.
 
 // Inline static variables require C++17.
-constexpr inline auto conj_if_needed = [](const auto& t)
+constexpr inline auto abs_if_needed = [](const auto& t)
 {
-  using T = std::remove_const_t<decltype(t)>;
-  return conj_if_needed_impl(t, has_conj<T>{});
+  using T = std::remove_const_t<decltype(t)>;  
+  if constexpr (std::is_unsigned_v<T>) {
+    return t;
+  }
+  else if (std::is_arithmetic_v<T>) {
+    return std::abs(t);
+  }
+  else {
+    return abs(t);
+  }
 };
 
 } // end namespace impl
@@ -97,4 +84,4 @@ constexpr inline auto conj_if_needed = [](const auto& t)
 } // end namespace MDSPAN_IMPL_PROPOSED_NAMESPACE
 } // end namespace MDSPAN_IMPL_STANDARD_NAMESPACE
 
-#endif //LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_CONJUGATE_IF_NEEDED_HPP_
+#endif //LINALG_INCLUDE_EXPERIMENTAL___P1673_BITS_ABS_IF_NEEDED_HPP_

--- a/include/experimental/__p1673_bits/abs_if_needed.hpp
+++ b/include/experimental/__p1673_bits/abs_if_needed.hpp
@@ -64,14 +64,16 @@ namespace impl {
 //   input, the program is ill-formed, no diagnostic required.
 
 // Inline static variables require C++17.
-constexpr inline auto abs_if_needed = [](const auto& t)
+constexpr inline auto abs_if_needed = [](auto t)
 {
-  using T = std::remove_const_t<decltype(t)>;  
-  if constexpr (std::is_unsigned_v<T>) {
-    return t;
-  }
-  else if (std::is_arithmetic_v<T>) {
-    return std::abs(t);
+  using T = std::remove_const_t<std::remove_reference_t<decltype(t)>>;
+  if constexpr (std::is_arithmetic_v<T>) {
+    if constexpr (std::is_unsigned_v<T>) {
+      return t;
+    }
+    else {
+      return std::abs(t);
+    }
   }
   else {
     return abs(t);

--- a/include/experimental/__p1673_bits/blas1_vector_abs_sum.hpp
+++ b/include/experimental/__p1673_bits/blas1_vector_abs_sum.hpp
@@ -84,12 +84,20 @@ Scalar vector_abs_sum(
   mdspan<ElementType, extents<SizeType, ext0>, Layout, Accessor> v,
   Scalar init)
 {
+  using std::abs;
+  using result_t = decltype(init + abs(impl::real_part(std::declval<ElementType>())));
   const SizeType numElt = v.extent(0);
+  result_t value = init;
   for (SizeType i = 0; i < numElt; ++i) {
-    using std::abs;
-    init += abs(v(i));
+    if constexpr (std::is_arithmetic_v<ElementType>) {
+        value += abs(v(i));
+    }
+    else {
+        value += abs(impl::real_part(v(i)));
+        value += abs(impl::imag_part(v(i)));
+    }
   }
-  return init;
+  return value;
 }
 
 template<class ExecutionPolicy,

--- a/include/experimental/linalg
+++ b/include/experimental/linalg
@@ -51,6 +51,7 @@
 #include "__p1673_bits/layout_tags.hpp"
 #include "__p1673_bits/layout_triangle.hpp"
 #include "__p1673_bits/packed_layout.hpp"
+#include "__p1673_bits/abs_if_needed.hpp"
 #include "__p1673_bits/conjugate_if_needed.hpp"
 #include "__p1673_bits/proxy_reference.hpp"
 #include "__p1673_bits/scaled.hpp"

--- a/tests/native/CMakeLists.txt
+++ b/tests/native/CMakeLists.txt
@@ -12,6 +12,7 @@ macro(linalg_add_test name)
   add_test(${name} ${name})
 endmacro()
 
+linalg_add_test(abs_if_needed)
 linalg_add_test(abs_sum)
 linalg_add_test(add)
 linalg_add_test(conjugate_transposed)

--- a/tests/native/abs_if_needed.cpp
+++ b/tests/native/abs_if_needed.cpp
@@ -1,0 +1,98 @@
+#include "./gtest_fixtures.hpp"
+
+namespace TestLinearAlgebra {
+
+class MyReal {
+public:
+  MyReal() = default;
+  explicit MyReal(double value) : value_(value) {}
+  double value() const { return value_; }
+
+  friend MyReal abs(MyReal x) { return MyReal{std::abs(x.value())}; }
+
+private:
+  double value_ = 0.0;
+};
+
+} // namespace TestLinearAlgebra
+
+namespace {
+  TEST(impl_abs_if_needed, arithmetic_types) {
+    {
+      auto input = 4u;
+      auto result = LinearAlgebra::impl::abs_if_needed(input);
+      static_assert(std::is_same_v<decltype(result), decltype(input)>);
+      EXPECT_EQ(result, input);
+    }
+    {
+      auto input = -4;
+      auto result = LinearAlgebra::impl::abs_if_needed(input);
+      static_assert(std::is_same_v<decltype(result), decltype(input)>);
+      EXPECT_EQ(result, -input);
+    }
+    {
+      auto input = 4;
+      auto result = LinearAlgebra::impl::abs_if_needed(input);
+      static_assert(std::is_same_v<decltype(result), decltype(input)>);
+      EXPECT_EQ(result, input);
+    }
+    {
+      auto input = static_cast<unsigned long long>(4u);
+      auto result = LinearAlgebra::impl::abs_if_needed(input);
+      static_assert(std::is_same_v<decltype(result), decltype(input)>);
+      EXPECT_EQ(result, input);
+    }
+    {
+      auto input = static_cast<long long>(-4);
+      auto result = LinearAlgebra::impl::abs_if_needed(input);
+      static_assert(std::is_same_v<decltype(result), decltype(input)>);
+      EXPECT_EQ(result, -input);
+    }
+    {
+      auto input = static_cast<long long>(4);
+      auto result = LinearAlgebra::impl::abs_if_needed(input);
+      static_assert(std::is_same_v<decltype(result), decltype(input)>);
+      EXPECT_EQ(result, input);
+    }
+    {
+      auto input = -5.0f;
+      auto result = LinearAlgebra::impl::abs_if_needed(input);
+      static_assert(std::is_same_v<decltype(result), decltype(input)>);
+      EXPECT_EQ(result, -input);
+    }
+    {
+      auto input = 5.0f;
+      auto result = LinearAlgebra::impl::abs_if_needed(input);
+      static_assert(std::is_same_v<decltype(result), decltype(input)>);
+      EXPECT_EQ(result, input);
+    }
+    {
+      auto input = -5.0;
+      auto result = LinearAlgebra::impl::abs_if_needed(input);
+      static_assert(std::is_same_v<decltype(result), decltype(input)>);
+      EXPECT_EQ(result, -input);
+    }
+    {
+      auto input = 5.0;
+      auto result = LinearAlgebra::impl::abs_if_needed(input);
+      static_assert(std::is_same_v<decltype(result), decltype(input)>);
+      EXPECT_EQ(result, input);
+    }
+  }
+
+  TEST(impl_abs_if_needed, custom_real) {
+    {
+      auto input = TestLinearAlgebra::MyReal(-4.0);
+      auto result = LinearAlgebra::impl::abs_if_needed(input);
+      static_assert(std::is_same_v<decltype(result), decltype(input)>);
+      EXPECT_EQ(result.value(), -input.value());
+    }
+    {
+      auto input = TestLinearAlgebra::MyReal(4.0);
+      auto result = LinearAlgebra::impl::abs_if_needed(input);
+      static_assert(std::is_same_v<decltype(result), decltype(input)>);
+      EXPECT_EQ(result.value(), input.value());
+    }
+  }
+
+} // end anonymous namespace

--- a/tests/native/abs_sum.cpp
+++ b/tests/native/abs_sum.cpp
@@ -2,21 +2,52 @@
 
 namespace {
 
+  class unsigned_double_vector : public ::testing::Test {
+  private:
+    std::vector<double> storage{
+      0.03125,
+      0.0625,
+      0.125,
+      0.25,
+      0.5,
+      1.0,
+      2.0,
+      4.0,
+      8.0,
+      16.0,
+      32.0
+    };
+  protected:
+    using mdspan_type =
+      mdspan<const double, extents<std::size_t, dynamic_extent>>;
+
+    mdspan_type get_test_mdspan() const {
+      return mdspan_type{storage.data(), 11};
+    }
+
+    double expected_abs_sum() const {
+      return 63.96875; // 63 and 31/32
+    }
+  }; // end class unsigned_double_vector
+
   using LinearAlgebra::vector_abs_sum;
 
   TEST_F(unsigned_double_vector, abs_sum)
   {
-    // EXPECT_DOUBLE_EQ expects values within 4 ULPs.
-    // We don't get that accurate of an answer, so we use EXPECT_NEAR instead.
-    EXPECT_NEAR( 4.6, vector_abs_sum(v,  0.0), 1e-15);
-    EXPECT_NEAR( 5.8, vector_abs_sum(v,  1.2), 1e-15);
-    EXPECT_NEAR(-0.4, vector_abs_sum(v, -5.0), 1e-15);
-    EXPECT_NEAR( 0.0, vector_abs_sum(v, -4.6), 1e-15);
+    auto v = this->get_test_mdspan();
+    auto expected = this->expected_abs_sum();
+    const auto tol =
+      std::sqrt(expected) * std::numeric_limits<decltype(expected)>::epsilon();
+    
+    EXPECT_NEAR( expected,          vector_abs_sum(v,  0.0),      tol);
+    EXPECT_NEAR( (expected + 1.25), vector_abs_sum(v,  1.25),     tol);
+    EXPECT_NEAR( (expected - 5.0),  vector_abs_sum(v, -5.0),      tol);
+    EXPECT_NEAR( 0.0,               vector_abs_sum(v, -expected), tol);
 
     // Test 'auto' overload.
-    const auto sumResultAuto = vector_abs_sum(v);
-    static_assert( std::is_same_v<std::remove_const_t<decltype(sumResultAuto)>, double> );
-    EXPECT_NEAR( 4.6, sumResultAuto, 1e-15 );
+    auto sumResultAuto = vector_abs_sum(v);
+    static_assert( std::is_same_v<decltype(sumResultAuto), decltype(expected)> );
+    EXPECT_NEAR( expected, sumResultAuto, tol );
   }
 
   TEST_F(signed_double_vector, abs_sum)

--- a/tests/native/abs_sum.cpp
+++ b/tests/native/abs_sum.cpp
@@ -31,24 +31,6 @@ namespace {
     }
   };
 
-  TEST_F(unsigned_double_vector, abs_sum)
-  {
-    auto v = this->get_test_mdspan();
-    auto expected = this->expected_abs_sum();
-    const auto tol =
-      std::sqrt(expected) * std::numeric_limits<decltype(expected)>::epsilon();
-
-    EXPECT_NEAR( expected,          vector_abs_sum(v,  0.0),      tol);
-    EXPECT_NEAR( (expected + 1.25), vector_abs_sum(v,  1.25),     tol);
-    EXPECT_NEAR( (expected - 5.0),  vector_abs_sum(v, -5.0),      tol);
-    EXPECT_NEAR( 0.0,               vector_abs_sum(v, -expected), tol);
-
-    // Test 'auto' overload.
-    auto sumResultAuto = vector_abs_sum(v);
-    static_assert( std::is_same_v<decltype(sumResultAuto), decltype(expected)> );
-    EXPECT_NEAR( expected, sumResultAuto, tol );
-  }
-
   class signed_double_vector : public ::testing::Test {
   private:
     std::vector<double> storage{
@@ -77,6 +59,53 @@ namespace {
     }
   };
 
+  class signed_complex_vector : public ::testing::Test {
+  private:
+    std::vector<std::complex<double>> storage{
+      { -0.03125,  0.0625},
+      {  0.0625,  -0.125},
+      { -0.125,    0.25},
+      {  0.25,    -0.5},
+      { -0.5,      1.0},
+      {  1.0,     -2.0},
+      { -2.0,      4.0},
+      {  4.0,     -8.0},
+      { -8.0,     16.0},
+      { 16.0,    -32.0},
+      {-32.0,     64.0}
+    };
+  protected:
+    using mdspan_type =
+      mdspan<const std::complex<double>,
+        extents<std::size_t, dynamic_extent>>;
+
+    mdspan_type get_test_mdspan() const {
+      return mdspan_type{storage.data(), 11};
+    }
+
+    double expected_abs_sum() const {
+      return 191.90625; // 63 and 31/32, plus 127 and 15/16
+    }
+  };
+
+  TEST_F(unsigned_double_vector, abs_sum)
+  {
+    auto v = this->get_test_mdspan();
+    auto expected = this->expected_abs_sum();
+    const auto tol =
+      std::sqrt(expected) * std::numeric_limits<decltype(expected)>::epsilon();
+
+    EXPECT_NEAR( expected,          vector_abs_sum(v,  0.0),      tol);
+    EXPECT_NEAR( (expected + 1.25), vector_abs_sum(v,  1.25),     tol);
+    EXPECT_NEAR( (expected - 5.0),  vector_abs_sum(v, -5.0),      tol);
+    EXPECT_NEAR( 0.0,               vector_abs_sum(v, -expected), tol);
+
+    // Test 'auto' overload.
+    auto sumResultAuto = vector_abs_sum(v);
+    static_assert( std::is_same_v<decltype(sumResultAuto), decltype(expected)> );
+    EXPECT_NEAR( expected, sumResultAuto, tol );
+  }
+
   TEST_F(signed_double_vector, abs_sum)
   {
     auto v = this->get_test_mdspan();
@@ -97,17 +126,23 @@ namespace {
 
   TEST_F(signed_complex_vector, abs_sum)
   {
-    // EXPECT_DOUBLE_EQ expects values within 4 ULPs.
-    // We don't get that accurate of an answer, so we use EXPECT_NEAR instead.
-    EXPECT_NEAR(3.5188912597625004, vector_abs_sum(v, 0.0), 1e-15);
-    EXPECT_NEAR(4.7188912597625004, vector_abs_sum(v, 1.2), 1e-15);
-    EXPECT_NEAR(-0.4811087402374996, vector_abs_sum(v, -4.0), 1e-15);
-    EXPECT_NEAR(0.0, vector_abs_sum(v, -3.5188912597625004), 1e-15);
+    auto v = this->get_test_mdspan();
+    auto expected = this->expected_abs_sum();
+    // Complex numbers have two parts (real and imaginary).
+    // This means there are twice as many terms in the sum.
+    const auto tol =
+      std::sqrt(decltype(expected)(2.0) * expected) *
+      std::numeric_limits<decltype(expected)>::epsilon();
+
+    EXPECT_NEAR( expected,          vector_abs_sum(v,  0.0),      tol);
+    EXPECT_NEAR( (expected + 1.25), vector_abs_sum(v,  1.25),     tol);
+    EXPECT_NEAR( (expected - 5.0),  vector_abs_sum(v, -5.0),      tol);
+    EXPECT_NEAR( 0.0,               vector_abs_sum(v, -expected), tol);
 
     // Test 'auto' overload.
-    const auto sumResultAuto = vector_abs_sum(v);
-    static_assert( std::is_same_v<std::remove_const_t<decltype(sumResultAuto)>, double> );
-    EXPECT_NEAR( 3.5188912597625004, sumResultAuto, 1e-15 );
+    auto sumResultAuto = vector_abs_sum(v);
+    static_assert( std::is_same_v<decltype(sumResultAuto), decltype(expected)> );
+    EXPECT_NEAR( expected, sumResultAuto, tol );
   }
 
 } // end anonymous namespace

--- a/tests/native/abs_sum.cpp
+++ b/tests/native/abs_sum.cpp
@@ -1,6 +1,7 @@
 #include "./gtest_fixtures.hpp"
 
 namespace {
+  using LinearAlgebra::vector_abs_sum;
 
   class unsigned_double_vector : public ::testing::Test {
   private:
@@ -28,9 +29,7 @@ namespace {
     double expected_abs_sum() const {
       return 63.96875; // 63 and 31/32
     }
-  }; // end class unsigned_double_vector
-
-  using LinearAlgebra::vector_abs_sum;
+  };
 
   TEST_F(unsigned_double_vector, abs_sum)
   {
@@ -38,7 +37,7 @@ namespace {
     auto expected = this->expected_abs_sum();
     const auto tol =
       std::sqrt(expected) * std::numeric_limits<decltype(expected)>::epsilon();
-    
+
     EXPECT_NEAR( expected,          vector_abs_sum(v,  0.0),      tol);
     EXPECT_NEAR( (expected + 1.25), vector_abs_sum(v,  1.25),     tol);
     EXPECT_NEAR( (expected - 5.0),  vector_abs_sum(v, -5.0),      tol);
@@ -50,19 +49,50 @@ namespace {
     EXPECT_NEAR( expected, sumResultAuto, tol );
   }
 
+  class signed_double_vector : public ::testing::Test {
+  private:
+    std::vector<double> storage{
+      -0.03125,
+      0.0625,
+      -0.125,
+      0.25,
+      -0.5,
+      1.0,
+      -2.0,
+      4.0,
+      -8.0,
+      16.0,
+      -32.0
+    };
+  protected:
+    using mdspan_type =
+      mdspan<const double, extents<std::size_t, dynamic_extent>>;
+
+    mdspan_type get_test_mdspan() const {
+      return mdspan_type{storage.data(), 11};
+    }
+
+    double expected_abs_sum() const {
+      return 63.96875; // 63 and 31/32
+    }
+  };
+
   TEST_F(signed_double_vector, abs_sum)
   {
-    // EXPECT_DOUBLE_EQ expects values within 4 ULPs.
-    // We don't get that accurate of an answer, so we use EXPECT_NEAR instead.
-    EXPECT_NEAR( 4.6, vector_abs_sum(v,  0.0), 1e-15);
-    EXPECT_NEAR( 5.8, vector_abs_sum(v,  1.2), 1e-15);
-    EXPECT_NEAR(-0.4, vector_abs_sum(v, -5.0), 1e-15);
-    EXPECT_NEAR( 0.0, vector_abs_sum(v, -4.6), 1e-15);
+    auto v = this->get_test_mdspan();
+    auto expected = this->expected_abs_sum();
+    const auto tol =
+      std::sqrt(expected) * std::numeric_limits<decltype(expected)>::epsilon();
+
+    EXPECT_NEAR( expected,          vector_abs_sum(v,  0.0),      tol);
+    EXPECT_NEAR( (expected + 1.25), vector_abs_sum(v,  1.25),     tol);
+    EXPECT_NEAR( (expected - 5.0),  vector_abs_sum(v, -5.0),      tol);
+    EXPECT_NEAR( 0.0,               vector_abs_sum(v, -expected), tol);
 
     // Test 'auto' overload.
-    const auto sumResultAuto = vector_abs_sum(v);
-    static_assert( std::is_same_v<std::remove_const_t<decltype(sumResultAuto)>, double> );
-    EXPECT_NEAR( 4.6, sumResultAuto, 1e-15 );
+    auto sumResultAuto = vector_abs_sum(v);
+    static_assert( std::is_same_v<decltype(sumResultAuto), decltype(expected)> );
+    EXPECT_NEAR( expected, sumResultAuto, tol );
   }
 
   TEST_F(signed_complex_vector, abs_sum)


### PR DESCRIPTION
1) using abs(real) + abs(imag) for non-arithmetic types
2) following GENERALIZED_SUM definition for intermediate calculation types