### PR TITLE
Fix vector idx abs max

### DIFF
--- a/examples/kokkos-based/idx_abs_max_kokkos.cpp
+++ b/examples/kokkos-based/idx_abs_max_kokkos.cpp
@@ -11,10 +11,10 @@ void run_trivial_example()
   using extents_type = stdexp::extents<stdexp::dynamic_extent>;
   stdexp::mdspan<value_type, extents_type> a(arr.data(),0);
 
-  const auto idx = stdla::idx_abs_max(std::execution::seq, a);
+  const auto idx = stdla::vector_idx_abs_max(std::execution::seq, a);
   std::cout << "Sequen result = " << idx << '\n';
 
-  const auto idx_kk = stdla::idx_abs_max(KokkosKernelsSTD::kokkos_exec<>(), a);
+  const auto idx_kk = stdla::vector_idx_abs_max(KokkosKernelsSTD::kokkos_exec<>(), a);
   std::cout << "Kokkos result = " << idx_kk << '\n';
 }
 
@@ -39,17 +39,17 @@ void run_nontrivial_example()
   a(9) = -0.9;
 
   // This goes to the base implementation
-  const auto idx = stdla::idx_abs_max(std::execution::seq, a);
+  const auto idx = stdla::vector_idx_abs_max(std::execution::seq, a);
   std::cout << "Sequen result = " << idx << '\n';
 
   // This forwards to KokkosKernels (https://github.com/kokkos/kokkos-kernels
