### PR TITLE
Fix hermitian rank-1/2/k/2k updates

### DIFF
--- a/include/experimental/__p1673_bits/blas2_matrix_rank_1_update.hpp
+++ b/include/experimental/__p1673_bits/blas2_matrix_rank_1_update.hpp
@@ -534,6 +534,7 @@ void hermitian_matrix_rank_1_update(
 
   if constexpr (std::is_same_v<Triangle, lower_triangle_t>) {
     for (size_type j = 0; j < A.extent(1); ++j) {
+      A(j,j) = impl::real_part(A(j,j));
       for (size_type i = j; i < A.extent(0); ++i) {
         A(i,j) += alpha * x(i) * impl::conj_if_needed(x(j));
       }
@@ -541,6 +542,7 @@ void hermitian_matrix_rank_1_update(
   }
   else {
     for (size_type j = 0; j < A.extent(1); ++j) {
+      A(j,j) = impl::real_part(A(j,j));
       for (size_type i = 0; i <= j; ++i) {
         A(i,j) += alpha * x(i) * impl::conj_if_needed(x(j));
       }
@@ -641,6 +643,7 @@ void hermitian_matrix_rank_1_update(
 
   if constexpr (std::is_same_v<Triangle, lower_triangle_t>) {
     for (size_type j = 0; j < A.extent(1); ++j) {
+      A(j,j) = impl::real_part(A(j,j));
       for (size_type i = j; i < A.extent(0); ++i) {
         A(i,j) += x(i) * impl::conj_if_needed(x(j));
       }
@@ -648,6 +651,7 @@ void hermitian_matrix_rank_1_update(
   }
   else {
     for (size_type j = 0; j < A.extent(1); ++j) {
+      A(j,j) = impl::real_part(A(j,j));
       for (size_type i = 0; i <= j; ++i) {
         A(i,j) += x(i) * impl::conj_if_needed(x(j));
       }

--- a/include/experimental/__p1673_bits/blas2_matrix_rank_2_update.hpp
+++ b/include/experimental/__p1673_bits/blas2_matrix_rank_2_update.hpp
@@ -217,6 +217,7 @@ void hermitian_matrix_rank_2_update(
     const size_type i_lower = lower_tri ? j : size_type(0);
     const size_type i_upper = lower_tri ? A.extent(0) : j+1;
 
+    A(j,j) = impl::real_part(A(j,j));
     for (size_type i = i_lower; i < i_upper; ++i) {
       A(i,j) += x(i) * impl::conj_if_needed(y(j)) + y(i) * impl::conj_if_needed(x(j));
     }

--- a/include/experimental/__p1673_bits/blas3_matrix_rank_2k_update.hpp
+++ b/include/experimental/__p1673_bits/blas3_matrix_rank_2k_update.hpp
@@ -211,6 +211,7 @@ void hermitian_matrix_rank_2k_update(
   for (size_type j = 0; j < C.extent(1); ++j) {
     const size_type i_lower = lower_tri ? j : size_type(0);
     const size_type i_upper = lower_tri ? C.extent(0) : j+1;
+    C(j,j) = impl::real_part(C(j,j));
     for (size_type i = i_lower; i < i_upper; ++i) {
       for (size_type k = 0; k < A.extent(1); ++k) {
         C(i,j) += A(i,k) * impl::conj_if_needed(B(j,k)) + B(i,k) * impl::conj_if_needed(A(j,k));

--- a/include/experimental/__p1673_bits/blas3_matrix_rank_k_update.hpp
+++ b/include/experimental/__p1673_bits/blas3_matrix_rank_k_update.hpp
@@ -355,6 +355,7 @@ void hermitian_matrix_rank_k_update(
   for (size_type j = 0; j < C.extent(1); ++j) {
     const size_type i_lower = lower_tri ? j : size_type(0);
     const size_type i_upper = lower_tri ? C.extent(0) : j+1;
+    C(j, j) = impl::real_part(C(j, j));
     for (size_type i = i_lower; i < i_upper; ++i) {
       for (size_type k = 0; k < A.extent(1); ++k) {
           C(i, j) += alpha * A(i, k) * impl::conj_if_needed(A(j, k));
@@ -455,6 +456,7 @@ void hermitian_matrix_rank_k_update(
   using size_type = std::common_type_t<SizeType_A, SizeType_C>;
 
   for (size_type j = 0; j < C.extent(1); ++j) {
+    C(j, j) = impl::real_part(C(j, j));
     const size_type i_lower = lower_tri ? j : size_type(0);
     const size_type i_upper = lower_tri ? C.extent(0) : j+1;
     for (size_type i = i_lower; i < i_upper; ++i) {


### PR DESCRIPTION
Imaginary part of the diagonal is zeroed.
Aligned with BLAS.
Can be considered aligned with spec change, where diagonal is not touched on read (but replaced on store).