### PR TITLE
Fix for vector_sum_of_squares and renaming for vector_norm2

### DIFF
--- a/include/experimental/__p1673_bits/blas1_vector_norm2.hpp
+++ b/include/experimental/__p1673_bits/blas1_vector_norm2.hpp
@@ -55,15 +55,15 @@ namespace linalg {
 namespace
 {
 template <class Exec, class x_t, class Scalar, class = void>
-struct is_custom_vector_norm2_avail : std::false_type {};
+struct is_custom_vector_two_norm_avail : std::false_type {};
 
 template <class Exec, class x_t, class Scalar>
-struct is_custom_vector_norm2_avail<
+struct is_custom_vector_two_norm_avail<
   Exec, x_t, Scalar,
   std::enable_if_t<
     std::is_same<
       decltype(
-	       vector_norm2(std::declval<Exec>(),
+	       vector_two_norm(std::declval<Exec>(),
 			    std::declval<x_t>(),
 			    std::declval<Scalar>())
 	       ),
@@ -80,7 +80,7 @@ template<class ElementType,
          class Layout,
          class Accessor,
          class Scalar>
-Scalar vector_norm2(
+Scalar vector_two_norm(
   impl::inline_exec_t&& exec,
   mdspan<ElementType, extents<SizeType, ext0>, Layout, Accessor> x,
   Scalar init)
@@ -105,20 +105,20 @@ template<class ExecutionPolicy,
          class Layout,
          class Accessor,
          class Scalar>
-Scalar vector_norm2(
+Scalar vector_two_norm(
   ExecutionPolicy&& exec,
   mdspan<ElementType, extents<SizeType, ext0>, Layout, Accessor> x,
   Scalar init)
 {
-  constexpr bool use_custom = is_custom_vector_norm2_avail<
+  constexpr bool use_custom = is_custom_vector_two_norm_avail<
     decltype(impl::map_execpolicy_with_check(exec)), decltype(x), Scalar
     >::value;
 
   if constexpr (use_custom) {
-    return vector_norm2(impl::map_execpolicy_with_check(exec), x, init);
+    return vector_two_norm(impl::map_execpolicy_with_check(exec), x, init);
   }
   else {
-    return vector_norm2(impl::inline_exec_t{}, x, init);
+    return vector_two_norm(impl::inline_exec_t{}, x, init);
   }
 }
 
@@ -127,15 +127,15 @@ template<class ElementType,
          class Layout,
          class Accessor,
          class Scalar>
-Scalar vector_norm2(
+Scalar vector_two_norm(
   mdspan<ElementType, extents<SizeType, ext0>, Layout, Accessor> x,
   Scalar init)
 {
-  return vector_norm2(impl::default_exec_t{}, x, init);
+  return vector_two_norm(impl::default_exec_t{}, x, init);
 }
 
 
-namespace vector_norm2_detail {
+namespace vector_two_norm_detail {
   using std::abs;
 
   // The point of this is to do correct ADL for abs,
@@ -145,21 +145,21 @@ namespace vector_norm2_detail {
     class SizeType, ::std::size_t ext0,
     class Layout,
     class Accessor>
-  auto vector_norm2_return_type_deducer(
+  auto vector_two_norm_return_type_deducer(
     mdspan<ElementType, extents<SizeType, ext0>, Layout, Accessor> x)
   -> decltype(abs(x(0)) * abs(x(0)));
-} // namespace vector_norm2_detail
+} // namespace vector_two_norm_detail
 
 template<class ElementType,
          class SizeType, ::std::size_t ext0,
          class Layout,
          class Accessor>
-auto vector_norm2(
+auto vector_two_norm(
   mdspan<ElementType, extents<SizeType, ext0>, Layout, Accessor> x)
--> decltype(vector_norm2_detail::vector_norm2_return_type_deducer(x))
+-> decltype(vector_two_norm_detail::vector_two_norm_return_type_deducer(x))
 {
-  using return_t = decltype(vector_norm2_detail::vector_norm2_return_type_deducer(x));
-  return vector_norm2(x, return_t{});
+  using return_t = decltype(vector_two_norm_detail::vector_two_norm_return_type_deducer(x));
+  return vector_two_norm(x, return_t{});
 }
 
 template<class ExecutionPolicy,
@@ -167,13 +167,13 @@ template<class ExecutionPolicy,
          class SizeType, ::std::size_t ext0,
          class Layout,
          class Accessor>
-auto vector_norm2(
+auto vector_two_norm(
   ExecutionPolicy&& exec,
   mdspan<ElementType, extents<SizeType, ext0>, Layout, Accessor> x)
--> decltype(vector_norm2_detail::vector_norm2_return_type_deducer(x))
+-> decltype(vector_two_norm_detail::vector_two_norm_return_type_deducer(x))
 {
-  using return_t = decltype(vector_norm2_detail::vector_norm2_return_type_deducer(x));
-  return vector_norm2(exec, x, return_t{});
+  using return_t = decltype(vector_two_norm_detail::vector_two_norm_return_type_deducer(x));
+  return vector_two_norm(exec, x, return_t{});
 }
 
 } // end namespace linalg

--- a/include/experimental/__p1673_bits/blas1_vector_sum_of_squares.hpp
+++ b/include/experimental/__p1673_bits/blas1_vector_sum_of_squares.hpp
@@ -107,12 +107,13 @@ sum_of_squares_result<Scalar> vector_sum_of_squares(
   for (SizeType i = 0; i < x.extent(0); ++i) {
     if (abs(x(i)) != 0.0) {
       const auto absxi = abs(x(i));
-      const auto quotient = scale / absxi;
       if (scale < absxi) {
+          const auto quotient = scale / absxi;
           ssq = Scalar(1.0) + ssq * quotient * quotient;
           scale = absxi;
       }
       else {
+        const auto quotient = absxi / scale;
         ssq = ssq + quotient * quotient;
       }
     }

--- a/tests/kokkos-based/vector_norm2_kokkos.cpp
+++ b/tests/kokkos-based/vector_norm2_kokkos.cpp
@@ -7,7 +7,7 @@ namespace
 {
 
 template<class x_t, class T>
-T vector_norm2_gold_solution(x_t x, T initValue, bool useInit)
+T vector_two_norm_gold_solution(x_t x, T initValue, bool useInit)
 {
   using std::abs;
   using value_type = typename x_t::value_type;
@@ -32,7 +32,7 @@ T vector_norm2_gold_solution(x_t x, T initValue, bool useInit)
 }
 
 template<class x_t, class T>
-void kokkos_blas1_vector_norm2_test_impl(x_t x, T initValue, bool useInit)
+void kokkos_blas1_vector_two_norm_test_impl(x_t x, T initValue, bool useInit)
 {
   namespace stdla = std::experimental::linalg;
 
@@ -42,14 +42,14 @@ void kokkos_blas1_vector_norm2_test_impl(x_t x, T initValue, bool useInit)
   // copy x to verify they are not changed after kernel
   auto x_preKernel = kokkostesting::create_stdvector_and_copy(x);
 
-  const T gold = vector_norm2_gold_solution(x, initValue, useInit);
+  const T gold = vector_two_norm_gold_solution(x, initValue, useInit);
 
   T result = {};
   if (useInit){
-    result = stdla::vector_norm2(KokkosKernelsSTD::kokkos_exec<>(),
+    result = stdla::vector_two_norm(KokkosKernelsSTD::kokkos_exec<>(),
 				 x, initValue);
   }else{
-    result = stdla::vector_norm2(KokkosKernelsSTD::kokkos_exec<>(),
+    result = stdla::vector_two_norm(KokkosKernelsSTD::kokkos_exec<>(),
 				 x);
   }
 
@@ -73,42 +73,42 @@ void kokkos_blas1_vector_norm2_test_impl(x_t x, T initValue, bool useInit)
 }
 }//end anonym namespace
 
-TEST_F(blas1_signed_float_fixture, kokkos_vector_norm2_noinitvalue)
+TEST_F(blas1_signed_float_fixture, kokkos_vector_two_norm_noinitvalue)
 {
-  kokkos_blas1_vector_norm2_test_impl(x, static_cast<float>(0), false);
+  kokkos_blas1_vector_two_norm_test_impl(x, static_cast<float>(0), false);
 }
 
-TEST_F(blas1_signed_float_fixture, kokkos_vector_norm2_initvalue)
+TEST_F(blas1_signed_float_fixture, kokkos_vector_two_norm_initvalue)
 {
-  kokkos_blas1_vector_norm2_test_impl(x, static_cast<float>(3), true);
+  kokkos_blas1_vector_two_norm_test_impl(x, static_cast<float>(3), true);
 }
 
-TEST_F(blas1_signed_double_fixture, kokkos_vector_norm2_noinitvalue)
+TEST_F(blas1_signed_double_fixture, kokkos_vector_two_norm_noinitvalue)
 {
-  kokkos_blas1_vector_norm2_test_impl(x, static_cast<double>(0), false);
+  kokkos_blas1_vector_two_norm_test_impl(x, static_cast<double>(0), false);
 }
 
-TEST_F(blas1_signed_double_fixture, kokkos_vector_norm2_initvalue)
+TEST_F(blas1_signed_double_fixture, kokkos_vector_two_norm_initvalue)
 {
-  kokkos_blas1_vector_norm2_test_impl(x, static_cast<double>(5), true);
+  kokkos_blas1_vector_two_norm_test_impl(x, static_cast<double>(5), true);
 }
 
-TEST_F(blas1_signed_complex_double_fixture, kokkos_vector_norm2_noinitvalue)
+TEST_F(blas1_signed_complex_double_fixture, kokkos_vector_two_norm_noinitvalue)
 {
   namespace stdla = std::experimental::linalg;
   using kc_t = Kokkos::complex<double>;
   using stdc_t = value_type;
   if constexpr (alignof(value_type) == alignof(kc_t)){
-    kokkos_blas1_vector_norm2_test_impl(x, static_cast<double>(0), false);
+    kokkos_blas1_vector_two_norm_test_impl(x, static_cast<double>(0), false);
   }
 }
 
-TEST_F(blas1_signed_complex_double_fixture, kokkos_vector_norm2_initvalue)
+TEST_F(blas1_signed_complex_double_fixture, kokkos_vector_two_norm_initvalue)
 {
   namespace stdla = std::experimental::linalg;
   using kc_t = Kokkos::complex<double>;
   using stdc_t = value_type;
   if constexpr (alignof(value_type) == alignof(kc_t)){
-    kokkos_blas1_vector_norm2_test_impl(x, static_cast<double>(5), true);
+    kokkos_blas1_vector_two_norm_test_impl(x, static_cast<double>(5), true);
   }
 }

--- a/tests/native/norm2.cpp
+++ b/tests/native/norm2.cpp
@@ -17,7 +17,7 @@ double dnrm2_wrapper(const int N, const double* X, const int INCX)
 #endif // 0
 
 namespace {
-  using LinearAlgebra::vector_norm2;
+  using LinearAlgebra::vector_two_norm;
 
   TEST(BLAS1_norm2, mdspan_zero)
   {
@@ -32,17 +32,17 @@ namespace {
     vector_t x(storage.data(), vectorSize);
 
     // Testing for absolute equality
-    const auto normResult = vector_norm2(x, mag_t{});
+    const auto normResult = vector_two_norm(x, mag_t{});
     static_assert( std::is_same_v<std::remove_const_t<decltype(normResult)>, mag_t> );
     const mag_t expectedNormResult{};
     EXPECT_EQ( expectedNormResult, normResult );
 
     // Make sure that init always gets added to the result.
-    const mag_t normResultPlusOne = vector_norm2(x, mag_t(1.0));
+    const mag_t normResultPlusOne = vector_two_norm(x, mag_t(1.0));
     EXPECT_EQ( expectedNormResult + mag_t(1.0), normResultPlusOne );
 
     // Test 'auto' overload.
-    const auto normResultAuto = vector_norm2(x);
+    const auto normResultAuto = vector_two_norm(x);
     static_assert( std::is_same_v<std::remove_const_t<decltype(normResultAuto)>, mag_t> );
     EXPECT_EQ( expectedNormResult, normResultAuto );
   }
@@ -64,17 +64,17 @@ namespace {
     x[0] = -3;
 
     // Testing for absolute equality
-    const auto normResult = vector_norm2(x, mag_t{});
+    const auto normResult = vector_two_norm(x, mag_t{});
     static_assert( std::is_same_v<std::remove_const_t<decltype(normResult)>, mag_t> );
     const mag_t expectedNormResult = abs( x[0] );
     EXPECT_EQ( expectedNormResult, normResult );
 
     // Make sure that init always gets added to the result.
-    const mag_t normResultPlusOne = vector_norm2(x, mag_t(1.0));
+    const mag_t normResultPlusOne = vector_two_norm(x, mag_t(1.0));
     EXPECT_EQ( expectedNormResult + mag_t(1.0), normResultPlusOne );
 
     // Test 'auto' overload.
-    const auto normResultAuto = vector_norm2(x);
+    const auto normResultAuto = vector_two_norm(x);
     static_assert( std::is_same_v<std::remove_const_t<decltype(normResultAuto)>, mag_t> );
     EXPECT_EQ( expectedNormResult, normResultAuto );
   }
@@ -104,13 +104,13 @@ namespace {
       expectedNormResultSquared += x_k * x_k;
     }
 
-    const auto normResult = vector_norm2(x, mag_t{});
+    const auto normResult = vector_two_norm(x, mag_t{});
     static_assert( std::is_same_v<std::remove_const_t<decltype(normResult)>, mag_t> );
     const mag_t expectedNormResult = sqrt(expectedNormResultSquared);
     EXPECT_NEAR( expectedNormResult, normResult, tol );
 
     // Test 'auto' overload.
-    const auto normResultAuto = vector_norm2(x);
+    const auto normResultAuto = vector_two_norm(x);
     static_assert( std::is_same_v<std::remove_const_t<decltype(normResultAuto)>, mag_t> );
     EXPECT_NEAR( expectedNormResult, normResultAuto, tol );
 
@@ -149,13 +149,13 @@ namespace {
       expectedNormResultSquared += abs(x_k) * abs(x_k);
     }
 
-    const auto normResult = vector_norm2(x, mag_t{});
+    const auto normResult = vector_two_norm(x, mag_t{});
     static_assert( std::is_same_v<std::remove_const_t<decltype(normResult)>, mag_t> );
     const mag_t expectedNormResult = sqrt(expectedNormResultSquared);
     EXPECT_NEAR( expectedNormResult, normResult, tol );
 
     // Test 'auto' overload.
-    const auto normResultAuto = vector_norm2(x);
+    const auto normResultAuto = vector_two_norm(x);
     static_assert( std::is_same_v<std::remove_const_t<decltype(normResultAuto)>, mag_t> );
     EXPECT_NEAR( expectedNormResult, normResultAuto, tol );
   }


### PR DESCRIPTION
1. implementation for vector_sum_of_squares was completely broken - fixed
2. vector_norm2 renamed to vecotr_two_norm (as it was done in p1673r12)