-  const auto idx_kk = stdla::idx_abs_max(KokkosKernelsSTD::kokkos_exec<>(), a);
+  const auto idx_kk = stdla::vector_idx_abs_max(KokkosKernelsSTD::kokkos_exec<>(), a);
   std::cout << "Kokkos result = " << idx_kk << '\n';
 }
 
 int main(int argc, char* argv[])
 {
-  std::cout << "idx_abs_max example: calling kokkos-kernels" << std::endl;
+  std::cout << "vector_idx_abs_max example: calling kokkos-kernels" << std::endl;
 
   Kokkos::initialize(argc,argv);
   {

--- a/include/experimental/__p1673_bits/blas1_vector_abs_sum.hpp
+++ b/include/experimental/__p1673_bits/blas1_vector_abs_sum.hpp
@@ -90,7 +90,6 @@ Scalar vector_abs_sum(
              impl::abs_if_needed(impl::real_if_needed(std::declval<value_type>())) +
              impl::abs_if_needed(impl::imag_if_needed(std::declval<value_type>())));
   static_assert(std::is_convertible_v<sum_type, Scalar>);
-  // TODO Implement the Remarks in para 4.
   
   const SizeType numElt = v.extent(0);
   if constexpr (std::is_arithmetic_v<value_type>) {

--- a/include/experimental/__p1673_bits/blas1_vector_idx_abs_max.hpp
+++ b/include/experimental/__p1673_bits/blas1_vector_idx_abs_max.hpp
@@ -77,14 +77,15 @@ SizeType vector_idx_abs_max_default_impl(
 {
   using std::abs;
   using value_type = typename decltype(v)::value_type;
+  using magnitude_type =
+    decltype(impl::abs_if_needed(impl::real_if_needed(std::declval<value_type>())) +
+             impl::abs_if_needed(impl::imag_if_needed(std::declval<value_type>())));
 
   if (v.extent(0) == 0) {
     return std::numeric_limits<SizeType>::max();
   }
 
   if constexpr (std::is_arithmetic_v<value_type>) {
-    using magnitude_type = decltype(impl::abs_if_needed(std::declval<value_type>()));
-
     SizeType maxInd = 0;
     magnitude_type maxVal = abs(v(0));
     for (SizeType i = 1; i < v.extent(0); ++i) {
@@ -93,12 +94,10 @@ SizeType vector_idx_abs_max_default_impl(
         maxInd = i;
       }
     }
+
+    return maxInd;
   }
   else {
-    using magnitude_type =
-      decltype(impl::abs_if_needed(impl::real_if_needed(std::declval<value_type>())) +
-               impl::abs_if_needed(impl::imag_if_needed(std::declval<value_type>())));
-
     SizeType maxInd = 0;
     magnitude_type maxVal = impl::abs_if_needed(impl::real_if_needed(v(0))) +
                             impl::abs_if_needed(impl::imag_if_needed(v(0)));
@@ -112,9 +111,9 @@ SizeType vector_idx_abs_max_default_impl(
         maxInd = i;
       }
     }
-  }
 
-  return maxInd; // FIXME check for NaN "never less than" stuff
+    return maxInd;
+  }
 }
 
 } // end anonymous namespace

--- a/include/experimental/__p1673_bits/blas1_vector_idx_abs_max.hpp
+++ b/include/experimental/__p1673_bits/blas1_vector_idx_abs_max.hpp
@@ -52,15 +52,15 @@ namespace linalg {
 namespace {
 
 template <class Exec, class v_t, class = void>
-struct is_custom_idx_abs_max_avail : std::false_type {};
+struct is_custom_vector_idx_abs_max_avail : std::false_type {};
 
 template <class Exec, class v_t>
-struct is_custom_idx_abs_max_avail<
+struct is_custom_vector_idx_abs_max_avail<
   Exec, v_t,
   std::enable_if_t<
     //FRizzi: maybe should use is_convertible?
     std::is_same<
-      decltype(idx_abs_max(std::declval<Exec>(), std::declval<v_t>())),
+      decltype(vector_idx_abs_max(std::declval<Exec>(), std::declval<v_t>())),
       typename v_t::extents_type::size_type
       >::value
     && ! impl::is_inline_exec_v<Exec>
@@ -72,7 +72,7 @@ template<class ElementType,
          class SizeType, ::std::size_t ext0,
          class Layout,
          class Accessor>
-SizeType idx_abs_max_default_impl(
+SizeType vector_idx_abs_max_default_impl(
   mdspan<ElementType, extents<SizeType, ext0>, Layout, Accessor> v)
 {
   using std::abs;
@@ -99,11 +99,11 @@ template<class ElementType,
          class SizeType, ::std::size_t ext0,
          class Layout,
          class Accessor>
-SizeType idx_abs_max(
+SizeType vector_idx_abs_max(
   impl::inline_exec_t&& /* exec */,
   mdspan<ElementType, extents<SizeType, ext0>, Layout, Accessor> v)
 {
-  return idx_abs_max_default_impl(v);
+  return vector_idx_abs_max_default_impl(v);
 }
 
 template<class ExecutionPolicy,
@@ -111,7 +111,7 @@ template<class ExecutionPolicy,
          class SizeType, ::std::size_t ext0,
          class Layout,
          class Accessor>
-SizeType idx_abs_max(
+SizeType vector_idx_abs_max(
   ExecutionPolicy&& exec,
   mdspan<ElementType, extents<SizeType, ext0>, Layout, Accessor> v)
 {
@@ -119,15 +119,15 @@ SizeType idx_abs_max(
     return std::numeric_limits<SizeType>::max();
   }
 
-  constexpr bool use_custom = is_custom_idx_abs_max_avail<
+  constexpr bool use_custom = is_custom_vector_idx_abs_max_avail<
     decltype(impl::map_execpolicy_with_check(exec)), decltype(v)
     >::value;
 
   if constexpr (use_custom) {
-    return idx_abs_max(impl::map_execpolicy_with_check(exec), v);
+    return vector_idx_abs_max(impl::map_execpolicy_with_check(exec), v);
   }
   else {
-    return idx_abs_max(impl::inline_exec_t{}, v);
+    return vector_idx_abs_max(impl::inline_exec_t{}, v);
   }
 }
 
@@ -135,10 +135,10 @@ template<class ElementType,
          class SizeType, ::std::size_t ext0,
          class Layout,
          class Accessor>
-SizeType idx_abs_max(
+SizeType vector_idx_abs_max(
   mdspan<ElementType, extents<SizeType, ext0>, Layout, Accessor> v)
 {
-  return idx_abs_max(impl::default_exec_t{}, v);
+  return vector_idx_abs_max(impl::default_exec_t{}, v);
 }
 
 } // end namespace linalg

--- a/tests/kokkos-based/helpers.hpp
+++ b/tests/kokkos-based/helpers.hpp
@@ -137,9 +137,9 @@ auto abs_max(mdspan<ElementType, extents<Extent>, LayoutPolicy, AccessorPolicy> 
   if (size == 0) {
     throw std::runtime_error("abs_max() requires non-empty input");
   }
-  const auto i = std::experimental::linalg::idx_abs_max(v);
+  const auto i = std::experimental::linalg::vector_idx_abs_max(v);
   if (i >= size) { // shouldn't happen: empty case is handled above
-    throw std::runtime_error("Fatal: idx_abs_max() failed");
+    throw std::runtime_error("Fatal: vector_idx_abs_max() failed");
   }
   return std::abs(v[i]);
 }

--- a/tests/kokkos-based/idx_abs_max_kokkos.cpp
+++ b/tests/kokkos-based/idx_abs_max_kokkos.cpp
@@ -7,7 +7,7 @@ namespace
 
 template<class x_t>
 std::experimental::extents<>::size_type
-idx_abs_max_gold_solution(x_t x)
+vector_idx_abs_max_gold_solution(x_t x)
 {
 
   using std::abs;
@@ -26,7 +26,7 @@ idx_abs_max_gold_solution(x_t x)
 }
 
 template<class x_t>
-void kokkos_blas1_idx_abs_max_test_impl(x_t x)
+void kokkos_blas1_vector_idx_abs_max_test_impl(x_t x)
 {
 
   namespace stdla = std::experimental::linalg;
@@ -34,11 +34,11 @@ void kokkos_blas1_idx_abs_max_test_impl(x_t x)
   // copy x to verify it is not changed after kernel
   auto x_preKernel = kokkostesting::create_stdvector_and_copy(x);
 
-  const auto gold = idx_abs_max_gold_solution(x);
-  const auto result = stdla::idx_abs_max(KokkosKernelsSTD::kokkos_exec<>(), x);
+  const auto gold = vector_idx_abs_max_gold_solution(x);
+  const auto result = stdla::vector_idx_abs_max(KokkosKernelsSTD::kokkos_exec<>(), x);
   EXPECT_TRUE(gold == result);
   static_assert(std::is_same_v<decltype(gold), decltype(result)>,
-		"test:idx_abs_max: gold and result types not same");
+		"test:vector_idx_abs_max: gold and result types not same");
 
   // x should not change after kernel
   const std::size_t extent = x.extent(0);
@@ -50,21 +50,21 @@ void kokkos_blas1_idx_abs_max_test_impl(x_t x)
 }//end anonym namespace
 
 
-TEST_F(blas1_signed_float_fixture, kokkos_idx_abs_max)
+TEST_F(blas1_signed_float_fixture, kokkos_vector_idx_abs_max)
 {
-  kokkos_blas1_idx_abs_max_test_impl(x);
+  kokkos_blas1_vector_idx_abs_max_test_impl(x);
 }
 
-TEST_F(blas1_signed_double_fixture, kokkos_idx_abs_max)
+TEST_F(blas1_signed_double_fixture, kokkos_vector_idx_abs_max)
 {
-  kokkos_blas1_idx_abs_max_test_impl(x);
+  kokkos_blas1_vector_idx_abs_max_test_impl(x);
 }
 
-TEST_F(blas1_signed_complex_double_fixture, kokkos_idx_abs_max)
+TEST_F(blas1_signed_complex_double_fixture, kokkos_vector_idx_abs_max)
 {
   using kc_t   = Kokkos::complex<double>;
   using stdc_t = value_type;
   if constexpr(alignof(value_type) == alignof(kc_t)){
-    kokkos_blas1_idx_abs_max_test_impl(x);
+    kokkos_blas1_vector_idx_abs_max_test_impl(x);
   }
 }

--- a/tests/native/gtest_fixtures.hpp
+++ b/tests/native/gtest_fixtures.hpp
@@ -142,14 +142,15 @@ protected:
 class signed_complex_vector : public ::testing::Test {
 protected:
   signed_complex_vector() :
-    storage(5),
-    v(storage.data(), 5)
+    storage(6),
+    v(storage.data(), 6)
   {
     v(0) = std::complex<double>( 0.5,  0.2);
     v(1) = std::complex<double>( 0.1,  0.4);
-    v(2) = std::complex<double>(-0.8, -0.7);
-    v(3) = std::complex<double>(-0.3,  0.5);
-    v(4) = std::complex<double>( 0.2, -0.9);
+    v(2) = std::complex<double>(-0.8,  0.7);
+    v(3) = std::complex<double>(-0.79, -0.711);
+    v(4) = std::complex<double>(-0.3,  0.5);
+    v(5) = std::complex<double>( 0.2, -0.9);
   }
 
   std::vector<std::complex<double>> storage;

--- a/tests/native/idx_abs_max.cpp
+++ b/tests/native/idx_abs_max.cpp
@@ -18,7 +18,7 @@ namespace {
 
   TEST_F(signed_complex_vector, vector_idx_abs_max)
   {
-    constexpr size_t expected(2);
+    constexpr size_t expected(3);
     EXPECT_EQ(expected, vector_idx_abs_max(v));
   }
 

--- a/tests/native/idx_abs_max.cpp
+++ b/tests/native/idx_abs_max.cpp
@@ -2,38 +2,38 @@
 
 namespace {
 
-  using LinearAlgebra::idx_abs_max;
+  using LinearAlgebra::vector_idx_abs_max;
 
-  TEST_F(unsigned_double_vector, idx_abs_max)
+  TEST_F(unsigned_double_vector, vector_idx_abs_max)
   {
     constexpr size_t expected(9);
-    EXPECT_EQ(expected, idx_abs_max(v));
+    EXPECT_EQ(expected, vector_idx_abs_max(v));
   }
 
-  TEST_F(signed_double_vector, idx_abs_max)
+  TEST_F(signed_double_vector, vector_idx_abs_max)
   {
     constexpr size_t expected(9);
-    EXPECT_EQ(expected, idx_abs_max(v));
+    EXPECT_EQ(expected, vector_idx_abs_max(v));
   }
 
-  TEST_F(signed_complex_vector, idx_abs_max)
+  TEST_F(signed_complex_vector, vector_idx_abs_max)
   {
     constexpr size_t expected(2);
-    EXPECT_EQ(expected, idx_abs_max(v));
+    EXPECT_EQ(expected, vector_idx_abs_max(v));
   }
 
-  TEST(BLAS1_idx_abs_max, trivial_case)
+  TEST(BLAS1_vector_idx_abs_max, trivial_case)
   {
     constexpr auto expected = std::numeric_limits<std::size_t>::max();
 
     std::array<double, 0> arr;
     using extents_type = extents<std::size_t, dynamic_extent>;
     mdspan<double, extents_type> a(arr.data(),0);
-    EXPECT_EQ(expected, idx_abs_max(a));
+    EXPECT_EQ(expected, vector_idx_abs_max(a));
 
     using extents_type2 = extents<std::size_t, 0>;
     mdspan<double, extents_type2> b(arr.data());
-    EXPECT_EQ(expected, idx_abs_max(b));
+    EXPECT_EQ(expected, vector_idx_abs_max(b));
   }
 
 } // end anonymous namespace

--- a/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas1_idx_abs_max_kk.hpp
+++ b/tpl-implementations/include/experimental/__p1673_bits/kokkos-kernels/blas1_idx_abs_max_kk.hpp
@@ -14,14 +14,14 @@ template<class ExeSpace,
          std::experimental::extents<>::size_type ext0,
          class Layout>
 std::experimental::extents<>::size_type
-idx_abs_max(kokkos_exec<ExeSpace> /*kexe*/,
+vector_idx_abs_max(kokkos_exec<ExeSpace> /*kexe*/,
 	    std::experimental::mdspan<
 	    ElementType,
 	    std::experimental::extents<ext0>,
 	    Layout,
 	    std::experimental::default_accessor<ElementType>> v)
 {
-  Impl::signal_kokkos_impl_called("idx_abs_max");
+  Impl::signal_kokkos_impl_called("vector_idx_abs_max");
 
   auto v_view = Impl::mdspan_to_view(v);
 


### PR DESCRIPTION
1) renamed idx_abs_max -> vector_idx_abs_max
2) aligned behavior for complex values with the spec (that is abs is not really abs)
3) Currently if NaN is in the first position output is 0. Output will ignore NaNs in any other position and will provide an index of the max value, ignoring all other NaNs. NaNs are checked the same way as in BLAS (that is not really checked). NaN behavior is not clarified with spec. Anything beyond that implementation will have cross-board performance implications. Leave NaNs to unspecified output. 