### PR TITLE
Updating symmetric/hermitian matrix product

### DIFF
--- a/include/experimental/__p1673_bits/blas3_matrix_product.hpp
+++ b/include/experimental/__p1673_bits/blas3_matrix_product.hpp
@@ -432,11 +432,57 @@ struct is_custom_triang_mat_right_product_avail<
   >
   : std::true_type{};
 
-template <class Exec, class A_t, class Tr_t, class DiagSt_t, class C_t, class = void>
+template <class Exec, class A_t, class Tr_t, class DiagSt_t, class B_t, class E_t, class C_t, class = void>
 struct is_custom_triang_mat_left_product_with_update_avail : std::false_type {};
 
-template <class Exec, class A_t, class Tr_t, class DiagSt_t, class C_t>
+template <class Exec, class A_t, class Tr_t, class DiagSt_t, class B_t, class E_t, class C_t>
 struct is_custom_triang_mat_left_product_with_update_avail<
+  Exec, A_t, Tr_t, DiagSt_t, B_t, E_t, C_t,
+  std::enable_if_t<
+    std::is_void_v<
+      decltype(
+	       triangular_matrix_product
+	       (std::declval<Exec>(),
+		std::declval<A_t>(),
+		std::declval<Tr_t>(),
+		std::declval<DiagSt_t>(),
+		std::declval<B_t>(),
+    	std::declval<E_t>(),
+		std::declval<C_t>()))
+      >
+    && ! impl::is_inline_exec_v<Exec>
+    >
+  >
+  : std::true_type{};
+
+template <class Exec, class A_t, class Tr_t, class DiagSt_t, class B_t, class E_t, class C_t, class = void>
+struct is_custom_triang_mat_right_product_with_update_avail : std::false_type {};
+
+template <class Exec, class A_t, class Tr_t, class DiagSt_t, class B_t, class E_t, class C_t>
+struct is_custom_triang_mat_right_product_with_update_avail<
+  Exec, A_t, Tr_t, DiagSt_t, B_t, E_t, C_t,
+  std::enable_if_t<
+    std::is_void_v<
+      decltype(
+	       triangular_matrix_product
+	       (std::declval<Exec>(),
+		std::declval<B_t>(),
+    	std::declval<A_t>(),
+		std::declval<Tr_t>(),
+		std::declval<DiagSt_t>(),
+    	std::declval<E_t>(),
+		std::declval<C_t>()))
+      >
+    && ! impl::is_inline_exec_v<Exec>
+    >
+  >
+  : std::true_type{};
+
+template <class Exec, class A_t, class Tr_t, class DiagSt_t, class C_t, class = void>
+struct is_custom_triang_mat_left_product_inplace_avail : std::false_type {};
+
+template <class Exec, class A_t, class Tr_t, class DiagSt_t, class C_t>
+struct is_custom_triang_mat_left_product_inplace_avail<
   Exec, A_t, Tr_t, DiagSt_t, C_t,
   std::enable_if_t<
     std::is_void_v<
@@ -454,10 +500,10 @@ struct is_custom_triang_mat_left_product_with_update_avail<
   : std::true_type{};
 
 template <class Exec, class A_t, class Tr_t, class DiagSt_t, class C_t, class = void>
-struct is_custom_triang_mat_right_product_with_update_avail : std::false_type {};
+struct is_custom_triang_mat_right_product_inplace_avail : std::false_type {};
 
 template <class Exec, class A_t, class Tr_t, class DiagSt_t, class C_t>
-struct is_custom_triang_mat_right_product_with_update_avail<
+struct is_custom_triang_mat_right_product_inplace_avail<
   Exec, A_t, Tr_t, DiagSt_t, C_t,
   std::enable_if_t<
     std::is_void_v<
@@ -964,7 +1010,7 @@ void triangular_matrix_product(
     decltype(impl::map_execpolicy_with_check(exec)), decltype(A), Triangle, DiagonalStorage, decltype(B), decltype(C)>::value;
 
   if constexpr (use_custom) {
-    triangular_matrix_left_product(impl::map_execpolicy_with_check(exec), A, t, d, B, C);
+    triangular_matrix_product(impl::map_execpolicy_with_check(exec), A, t, d, B, C);
   } else {
     triangular_matrix_product(impl::inline_exec_t{}, A, t, d, B, C);
   }
@@ -1079,7 +1125,7 @@ void triangular_matrix_product(
     decltype(A), Triangle, DiagonalStorage, decltype(B), decltype(C)>::value;
 
   if constexpr (use_custom) {
-    triangular_matrix_right_product(impl::map_execpolicy_with_check(exec), A, t, d, B, C);
+    triangular_matrix_product(impl::map_execpolicy_with_check(exec), B, A, t, d, C);
   } else {
     triangular_matrix_product(impl::inline_exec_t{}, B, A, t, d, C);
   }
@@ -1111,6 +1157,267 @@ void triangular_matrix_product(
 
 
 // Updating triangular matrix-matrix product
+
+template<class ElementType_A,
+         class SizeType_A, ::std::size_t numRows_A, ::std::size_t numCols_A,
+         class Layout_A,
+         class Accessor_A,
+         class Triangle,
+         class DiagonalStorage,
+         class ElementType_B,
+         class SizeType_B, ::std::size_t numRows_B, ::std::size_t numCols_B,
+         class Layout_B,
+         class Accessor_B,
+         class ElementType_E,
+         class SizeType_E, ::std::size_t numRows_E, ::std::size_t numCols_E,
+         class Layout_E,
+         class Accessor_E,
+         class ElementType_C,
+         class SizeType_C, ::std::size_t numRows_C, ::std::size_t numCols_C,
+         class Layout_C,
+         class Accessor_C>
+void triangular_matrix_product(
+  impl::inline_exec_t&& /* exec */,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  Triangle /* t */,
+  DiagonalStorage /* d */,
+  mdspan<ElementType_B, extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_E, extents<SizeType_E, numRows_E, numCols_E>, Layout_E, Accessor_E> E,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
+{
+  using size_type = ::std::common_type_t<SizeType_A, SizeType_B, SizeType_E, SizeType_C>;
+  constexpr bool explicitDiagonal =
+    std::is_same_v<DiagonalStorage, explicit_diagonal_t>;
+
+  if constexpr (std::is_same_v<Triangle, lower_triangle_t>) {
+    for (size_type j = 0; j < C.extent(1); ++j) {
+      for (size_type i = 0; i < C.extent(0); ++i) {
+        C(i,j) = E(i,j);
+        const ptrdiff_t k_upper = explicitDiagonal ? i : i - ptrdiff_t(1);
+        for (ptrdiff_t k = 0; k <= k_upper; ++k) {
+          C(i,j) += A(i,k) * B(k,j);
+        }
+        if constexpr (! explicitDiagonal) {
+          C(i,j) += /* 1 times */ B(i,j);
+        }
+      }
+    }
+  }
+  else { // upper_triangle_t
+    for (size_type j = 0; j < C.extent(1); ++j) {
+      for (size_type i = 0; i < C.extent(0); ++i) {
+        C(i,j) = E(i,j);
+        const size_type k_lower = explicitDiagonal ? i : i + 1;
+        for (size_type k = k_lower; k < C.extent(0); ++k) {
+          C(i,j) += A(i,k) * B(k,j);
+        }
+        if constexpr (! explicitDiagonal) {
+          C(i,j) += /* 1 times */ B(i,j);
+        }
+      }
+    }
+  }
+}
+
+template<class ExecutionPolicy,
+         class ElementType_A,
+         class SizeType_A, ::std::size_t numRows_A, ::std::size_t numCols_A,
+         class Layout_A,
+         class Accessor_A,
+         class Triangle,
+         class DiagonalStorage,
+         class ElementType_B,
+         class SizeType_B, ::std::size_t numRows_B, ::std::size_t numCols_B,
+         class Layout_B,
+         class Accessor_B,
+         class ElementType_E,
+         class SizeType_E, ::std::size_t numRows_E, ::std::size_t numCols_E,
+         class Layout_E,
+         class Accessor_E,
+         class ElementType_C,
+         class SizeType_C, ::std::size_t numRows_C, ::std::size_t numCols_C,
+         class Layout_C,
+         class Accessor_C>
+void triangular_matrix_product(
+  ExecutionPolicy&& exec,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  Triangle t,
+  DiagonalStorage d,
+  mdspan<ElementType_B, extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_E, extents<SizeType_E, numRows_E, numCols_E>, Layout_E, Accessor_E> E,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
+{
+  constexpr bool use_custom = is_custom_triang_mat_left_product_with_update_avail<
+    decltype(impl::map_execpolicy_with_check(exec)), decltype(A), Triangle, DiagonalStorage, decltype(B), decltype(E), decltype(C)>::value;
+
+  if constexpr (use_custom) {
+    triangular_matrix_product(impl::map_execpolicy_with_check(exec), A, t, d, B, E, C);
+  } else {
+    triangular_matrix_product(impl::inline_exec_t{}, A, t, d, B, E, C);
+  }
+}
+
+template<class ElementType_A,
+         class SizeType_A, ::std::size_t numRows_A, ::std::size_t numCols_A,
+         class Layout_A,
+         class Accessor_A,
+         class Triangle,
+         class DiagonalStorage,
+         class ElementType_B,
+         class SizeType_B, ::std::size_t numRows_B, ::std::size_t numCols_B,
+         class Layout_B,
+         class Accessor_B,
+         class ElementType_E,
+         class SizeType_E, ::std::size_t numRows_E, ::std::size_t numCols_E,
+         class Layout_E,
+         class Accessor_E,
+         class ElementType_C,
+         class SizeType_C, ::std::size_t numRows_C, ::std::size_t numCols_C,
+         class Layout_C,
+         class Accessor_C>
+void triangular_matrix_product(
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  Triangle t,
+  DiagonalStorage d,
+  mdspan<ElementType_B, extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_E, extents<SizeType_E, numRows_E, numCols_E>, Layout_E, Accessor_E> E,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
+{
+  triangular_matrix_product(impl::default_exec_t{}, A, t, d, B, E, C);
+}
+
+
+template<class ElementType_A,
+         class SizeType_A, ::std::size_t numRows_A, ::std::size_t numCols_A,
+         class Layout_A,
+         class Accessor_A,
+         class Triangle,
+         class DiagonalStorage,
+         class ElementType_B,
+         class SizeType_B, ::std::size_t numRows_B, ::std::size_t numCols_B,
+         class Layout_B,
+         class Accessor_B,
+         class ElementType_E,
+         class SizeType_E, ::std::size_t numRows_E, ::std::size_t numCols_E,
+         class Layout_E,
+         class Accessor_E,
+         class ElementType_C,
+         class SizeType_C, ::std::size_t numRows_C, ::std::size_t numCols_C,
+         class Layout_C,
+         class Accessor_C>
+void triangular_matrix_product(
+  impl::inline_exec_t&& /* exec */,
+  mdspan<ElementType_B, extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  Triangle /* t */,
+  DiagonalStorage /* d */,
+  mdspan<ElementType_E, extents<SizeType_E, numRows_E, numCols_E>, Layout_E, Accessor_E> E,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
+{
+  using size_type = ::std::common_type_t<SizeType_A, SizeType_B, SizeType_E, SizeType_C>;
+  constexpr bool explicitDiagonal =
+    std::is_same_v<DiagonalStorage, explicit_diagonal_t>;
+
+  if constexpr (std::is_same_v<Triangle, lower_triangle_t>) {
+    for (size_type j = 0; j < C.extent(1); ++j) {
+      const size_type k_lower = explicitDiagonal ? j : j + 1;
+      for (size_type i = 0; i < C.extent(0); ++i) {
+        C(i,j) = E(i,j);
+        for (size_type k = k_lower; k < C.extent(1); ++k) {
+          C(i,j) += B(i,k) * A(k,j);
+        }
+        if constexpr (! explicitDiagonal) {
+          C(i,j) += /* 1 times */ B(i,j);
+        }
+      }
+    }
+  }
+  else { // upper_triangle_t
+    for (size_type j = 0; j < C.extent(1); ++j) {
+      const ptrdiff_t k_upper = explicitDiagonal ? j : j - ptrdiff_t(1);
+      for (size_type i = 0; i < C.extent(0); ++i) {
+        C(i,j) = E(i,j);
+        for (ptrdiff_t k = 0; k <= k_upper; ++k) {
+          C(i,j) += B(i,k) * A(k,j);
+        }
+        if constexpr (! explicitDiagonal) {
+          C(i,j) += /* 1 times */ B(i,j);
+        }
+      }
+    }
+  }
+}
+
+template<class ExecutionPolicy,
+         class ElementType_A,
+         class SizeType_A, ::std::size_t numRows_A, ::std::size_t numCols_A,
+         class Layout_A,
+         class Accessor_A,
+         class Triangle,
+         class DiagonalStorage,
+         class ElementType_B,
+         class SizeType_B, ::std::size_t numRows_B, ::std::size_t numCols_B,
+         class Layout_B,
+         class Accessor_B,
+         class ElementType_E,
+         class SizeType_E, ::std::size_t numRows_E, ::std::size_t numCols_E,
+         class Layout_E,
+         class Accessor_E,
+         class ElementType_C,
+         class SizeType_C, ::std::size_t numRows_C, ::std::size_t numCols_C,
+         class Layout_C,
+         class Accessor_C>
+void triangular_matrix_product(
+  ExecutionPolicy&& exec,
+  mdspan<ElementType_B, extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  Triangle t,
+  DiagonalStorage d,
+  mdspan<ElementType_E, extents<SizeType_E, numRows_E, numCols_E>, Layout_E, Accessor_E> E,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
+{
+  constexpr bool use_custom = is_custom_triang_mat_right_product_with_update_avail<
+    decltype(impl::map_execpolicy_with_check(exec)),
+    decltype(A), Triangle, DiagonalStorage, decltype(B), decltype(E), decltype(C)>::value;
+
+  if constexpr (use_custom) {
+    triangular_matrix_product(impl::map_execpolicy_with_check(exec), B, A, t, d, E, C);
+  } else {
+    triangular_matrix_product(impl::inline_exec_t{}, B, A, t, d, E, C);
+  }
+}
+
+template<class ElementType_A,
+         class SizeType_A, ::std::size_t numRows_A, ::std::size_t numCols_A,
+         class Layout_A,
+         class Accessor_A,
+         class Triangle,
+         class DiagonalStorage,
+         class ElementType_B,
+         class SizeType_B, ::std::size_t numRows_B, ::std::size_t numCols_B,
+         class Layout_B,
+         class Accessor_B,
+         class ElementType_E,
+         class SizeType_E, ::std::size_t numRows_E, ::std::size_t numCols_E,
+         class Layout_E,
+         class Accessor_E,
+         class ElementType_C,
+         class SizeType_C, ::std::size_t numRows_C, ::std::size_t numCols_C,
+         class Layout_C,
+         class Accessor_C>
+void triangular_matrix_product(
+  mdspan<ElementType_B, extents<SizeType_B, numRows_B, numCols_B>, Layout_B, Accessor_B> B,
+  mdspan<ElementType_A, extents<SizeType_A, numRows_A, numCols_A>, Layout_A, Accessor_A> A,
+  Triangle t,
+  DiagonalStorage d ,
+  mdspan<ElementType_E, extents<SizeType_E, numRows_E, numCols_E>, Layout_E, Accessor_E> E,
+  mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
+{
+  triangular_matrix_product(impl::default_exec_t{}, B, A, t, d, E, C);
+}
+
+
+// In-place triangular matrix-matrix product
 
 template<class ElementType_A,
          class SizeType_A, ::std::size_t numRows_A, ::std::size_t numCols_A,
@@ -1177,7 +1484,7 @@ void triangular_matrix_left_product(
   DiagonalStorage d,
   mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
 {
-  constexpr bool use_custom = is_custom_triang_mat_left_product_with_update_avail<
+  constexpr bool use_custom = is_custom_triang_mat_left_product_inplace_avail<
     decltype(impl::map_execpolicy_with_check(exec)), decltype(A), Triangle, DiagonalStorage, decltype(C)>::value;
 
   if constexpr (use_custom) {
@@ -1275,7 +1582,7 @@ void triangular_matrix_right_product(
   DiagonalStorage d,
   mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
 {
-  constexpr bool use_custom = is_custom_triang_mat_right_product_with_update_avail<
+  constexpr bool use_custom = is_custom_triang_mat_right_product_inplace_avail<
     decltype(impl::map_execpolicy_with_check(exec)), decltype(A), Triangle, DiagonalStorage, decltype(C)>::value;
 
   if constexpr (use_custom) {

--- a/include/experimental/__p1673_bits/blas3_matrix_product.hpp
+++ b/include/experimental/__p1673_bits/blas3_matrix_product.hpp
@@ -1538,7 +1538,30 @@ void symmetric_matrix_product(
   mdspan<ElementType_E, extents<SizeType_E, numRows_E, numCols_E>, Layout_E, Accessor_E> E,
   mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
 {
-  assert(false);
+  using size_type = ::std::common_type_t<SizeType_A, SizeType_B, SizeType_C>;
+
+  if constexpr (std::is_same_v<Triangle, lower_triangle_t>) {
+    for (size_type j = 0; j < C.extent(1); ++j) {
+      for (size_type i = 0; i < C.extent(0); ++i) {
+        C(i,j) = E(i,j);
+        for (size_type k = 0; k < A.extent(1); ++k) {
+          ElementType_A aik = i <= k ? A(k,i) : A(i,k);
+          C(i,j) += aik * B(k,j);
+        }
+      }
+    }
+  }
+  else { // upper_triangle_t
+    for (size_type j = 0; j < C.extent(1); ++j) {
+      for (size_type i = 0; i < C.extent(0); ++i) {
+        C(i,j) = E(i,j);
+        for (size_type k = 0; k < A.extent(1); ++k) {
+          ElementType_A aik = i >= k ? A(k,i) : A(i,k);
+          C(i,j) += aik * B(k,j);
+        }
+      }
+    }
+  }
 }
 
 template<class ExecutionPolicy,
@@ -1632,7 +1655,30 @@ void symmetric_matrix_product(
   mdspan<ElementType_E, extents<SizeType_E, numRows_E, numCols_E>, Layout_E, Accessor_E> E,
   mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
 {
-  assert(false);
+  using size_type = ::std::common_type_t<SizeType_A, SizeType_B, SizeType_C>;
+
+  if constexpr (std::is_same_v<Triangle, lower_triangle_t>) {
+    for (size_type j = 0; j < C.extent(1); ++j) {
+      for (size_type i = 0; i < C.extent(0); ++i) {
+        C(i,j) = E(i,j);
+        for (size_type k = 0; k < A.extent(1); ++k) {
+          ElementType_A akj = j <= k ? A(k,j) : A(j,k);
+          C(i,j) += B(i,k) * akj;
+        }
+      }
+    }
+  }
+  else { // upper_triangle_t
+    for (size_type j = 0; j < C.extent(1); ++j) {
+      for (size_type i = 0; i < C.extent(0); ++i) {
+        C(i,j) = E(i,j);
+        for (size_type k = 0; k < A.extent(1); ++k) {
+          ElementType_A akj = j >= k ? A(k,j) : A(j,k);
+          C(i,j) += B(i,k) * akj;
+        }
+      }
+    }
+  }
 }
 
 template<class ExecutionPolicy,
@@ -1835,9 +1881,12 @@ void hermitian_matrix_product(
     for (size_type j = 0; j < C.extent(1); ++j) {
       for (size_type i = 0; i < C.extent(0); ++i) {
         C(i,j) = ElementType_C{};
-        for (size_type k = 0; k < A.extent(1); ++k) {
-          ElementType_A akj = j <= k ? A(k,j) : impl::conj_if_needed(A(j,k));
-          C(i,j) += B(i,k) * akj;
+        for (size_type k = 0; k < j; ++k) {
+          C(i,j) += B(i,k) * impl::conj_if_needed(A(j,k));
+        }
+        C(i,j) += B(i,j) * impl::real_if_needed(A(j,j));
+        for (size_type k = j+1; k < A.extent(1); ++k) {
+          C(i,j) += B(i,k) * A(k,j);
         }
       }
     }
@@ -1846,9 +1895,12 @@ void hermitian_matrix_product(
     for (size_type j = 0; j < C.extent(1); ++j) {
       for (size_type i = 0; i < C.extent(0); ++i) {
         C(i,j) = ElementType_C{};
-        for (size_type k = 0; k < A.extent(1); ++k) {
-          ElementType_A akj = j >= k ? A(k,j) : impl::conj_if_needed(A(j,k));
-          C(i,j) += B(i,k) * akj;
+        for (size_type k = 0; k < j; ++k) {
+          C(i,j) += B(i,k) * A(k,j);
+        }
+        C(i,j) += B(i,j) * impl::real_if_needed(A(j,j));
+        for (size_type k = j+1; k < A.extent(1); ++k) {
+          C(i,j) += B(i,k) * impl::conj_if_needed(A(j,k));
         }
       }
     }
@@ -1937,7 +1989,36 @@ void hermitian_matrix_product(
   mdspan<ElementType_E, extents<SizeType_E, numRows_E, numCols_E>, Layout_E, Accessor_E> E,
   mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
 {
-  assert(false);
+  using size_type = ::std::common_type_t<SizeType_A, SizeType_B, SizeType_C>;
+
+  if constexpr (std::is_same_v<Triangle, lower_triangle_t>) {
+    for (size_type j = 0; j < C.extent(1); ++j) {
+      for (size_type i = 0; i < C.extent(0); ++i) {
+        C(i,j) = E(i,j);
+        for (size_type k = 0; k < i; ++k){
+          C(i,j) += A(i,k) * B(k,j);
+        }
+        C(i,j) += impl::real_if_needed(A(i,i)) * B(i,j);
+        for (size_type k = i+1; k < A.extent(0); ++k){
+          C(i,j) += impl::conj_if_needed(A(k,i)) * B(k,j);
+        }
+      }
+    }
+  }
+  else { // upper_triangle_t
+    for (size_type j = 0; j < C.extent(1); ++j) {
+      for (size_type i = 0; i < C.extent(0); ++i) {
+        C(i,j) = E(i,j);
+        for (size_type k = 0; k < i; ++k) {
+          C(i,j) += impl::conj_if_needed(A(k,i)) * B(k,j);
+        }
+        C(i,j) += impl::real_if_needed(A(i,i)) * B(i,j);
+        for (size_type k = i+1; k < A.extent(1); ++k) {
+          C(i,j) += A(i,k) * B(k,j);
+        }
+      }
+    }
+  }
 }
 
 template<class ExecutionPolicy,
@@ -2031,7 +2112,36 @@ void hermitian_matrix_product(
   mdspan<ElementType_E, extents<SizeType_E, numRows_E, numCols_E>, Layout_E, Accessor_E> E,
   mdspan<ElementType_C, extents<SizeType_C, numRows_C, numCols_C>, Layout_C, Accessor_C> C)
 {
-  assert(false);
+  using size_type = ::std::common_type_t<SizeType_A, SizeType_B, SizeType_C>;
+
+  if constexpr (std::is_same_v<Triangle, lower_triangle_t>) {
+    for (size_type j = 0; j < C.extent(1); ++j) {
+      for (size_type i = 0; i < C.extent(0); ++i) {
+        C(i,j) = E(i,j);
+        for (size_type k = 0; k < j; ++k) {
+          C(i,j) += B(i,k) * impl::conj_if_needed(A(j,k));
+        }
+        C(i,j) += B(i,j) * impl::real_if_needed(A(j,j));
+        for (size_type k = j+1; k < A.extent(1); ++k) {
+          C(i,j) += B(i,k) * A(k,j);
+        }
+      }
+    }
+  }
+  else { // upper_triangle_t
+    for (size_type j = 0; j < C.extent(1); ++j) {
+      for (size_type i = 0; i < C.extent(0); ++i) {
+        C(i,j) = E(i,j);
+        for (size_type k = 0; k < j; ++k) {
+          C(i,j) += B(i,k) * A(k,j);
+        }
+        C(i,j) += B(i,j) * impl::real_if_needed(A(j,j));
+        for (size_type k = j+1; k < A.extent(1); ++k) {
+          C(i,j) += B(i,k) * impl::conj_if_needed(A(j,k));
+        }
+      }
+    }
+  }
 }
 
 template<class ExecutionPolicy,

--- a/tests/native/hemm.cpp
+++ b/tests/native/hemm.cpp
@@ -17,7 +17,8 @@ namespace {
     EXPECT_NEAR(a.real(), b.real(), tol); \
     EXPECT_NEAR(a.imag(), b.imag(), tol)
 
-  TEST(BLAS3_hemm, left_lower_tri)
+  template<bool isLeft, typename Triangle, bool isUpdating>
+  void test_hermitian_matrix_product()
   {
     /* C = A * B, where A is hermitian mxm */
     using extents_t = extents<std::size_t, dynamic_extent, dynamic_extent>;
@@ -28,216 +29,143 @@ namespace {
     int m = 3, n = 2;
     std::vector<complex<double>> A_mem(m*m, snan);
     std::vector<double> B_mem(m*n);
+    std::vector<complex<double>> E_mem(m*n);
     std::vector<complex<double>> C_mem(m*n, snan);
     std::vector<complex<double>> gs_mem(m*n);
 
     cmatrix_t A(A_mem.data(), m, m);
-    dmatrix_t B(B_mem.data(), m, n);
-    cmatrix_t C(C_mem.data(), m, n);
-    cmatrix_t gs(gs_mem.data(), m, n);
+    dmatrix_t B(B_mem.data(), (isLeft)?m:n, (isLeft)?n:m);
+    cmatrix_t E(E_mem.data(), (isLeft)?m:n, (isLeft)?n:m);
+    cmatrix_t C(C_mem.data(), (isLeft)?m:n, (isLeft)?n:m);
+    cmatrix_t gs(gs_mem.data(), (isLeft)?m:n, (isLeft)?n:m);
 
     // Fill A
-    A(0,0) = -4.0;
-    A(1,0) = 4.0 + 4.4i;
-    A(1,1) = 3.5;
-    A(2,0) = 4.4 + 2.2i;
-    A(2,1) = -2.8 - 4.0i;
-    A(2,2) = -1.2;
+    if(std::is_same_v<Triangle, decltype(lower_triangle)>) {
+      A(0,0) = -4.0 + 1.i;
+      A(1,0) = 4.0 + 4.4i;
+      A(1,1) = 3.5 + 1.i;
+      A(2,0) = 4.4 + 2.2i;
+      A(2,1) = -2.8 - 4.0i;
+      A(2,2) = -1.2 + 1.i;
+    }
+    else {
+      A(0,0) = -4.0 + 1.i;
+      A(0,1) = 4.0 - 4.4i;
+      A(1,1) = 3.5 + 1.i;
+      A(0,2) = 4.4 - 2.2i;
+      A(1,2) = -2.8 + 4.0i;
+      A(2,2) = -1.2 + 1.i;
+    }
 
     // Fill B
-    B(0,0) = 1.3;
-    B(0,1) = 2.5;
-    B(1,0) = -4.6;
-    B(1,1) = -3.7;
-    B(2,0) = 3.1;
-    B(2,1) = -1.5;
+    if(isLeft) {
+      B(0,0) = 1.3;
+      B(0,1) = 2.5;
+      B(1,0) = -4.6;
+      B(1,1) = -3.7;
+      B(2,0) = 3.1;
+      B(2,1) = -1.5;
+    }
+    else {
+      B(0,0) = 1.3;
+      B(1,0) = 2.5;
+      B(0,1) = -4.6;
+      B(1,1) = -3.7;
+      B(0,2) = 3.1;
+      B(1,2) = -1.5;
+    }
+
+    if(isUpdating) {
+      for (ptrdiff_t j = 0; j < (isLeft?n:m); ++j) {
+        for (ptrdiff_t i = 0; i < (isLeft?m:n); ++i) {
+          E(i,j) = B(i,j);
+        }
+      }
+    }
 
     // Fill GS
-    gs(0,0) = -9.96 + 13.42i;
-    gs(0,1) = -31.4 + 19.58i;
-    gs(1,0) = -19.58 + 18.12i;
-    gs(1,1) = 1.25 + 5.0i;
-    gs(2,0) = 14.88 + 21.26i;
-    gs(2,1) = 23.16 + 20.3i;
+    if(isLeft) {
+      gs(0,0) = E(0,0) - 9.96 + 13.42i;
+      gs(0,1) = E(0,1) - 31.4 + 19.58i;
+      gs(1,0) = E(1,0) - 19.58 + 18.12i;
+      gs(1,1) = E(1,1) + 1.25 + 5.0i;
+      gs(2,0) = E(2,0) + 14.88 + 21.26i;
+      gs(2,1) = E(2,1) + 23.16 + 20.3i;
+    }
+    else {
+      gs(0,0) = E(0,0) - 9.96 - 13.42i;
+      gs(1,0) = E(1,0) - 31.4 - 19.58i;
+      gs(0,1) = E(0,1) - 19.58 - 18.12i;
+      gs(1,1) = E(1,1) + 1.25 - 5.0i;
+      gs(0,2) = E(0,2) + 14.88 - 21.26i;
+      gs(1,2) = E(1,2) + 23.16 - 20.3i;
+    }
 
-    hermitian_matrix_product(A, lower_triangle, B, C);
+    if(isLeft) {
+      if(isUpdating) {
+        hermitian_matrix_product(A, Triangle{}, B, E, C);
+      }
+      else {
+        hermitian_matrix_product(A, Triangle{}, B, C);
+      }
+    }
+    else {
+      if(isUpdating) {
+        hermitian_matrix_product(B, A, Triangle{}, E, C);
+      }
+      else {
+        hermitian_matrix_product(B, A, Triangle{}, C);
+      }
+    }
 
     // TODO: Choose a more reasonable value
     constexpr double TOL = 1e-9;
-    for (ptrdiff_t j = 0; j < n; ++j) {
-      for (ptrdiff_t i = 0; i < m; ++i) {
+    for (ptrdiff_t j = 0; j < (isLeft?n:m); ++j) {
+      for (ptrdiff_t i = 0; i < (isLeft?m:n); ++i) {
         EXPECT_COMPLEX_NEAR(gs(i,j), C(i,j), TOL)
           << "Matrices differ at index ("
           << i << "," << j << ")\n";
       }
     }
+  }
+
+  TEST(BLAS3_hemm, left_lower_tri)
+  {
+    test_hermitian_matrix_product<true, decltype(lower_triangle), false>();
   }
 
   TEST(BLAS3_hemm, left_upper_tri)
   {
-    /* C = A * B, where A is hermitian mxm */
-    using extents_t = extents<std::size_t, dynamic_extent, dynamic_extent>;
-    using cmatrix_t = mdspan<complex<double>, extents_t, layout_left>;
-    using dmatrix_t = mdspan<double, extents_t, layout_left>;
-    constexpr double snan = std::numeric_limits<double>::signaling_NaN();
-
-    int m = 3, n = 2;
-    std::vector<complex<double>> A_mem(m*m, snan);
-    std::vector<double> B_mem(m*n);
-    std::vector<complex<double>> C_mem(m*n, snan);
-    std::vector<complex<double>> gs_mem(m*n);
-
-    cmatrix_t A(A_mem.data(), m, m);
-    dmatrix_t B(B_mem.data(), m, n);
-    cmatrix_t C(C_mem.data(), m, n);
-    cmatrix_t gs(gs_mem.data(), m, n);
-
-    // Fill A
-    A(0,0) = -4.0;
-    A(0,1) = 4.0 - 4.4i;
-    A(1,1) = 3.5;
-    A(0,2) = 4.4 - 2.2i;
-    A(1,2) = -2.8 + 4.0i;
-    A(2,2) = -1.2;
-
-    // Fill B
-    B(0,0) = 1.3;
-    B(0,1) = 2.5;
-    B(1,0) = -4.6;
-    B(1,1) = -3.7;
-    B(2,0) = 3.1;
-    B(2,1) = -1.5;
-
-    // Fill GS
-    gs(0,0) = -9.96 + 13.42i;
-    gs(0,1) = -31.4 + 19.58i;
-    gs(1,0) = -19.58 + 18.12i;
-    gs(1,1) = 1.25 + 5.0i;
-    gs(2,0) = 14.88 + 21.26i;
-    gs(2,1) = 23.16 + 20.3i;
-
-    hermitian_matrix_product(A, upper_triangle, B, C);
-
-    // TODO: Choose a more reasonable value
-    constexpr double TOL = 1e-9;
-    for (ptrdiff_t j = 0; j < n; ++j) {
-      for (ptrdiff_t i = 0; i < m; ++i) {
-        EXPECT_COMPLEX_NEAR(gs(i,j), C(i,j), TOL)
-          << "Matrices differ at index ("
-          << i << "," << j << ")\n";
-      }
-    }
+    test_hermitian_matrix_product<true, decltype(upper_triangle), false>();
   }
 
   TEST(BLAS3_hemm, right_lower_tri)
   {
-    /* C = B * A, where A is hermitian mxm */
-    using extents_t = extents<std::size_t, dynamic_extent, dynamic_extent>;
-    using cmatrix_t = mdspan<complex<double>, extents_t, layout_left>;
-    using dmatrix_t = mdspan<double, extents_t, layout_left>;
-    constexpr double snan = std::numeric_limits<double>::signaling_NaN();
-
-    int m = 3, n = 2;
-    std::vector<complex<double>> A_mem(m*m, snan);
-    std::vector<double> B_mem(m*n);
-    std::vector<complex<double>> C_mem(m*n, snan);
-    std::vector<complex<double>> gs_mem(m*n);
-
-    cmatrix_t A(A_mem.data(), m, m);
-    dmatrix_t B(B_mem.data(), n, m);
-    cmatrix_t C(C_mem.data(), n, m);
-    cmatrix_t gs(gs_mem.data(), n, m);
-
-    // Fill A
-    A(0,0) = -4.0;
-    A(1,0) = 4.0 + 4.4i;
-    A(1,1) = 3.5;
-    A(2,0) = 4.4 + 2.2i;
-    A(2,1) = -2.8 - 4.0i;
-    A(2,2) = -1.2;
-
-    // Fill B
-    B(0,0) = 1.3;
-    B(1,0) = 2.5;
-    B(0,1) = -4.6;
-    B(1,1) = -3.7;
-    B(0,2) = 3.1;
-    B(1,2) = -1.5;
-
-    // Fill GS
-    gs(0,0) = -9.96 - 13.42i;
-    gs(1,0) = -31.4 - 19.58i;
-    gs(0,1) = -19.58 - 18.12i;
-    gs(1,1) = 1.25 - 5.0i;
-    gs(0,2) = 14.88 - 21.26i;
-    gs(1,2) = 23.16 - 20.3i;
-
-    hermitian_matrix_product(B, A, lower_triangle, C);
-
-    // TODO: Choose a more reasonable value
-    constexpr double TOL = 1e-9;
-    for (ptrdiff_t j = 0; j < m; ++j) {
-      for (ptrdiff_t i = 0; i < n; ++i) {
-        EXPECT_COMPLEX_NEAR(gs(i,j), C(i,j), TOL)
-          << "Matrices differ at index ("
-          << i << "," << j << ")\n";
-      }
-    }
+    test_hermitian_matrix_product<false, decltype(lower_triangle), false>();
   }
 
   TEST(BLAS3_hemm, right_upper_tri)
   {
-    /* C = B * A, where A is hermitian mxm */
-    using extents_t = extents<std::size_t, dynamic_extent, dynamic_extent>;
-    using cmatrix_t = mdspan<complex<double>, extents_t, layout_left>;
-    using dmatrix_t = mdspan<double, extents_t, layout_left>;
-    constexpr double snan = std::numeric_limits<double>::signaling_NaN();
+    test_hermitian_matrix_product<false, decltype(upper_triangle), false>();
+  }
 
-    int m = 3, n = 2;
-    std::vector<complex<double>> A_mem(m*m, snan);
-    std::vector<double> B_mem(m*n);
-    std::vector<complex<double>> C_mem(m*n, snan);
-    std::vector<complex<double>> gs_mem(m*n);
+  TEST(BLAS3_hemm, left_lower_tri_upd)
+  {
+    test_hermitian_matrix_product<true, decltype(lower_triangle), true>();
+  }
 
-    cmatrix_t A(A_mem.data(), m, m);
-    dmatrix_t B(B_mem.data(), n, m);
-    cmatrix_t C(C_mem.data(), n, m);
-    cmatrix_t gs(gs_mem.data(), n, m);
+  TEST(BLAS3_hemm, left_upper_tri_upd)
+  {
+    test_hermitian_matrix_product<true, decltype(upper_triangle), true>();
+  }
 
-    // Fill A
-    A(0,0) = -4.0;
-    A(0,1) = 4.0 - 4.4i;
-    A(1,1) = 3.5;
-    A(0,2) = 4.4 - 2.2i;
-    A(1,2) = -2.8 + 4.0i;
-    A(2,2) = -1.2;
+  TEST(BLAS3_hemm, right_lower_tri_upd)
+  {
+    test_hermitian_matrix_product<false, decltype(lower_triangle), true>();
+  }
 
-    // Fill B
-    B(0,0) = 1.3;
-    B(1,0) = 2.5;
-    B(0,1) = -4.6;
-    B(1,1) = -3.7;
-    B(0,2) = 3.1;
-    B(1,2) = -1.5;
-
-    // Fill GS
-    gs(0,0) = -9.96 - 13.42i;
-    gs(1,0) = -31.4 - 19.58i;
-    gs(0,1) = -19.58 - 18.12i;
-    gs(1,1) = 1.25 - 5.0i;
-    gs(0,2) = 14.88 - 21.26i;
-    gs(1,2) = 23.16 - 20.3i;
-
-    hermitian_matrix_product(B, A, upper_triangle, C);
-
-    // TODO: Choose a more reasonable value
-    constexpr double TOL = 1e-9;
-    for (ptrdiff_t j = 0; j < m; ++j) {
-      for (ptrdiff_t i = 0; i < n; ++i) {
-        EXPECT_COMPLEX_NEAR(gs(i,j), C(i,j), TOL)
-          << "Matrices differ at index ("
-          << i << "," << j << ")\n";
-      }
-    }
+  TEST(BLAS3_hemm, right_upper_tri_upd)
+  {
+    test_hermitian_matrix_product<false, decltype(upper_triangle), true>();
   }
 } // end anonymous namespace

--- a/tests/native/symm.cpp
+++ b/tests/native/symm.cpp
@@ -17,7 +17,8 @@ namespace {
     EXPECT_NEAR(a.real(), b.real(), tol); \
     EXPECT_NEAR(a.imag(), b.imag(), tol)
 
-  TEST(BLAS3_symm, left_lower_tri)
+  template<bool isLeft, typename Triangle, bool isUpdating>
+  void test_symmetric_matrix_product()
   {
     /* C = A * B, where A is symmetric mxm */
     using extents_t = extents<std::size_t, dynamic_extent, dynamic_extent>;
@@ -28,216 +29,143 @@ namespace {
     int m = 3, n = 2;
     std::vector<complex<double>> A_mem(m*m, snan);
     std::vector<double> B_mem(m*n);
+    std::vector<complex<double>> E_mem(m*n);
     std::vector<complex<double>> C_mem(m*n, snan);
     std::vector<complex<double>> gs_mem(m*n);
 
     cmatrix_t A(A_mem.data(), m, m);
-    dmatrix_t B(B_mem.data(), m, n);
-    cmatrix_t C(C_mem.data(), m, n);
-    cmatrix_t gs(gs_mem.data(), m, n);
+    dmatrix_t B(B_mem.data(), (isLeft)?m:n, (isLeft)?n:m);
+    cmatrix_t E(E_mem.data(), (isLeft)?m:n, (isLeft)?n:m);
+    cmatrix_t C(C_mem.data(), (isLeft)?m:n, (isLeft)?n:m);
+    cmatrix_t gs(gs_mem.data(), (isLeft)?m:n, (isLeft)?n:m);
 
     // Fill A
-    A(0,0) = -4.0 + 0.9i;
-    A(1,0) = 4.0 + 4.4i;
-    A(1,1) = 3.5 - 4.2i;
-    A(2,0) = 4.4 + 2.2i;
-    A(2,1) = -2.8 - 4.0i;
-    A(2,2) = -1.2 + 1.7i;
+    if(std::is_same_v<Triangle, decltype(lower_triangle)>) {
+      A(0,0) = -4.0 + 0.9i;
+      A(1,0) = 4.0 + 4.4i;
+      A(1,1) = 3.5 - 4.2i;
+      A(2,0) = 4.4 + 2.2i;
+      A(2,1) = -2.8 - 4.0i;
+      A(2,2) = -1.2 + 1.7i;
+    }
+    else {
+      A(0,0) = -4.0 + 0.9i;
+      A(0,1) = 4.0 + 4.4i;
+      A(1,1) = 3.5 - 4.2i;
+      A(0,2) = 4.4 + 2.2i;
+      A(1,2) = -2.8 - 4.0i;
+      A(2,2) = -1.2 + 1.7i;
+    }
 
     // Fill B
-    B(0,0) = 1.3;
-    B(0,1) = 2.5;
-    B(1,0) = -4.6;
-    B(1,1) = -3.7;
-    B(2,0) = 3.1;
-    B(2,1) = -1.5;
+    if(isLeft) {
+      B(0,0) = 1.3;
+      B(0,1) = 2.5;
+      B(1,0) = -4.6;
+      B(1,1) = -3.7;
+      B(2,0) = 3.1;
+      B(2,1) = -1.5;
+    }
+    else {
+      B(0,0) = 1.3;
+      B(1,0) = 2.5;
+      B(0,1) = -4.6;
+      B(1,1) = -3.7;
+      B(0,2) = 3.1;
+      B(1,2) = -1.5;
+    }
+
+    if(isUpdating) {
+      for (ptrdiff_t j = 0; j < (isLeft?n:m); ++j) {
+        for (ptrdiff_t i = 0; i < (isLeft?m:n); ++i) {
+          E(i,j) = B(i,j);
+        }
+      }
+    }
 
     // Fill GS
-    gs(0,0) = -9.96 - 12.25i;
-    gs(0,1) = -31.4 - 17.33i;
-    gs(1,0) = -19.58 + 12.64i;
-    gs(1,1) = 1.25 + 32.54i;
-    gs(2,0) = 14.88 + 26.53i;
-    gs(2,1) = 23.16 + 17.75i;
+    if(isLeft) {
+      gs(0,0) = E(0,0) - 9.96 - 12.25i;
+      gs(0,1) = E(0,1) - 31.4 - 17.33i;
+      gs(1,0) = E(1,0) - 19.58 + 12.64i;
+      gs(1,1) = E(1,1) + 1.25 + 32.54i;
+      gs(2,0) = E(2,0) + 14.88 + 26.53i;
+      gs(2,1) = E(2,1) + 23.16 + 17.75i;
+    }
+    else {
+      gs(0,0) = E(0,0) - 9.96 - 12.25i;
+      gs(1,0) = E(1,0) - 31.4 - 17.33i;
+      gs(0,1) = E(0,1) - 19.58 + 12.64i;
+      gs(1,1) = E(1,1) + 1.25 + 32.54i;
+      gs(0,2) = E(0,2) + 14.88 + 26.53i;
+      gs(1,2) = E(1,2) + 23.16 + 17.75i;
+    }
 
-    symmetric_matrix_product(A, lower_triangle, B, C);
+    if(isLeft) {
+      if(isUpdating) {
+        symmetric_matrix_product(A, Triangle{}, B, E, C);
+      }
+      else {
+        symmetric_matrix_product(A, Triangle{}, B, C);
+      }
+    }
+    else {
+      if(isUpdating) {
+        symmetric_matrix_product(B, A, Triangle{}, E, C);
+      }
+      else {
+        symmetric_matrix_product(B, A, Triangle{}, C);
+      }
+    }
 
     // TODO: Choose a more reasonable value
     constexpr double TOL = 1e-9;
-    for (ptrdiff_t j = 0; j < n; ++j) {
-      for (ptrdiff_t i = 0; i < m; ++i) {
+    for (ptrdiff_t j = 0; j < (isLeft?n:m); ++j) {
+      for (ptrdiff_t i = 0; i < (isLeft?m:n); ++i) {
         EXPECT_COMPLEX_NEAR(gs(i,j), C(i,j), TOL)
           << "Matrices differ at index ("
           << i << "," << j << ")\n";
       }
     }
+  }
+
+  TEST(BLAS3_symm, left_lower_tri)
+  {
+    test_symmetric_matrix_product<true, decltype(lower_triangle), false>();
   }
 
   TEST(BLAS3_symm, left_upper_tri)
   {
-    /* C = A * B, where A is symmetric mxm */
-    using extents_t = extents<std::size_t, dynamic_extent, dynamic_extent>;
-    using cmatrix_t = mdspan<complex<double>, extents_t, layout_left>;
-    using dmatrix_t = mdspan<double, extents_t, layout_left>;
-    constexpr double snan = std::numeric_limits<double>::signaling_NaN();
-
-    int m = 3, n = 2;
-    std::vector<complex<double>> A_mem(m*m, snan);
-    std::vector<double> B_mem(m*n);
-    std::vector<complex<double>> C_mem(m*n, snan);
-    std::vector<complex<double>> gs_mem(m*n);
-
-    cmatrix_t A(A_mem.data(), m, m);
-    dmatrix_t B(B_mem.data(), m, n);
-    cmatrix_t C(C_mem.data(), m, n);
-    cmatrix_t gs(gs_mem.data(), m, n);
-
-    // Fill A
-    A(0,0) = -4.0 + 0.9i;
-    A(0,1) = 4.0 + 4.4i;
-    A(1,1) = 3.5 - 4.2i;
-    A(0,2) = 4.4 + 2.2i;
-    A(1,2) = -2.8 - 4.0i;
-    A(2,2) = -1.2 + 1.7i;
-
-    // Fill B
-    B(0,0) = 1.3;
-    B(0,1) = 2.5;
-    B(1,0) = -4.6;
-    B(1,1) = -3.7;
-    B(2,0) = 3.1;
-    B(2,1) = -1.5;
-
-    // Fill GS
-    gs(0,0) = -9.96 - 12.25i;
-    gs(0,1) = -31.4 - 17.33i;
-    gs(1,0) = -19.58 + 12.64i;
-    gs(1,1) = 1.25 + 32.54i;
-    gs(2,0) = 14.88 + 26.53i;
-    gs(2,1) = 23.16 + 17.75i;
-
-    symmetric_matrix_product(A, upper_triangle, B, C);
-
-    // TODO: Choose a more reasonable value
-    constexpr double TOL = 1e-9;
-    for (ptrdiff_t j = 0; j < n; ++j) {
-      for (ptrdiff_t i = 0; i < m; ++i) {
-        EXPECT_COMPLEX_NEAR(gs(i,j), C(i,j), TOL)
-          << "Matrices differ at index ("
-          << i << "," << j << ")\n";
-      }
-    }
+    test_symmetric_matrix_product<true, decltype(upper_triangle), false>();
   }
 
   TEST(BLAS3_symm, right_lower_tri)
   {
-    /* C = B * A, where A is symmetric mxm */
-    using extents_t = extents<std::size_t, dynamic_extent, dynamic_extent>;
-    using cmatrix_t = mdspan<complex<double>, extents_t, layout_left>;
-    using dmatrix_t = mdspan<double, extents_t, layout_left>;
-    constexpr double snan = std::numeric_limits<double>::signaling_NaN();
-
-    int m = 3, n = 2;
-    std::vector<complex<double>> A_mem(m*m, snan);
-    std::vector<double> B_mem(m*n);
-    std::vector<complex<double>> C_mem(m*n, snan);
-    std::vector<complex<double>> gs_mem(m*n);
-
-    cmatrix_t A(A_mem.data(), m, m);
-    dmatrix_t B(B_mem.data(), n, m);
-    cmatrix_t C(C_mem.data(), n, m);
-    cmatrix_t gs(gs_mem.data(), n, m);
-
-    // Fill A
-    A(0,0) = -4.0 + 0.9i;
-    A(1,0) = 4.0 + 4.4i;
-    A(1,1) = 3.5 - 4.2i;
-    A(2,0) = 4.4 + 2.2i;
-    A(2,1) = -2.8 - 4.0i;
-    A(2,2) = -1.2 + 1.7i;
-
-    // Fill B
-    B(0,0) = 1.3;
-    B(1,0) = 2.5;
-    B(0,1) = -4.6;
-    B(1,1) = -3.7;
-    B(0,2) = 3.1;
-    B(1,2) = -1.5;
-
-    // Fill GS
-    gs(0,0) = -9.96 - 12.25i;
-    gs(1,0) = -31.4 - 17.33i;
-    gs(0,1) = -19.58 + 12.64i;
-    gs(1,1) = 1.25 + 32.54i;
-    gs(0,2) = 14.88 + 26.53i;
-    gs(1,2) = 23.16 + 17.75i;
-
-    symmetric_matrix_product(B, A, lower_triangle, C);
-
-    // TODO: Choose a more reasonable value
-    constexpr double TOL = 1e-9;
-    for (ptrdiff_t j = 0; j < m; ++j) {
-      for (ptrdiff_t i = 0; i < n; ++i) {
-        EXPECT_COMPLEX_NEAR(gs(i,j), C(i,j), TOL)
-          << "Matrices differ at index ("
-          << i << "," << j << ")\n";
-      }
-    }
+    test_symmetric_matrix_product<false, decltype(lower_triangle), false>();
   }
 
   TEST(BLAS3_symm, right_upper_tri)
   {
-    /* C = B * A, where A is symmetric mxm */
-    using extents_t = extents<std::size_t, dynamic_extent, dynamic_extent>;
-    using cmatrix_t = mdspan<complex<double>, extents_t, layout_left>;
-    using dmatrix_t = mdspan<double, extents_t, layout_left>;
-    constexpr double snan = std::numeric_limits<double>::signaling_NaN();
+    test_symmetric_matrix_product<false, decltype(upper_triangle), false>();
+  }
 
-    int m = 3, n = 2;
-    std::vector<complex<double>> A_mem(m*m, snan);
-    std::vector<double> B_mem(m*n);
-    std::vector<complex<double>> C_mem(m*n, snan);
-    std::vector<complex<double>> gs_mem(m*n);
+  TEST(BLAS3_symm, left_lower_tri_upd)
+  {
+    test_symmetric_matrix_product<true, decltype(lower_triangle), true>();
+  }
 
-    cmatrix_t A(A_mem.data(), m, m);
-    dmatrix_t B(B_mem.data(), n, m);
-    cmatrix_t C(C_mem.data(), n, m);
-    cmatrix_t gs(gs_mem.data(), n, m);
+  TEST(BLAS3_symm, left_upper_tri_upd)
+  {
+    test_symmetric_matrix_product<true, decltype(upper_triangle), true>();
+  }
 
-    // Fill A
-    A(0,0) = -4.0 + 0.9i;
-    A(0,1) = 4.0 + 4.4i;
-    A(1,1) = 3.5 - 4.2i;
-    A(0,2) = 4.4 + 2.2i;
-    A(1,2) = -2.8 - 4.0i;
-    A(2,2) = -1.2 + 1.7i;
+  TEST(BLAS3_symm, right_lower_tri_upd)
+  {
+    test_symmetric_matrix_product<false, decltype(lower_triangle), true>();
+  }
 
-    // Fill B
-    B(0,0) = 1.3;
-    B(1,0) = 2.5;
-    B(0,1) = -4.6;
-    B(1,1) = -3.7;
-    B(0,2) = 3.1;
-    B(1,2) = -1.5;
-
-    // Fill GS
-    gs(0,0) = -9.96 - 12.25i;
-    gs(1,0) = -31.4 - 17.33i;
-    gs(0,1) = -19.58 + 12.64i;
-    gs(1,1) = 1.25 + 32.54i;
-    gs(0,2) = 14.88 + 26.53i;
-    gs(1,2) = 23.16 + 17.75i;
-
-    symmetric_matrix_product(B, A, upper_triangle, C);
-
-    // TODO: Choose a more reasonable value
-    constexpr double TOL = 1e-9;
-    for (ptrdiff_t j = 0; j < m; ++j) {
-      for (ptrdiff_t i = 0; i < n; ++i) {
-        EXPECT_COMPLEX_NEAR(gs(i,j), C(i,j), TOL)
-          << "Matrices differ at index ("
-          << i << "," << j << ")\n";
-      }
-    }
+  TEST(BLAS3_symm, right_upper_tri_upd)
+  {
+    test_symmetric_matrix_product<false, decltype(upper_triangle), true>();
   }
 } // end anonymous namespace

--- a/tests/native/trmm.cpp
+++ b/tests/native/trmm.cpp
@@ -11,524 +11,226 @@ namespace {
   using std::cout;
   using std::endl;
 
+  template<bool isLeft, typename Triangle, typename Diagonal>
+  void test_triangular_matrix_product()
+  {
+    /* C = A * B, where A is triangular mxm */
+    using extents_t = dextents<std::size_t, 2>;
+    using matrix_t = mdspan<double, extents_t, layout_left>;
+    constexpr double snan = std::numeric_limits<double>::signaling_NaN();
+
+    int m = 3, n = 2;
+    std::vector<double> A_mem(m*m, snan);
+    std::vector<double> B_mem(m*n);
+    std::vector<double> E_mem(m*n);
+    std::vector<double> C_mem(m*n, snan);
+    std::vector<double> gs_mem(m*n);
+
+    matrix_t A(A_mem.data(), m, m);
+    matrix_t B(B_mem.data(), (isLeft)?m:n, (isLeft)?n:m);
+    matrix_t E(E_mem.data(), (isLeft)?m:n, (isLeft)?n:m);
+    matrix_t C(C_mem.data(), (isLeft)?m:n, (isLeft)?n:m);
+    matrix_t gs(gs_mem.data(), m, n);
+
+    // Fill A
+    if(std::is_same_v<Triangle, decltype(lower_triangle)>) {
+      if(std::is_same_v<Diagonal, decltype(explicit_diagonal)>) {
+        A(0,0) = 3.5;
+        A(1,1) = 1.2;
+        A(2,2) = -1.0;
+      }
+
+      A(1,0) = -2.0;
+      A(2,0) = -0.1;
+      A(2,1) = 4.5;
+    }
+    else {
+      if(std::is_same_v<Diagonal, decltype(explicit_diagonal)>) {
+        A(0,0) = 3.5;
+        A(1,1) = 1.2;
+        A(2,2) = -1.0;
+      }
+
+      A(0,1) = -2.0;
+      A(0,2) = -0.1;
+      A(1,2) = 4.5;
+    }
+
+    // Fill B
+    if(isLeft) {
+      B(0,0) = -4.4;
+      B(0,1) = 1.8;
+      B(1,0) = -1.4;
+      B(1,1) = 3.4;
+      B(2,0) = 1.8;
+      B(2,1) = 1.6;
+    }
+    else {
+      B(0,0) = -4.4;
+      B(1,0) = 1.8;
+      B(0,1) = -1.4;
+      B(1,1) = 3.4;
+      B(0,2) = 1.8;
+      B(1,2) = 1.6;
+    }
+
+    for (ptrdiff_t j = 0; j < (isLeft?n:m); ++j) {
+      for (ptrdiff_t i = 0; i < (isLeft?m:n); ++i) {
+        E(i,j) = B(i,j);
+      }
+    }
+
+    // Fill GS
+    if(std::is_same_v<Diagonal, decltype(explicit_diagonal)>) {
+        if(std::is_same_v<Triangle, decltype(lower_triangle)> == isLeft) {
+          gs(0,0) = -15.4;
+          gs(0,1) = 6.3;
+          gs(1,0) = 7.12;
+          gs(1,1) = 0.48;
+          gs(2,0) = -7.66;
+          gs(2,1) = 13.52;
+        }
+        else {
+          gs(0,0) = -12.78;
+          gs(0,1) = -0.66;
+          gs(1,0) = 6.42;
+          gs(1,1) = 11.28;
+          gs(2,0) = -1.8;
+          gs(2,1) = -1.6;
+        }
+    }
+    else {
+        if(std::is_same_v<Triangle, decltype(lower_triangle)> == isLeft) {
+          gs(0,0) = -4.4;
+          gs(0,1) = 1.8; 
+          gs(1,0) = 7.4; 
+          gs(1,1) = -0.2;
+          gs(2,0) = -4.06;
+          gs(2,1) = 16.72;
+        }
+        else {
+          gs(0,0) = -1.78;
+          gs(0,1) = -5.16;
+          gs(1,0) = 6.7;
+          gs(1,1) = 10.6;
+          gs(2,0) = 1.8;
+          gs(2,1) = 1.6;
+        }
+    }
+
+    // Check the Updating version
+    if(isLeft) {
+      triangular_matrix_product(A, Triangle{}, Diagonal{}, B, E, C);
+    }
+    else {
+      triangular_matrix_product(B, A, Triangle{}, Diagonal{}, E, C);
+    }
+
+    for (ptrdiff_t j = 0; j < (isLeft?n:m); ++j) {
+      for (ptrdiff_t i = 0; i < (isLeft?m:n); ++i) {
+        constexpr double tol = 1e-9;
+        if(isLeft) {
+          EXPECT_NEAR(gs(i,j)+E(i,j), C(i,j), tol)
+            << "Matrices differ at index ("
+            << i << "," << j << ")\n";
+        }
+        else {
+          EXPECT_NEAR(gs(j,i)+E(i,j), C(i,j), tol)
+            << "Matrices differ at index ("
+            << i << "," << j << ")\n";
+        }
+      }
+    }
+
+    // Check the non-overwriting version
+    if(isLeft) {
+      triangular_matrix_product(A, Triangle{}, Diagonal{}, B, C);
+    }
+    else {
+      triangular_matrix_product(B, A, Triangle{}, Diagonal{}, C);
+    }
+
+    for (ptrdiff_t j = 0; j < (isLeft?n:m); ++j) {
+      for (ptrdiff_t i = 0; i < (isLeft?m:n); ++i) {
+        constexpr double tol = 1e-9;
+        if(isLeft) {
+          EXPECT_NEAR(gs(i,j), C(i,j), tol)
+            << "Matrices differ at index ("
+            << i << "," << j << ")\n";
+        }
+        else {
+          EXPECT_NEAR(gs(j,i), C(i,j), tol)
+            << "Matrices differ at index ("
+            << i << "," << j << ")\n";
+        }
+      }
+    }
+
+    // Check the overwriting version
+    if(isLeft) {
+      triangular_matrix_left_product(A, Triangle{}, Diagonal{}, B);
+    }
+    else {
+      triangular_matrix_right_product(A, Triangle{}, Diagonal{}, B);
+    }
+
+    for (ptrdiff_t j = 0; j < (isLeft?n:m); ++j) {
+      for (ptrdiff_t i = 0; i < (isLeft?m:n); ++i) {
+        constexpr double tol = 1e-9;
+        if(isLeft) {
+          EXPECT_NEAR(gs(i,j), B(i,j), tol)
+            << "Matrices differ at index ("
+            << i << "," << j << ")\n";
+        }
+        else {
+          EXPECT_NEAR(gs(j,i), B(i,j), tol)
+            << "Matrices differ at index ("
+            << i << "," << j << ")\n";
+        }
+      }
+    }
+  }
+
+
   TEST(BLAS3_trmm, left_lower_tri_explicit_diag)
   {
-    /* C = A * B, where A is triangular mxm */
-    using extents_t = dextents<std::size_t, 2>;
-    using matrix_t = mdspan<double, extents_t, layout_left>;
-    constexpr double snan = std::numeric_limits<double>::signaling_NaN();
-
-    int m = 3, n = 2;
-    std::vector<double> A_mem(m*m, snan);
-    std::vector<double> B_mem(m*n);
-    std::vector<double> C_mem(m*n, snan);
-    std::vector<double> gs_mem(m*n);
-
-    matrix_t A(A_mem.data(), m, m);
-    matrix_t B(B_mem.data(), m, n);
-    matrix_t C(C_mem.data(), m, n);
-    matrix_t gs(gs_mem.data(), m, n);
-
-    // Fill A
-    A(0,0) = 3.5;
-    A(1,0) = -2.0;
-    A(1,1) = 1.2;
-    A(2,0) = -0.1;
-    A(2,1) = 4.5;
-    A(2,2) = -1.0;
-
-    // Fill B
-    B(0,0) = -4.4;
-    B(0,1) = 1.8;
-    B(1,0) = -1.4;
-    B(1,1) = 3.4;
-    B(2,0) = 1.8;
-    B(2,1) = 1.6;
-
-    // Fill GS
-    gs(0,0) = -15.4;
-    gs(0,1) = 6.3;
-    gs(1,0) = 7.12;
-    gs(1,1) = 0.48;
-    gs(2,0) = -7.66;
-    gs(2,1) = 13.52;
-
-    // Check the non-overwriting version
-    triangular_matrix_product(A, lower_triangle, explicit_diagonal, B, C);
-
-    for (ptrdiff_t j = 0; j < n; ++j) {
-      for (ptrdiff_t i = 0; i < m; ++i) {
-        EXPECT_DOUBLE_EQ(gs(i,j), C(i,j))
-          << "Matrices differ at index ("
-          << i << "," << j << ")\n";
-      }
-    }
-
-    // Check the overwriting version
-    triangular_matrix_left_product(A, lower_triangle, explicit_diagonal, B);
-
-    for (ptrdiff_t j = 0; j < n; ++j) {
-      for (ptrdiff_t i = 0; i < m; ++i) {
-        EXPECT_DOUBLE_EQ(gs(i,j), B(i,j))
-          << "Matrices differ at index ("
-          << i << "," << j << ")\n";
-      }
-    }
+    test_triangular_matrix_product<true, decltype(lower_triangle), decltype(explicit_diagonal)>();
   }
 
-TEST(BLAS3_trmm, left_lower_tri_implicit_diag)
+
+  TEST(BLAS3_trmm, left_lower_tri_implicit_diag)
   {
-    /* C = A * B, where A is triangular mxm */
-    using extents_t = dextents<std::size_t, 2>;
-    using matrix_t = mdspan<double, extents_t, layout_left>;
-    constexpr double snan = std::numeric_limits<double>::signaling_NaN();
-
-    int m = 3, n = 2;
-    std::vector<double> A_mem(m*m, snan);
-    std::vector<double> B_mem(m*n);
-    std::vector<double> C_mem(m*n, snan);
-    std::vector<double> gs_mem(m*n);
-
-    matrix_t A(A_mem.data(), m, m);
-    matrix_t B(B_mem.data(), m, n);
-    matrix_t C(C_mem.data(), m, n);
-    matrix_t gs(gs_mem.data(), m, n);
-
-    // Fill A
-    A(1,0) = -2.0;
-    A(2,0) = -0.1;
-    A(2,1) = 4.5;
-
-    // Fill B
-    B(0,0) = -4.4;
-    B(0,1) = 1.8;
-    B(1,0) = -1.4;
-    B(1,1) = 3.4;
-    B(2,0) = 1.8;
-    B(2,1) = 1.6;
-
-    triangular_matrix_product(A, lower_triangle, implicit_unit_diagonal, B, C);
-
-    // Fill GS
-    gs(0,0) = -4.4;
-    gs(0,1) = 1.8;
-    gs(1,0) = 7.4;
-    gs(1,1) = -0.2;
-    gs(2,0) = -4.06;
-    gs(2,1) = 16.72;
-
-    for (ptrdiff_t j = 0; j < n; ++j) {
-      for (ptrdiff_t i = 0; i < m; ++i) {
-        // FIXME: Choose a more reasonable value for the tolerance
-        constexpr double tol = 1e-9;
-        EXPECT_NEAR(gs(i,j), C(i,j), tol)
-          << "Matrices differ at index ("
-          << i << "," << j << ")\n";
-      }
-    }
-
-    // Check the overwriting version
-    triangular_matrix_left_product(A, lower_triangle, implicit_unit_diagonal, B);
-
-    for (ptrdiff_t j = 0; j < n; ++j) {
-      for (ptrdiff_t i = 0; i < m; ++i) {
-        // FIXME: Choose a more reasonable value for the tolerance
-        constexpr double tol = 1e-9;
-        EXPECT_NEAR(gs(i,j), B(i,j), tol)
-          << "Matrices differ at index ("
-          << i << "," << j << ")\n";
-      }
-    }
+    test_triangular_matrix_product<true, decltype(lower_triangle), decltype(implicit_unit_diagonal)>();
   }
 
-TEST(BLAS3_trmm, left_upper_tri_explicit_diag)
+  TEST(BLAS3_trmm, left_upper_tri_explicit_diag)
   {
-    /* C = A * B, where A is triangular mxm */
-    using extents_t = dextents<std::size_t, 2>;
-    using matrix_t = mdspan<double, extents_t, layout_left>;
-    constexpr double snan = std::numeric_limits<double>::signaling_NaN();
-
-    int m = 3, n = 2;
-    std::vector<double> A_mem(m*m, snan);
-    std::vector<double> B_mem(m*n);
-    std::vector<double> C_mem(m*n, snan);
-    std::vector<double> gs_mem(m*n);
-
-    matrix_t A(A_mem.data(), m, m);
-    matrix_t B(B_mem.data(), m, n);
-    matrix_t C(C_mem.data(), m, n);
-    matrix_t gs(gs_mem.data(), m, n);
-
-    // Fill A
-    A(0,0) = 3.5;
-    A(0,1) = -2.0;
-    A(1,1) = 1.2;
-    A(0,2) = -0.1;
-    A(1,2) = 4.5;
-    A(2,2) = -1.0;
-
-    // Fill B
-    B(0,0) = -4.4;
-    B(0,1) = 1.8;
-    B(1,0) = -1.4;
-    B(1,1) = 3.4;
-    B(2,0) = 1.8;
-    B(2,1) = 1.6;
-
-    // Fill GS
-    gs(0,0) = -12.78;
-    gs(0,1) = -0.66;
-    gs(1,0) = 6.42;
-    gs(1,1) = 11.28;
-    gs(2,0) = -1.8;
-    gs(2,1) = -1.6;
-
-    // Check the non-overwriting version
-    triangular_matrix_product(A, upper_triangle, explicit_diagonal, B, C);
-
-    for (ptrdiff_t j = 0; j < n; ++j) {
-      for (ptrdiff_t i = 0; i < m; ++i) {
-        EXPECT_DOUBLE_EQ(gs(i,j), C(i,j))
-          << "Matrices differ at index ("
-          << i << "," << j << ")\n";
-      }
-    }
-
-    // Check the overwriting version
-    triangular_matrix_left_product(A, upper_triangle, explicit_diagonal, B);
-
-    for (ptrdiff_t j = 0; j < n; ++j) {
-      for (ptrdiff_t i = 0; i < m; ++i) {
-        EXPECT_DOUBLE_EQ(gs(i,j), B(i,j))
-          << "Matrices differ at index ("
-          << i << "," << j << ")\n";
-      }
-    }
+    test_triangular_matrix_product<true, decltype(upper_triangle), decltype(explicit_diagonal)>();
   }
 
-TEST(BLAS3_trmm, left_upper_tri_implicit_diag)
+  TEST(BLAS3_trmm, left_upper_tri_implicit_diag)
   {
-    /* C = A * B, where A is triangular mxm */
-    using extents_t = dextents<std::size_t, 2>;
-    using matrix_t = mdspan<double, extents_t, layout_left>;
-    constexpr double snan = std::numeric_limits<double>::signaling_NaN();
-
-    int m = 3, n = 2;
-    std::vector<double> A_mem(m*m, snan);
-    std::vector<double> B_mem(m*n);
-    std::vector<double> C_mem(m*n, snan);
-    std::vector<double> gs_mem(m*n);
-
-    matrix_t A(A_mem.data(), m, m);
-    matrix_t B(B_mem.data(), m, n);
-    matrix_t C(C_mem.data(), m, n);
-    matrix_t gs(gs_mem.data(), m, n);
-
-    // Fill A
-    A(0,1) = -2.0;
-    A(0,2) = -0.1;
-    A(1,2) = 4.5;
-
-    // Fill B
-    B(0,0) = -4.4;
-    B(0,1) = 1.8;
-    B(1,0) = -1.4;
-    B(1,1) = 3.4;
-    B(2,0) = 1.8;
-    B(2,1) = 1.6;
-
-    triangular_matrix_product(A, upper_triangle, implicit_unit_diagonal, B, C);
-
-    // Fill GS
-    gs(0,0) = -1.78;
-    gs(0,1) = -5.16;
-    gs(1,0) = 6.7;
-    gs(1,1) = 10.6;
-    gs(2,0) = 1.8;
-    gs(2,1) = 1.6;
-
-    for (ptrdiff_t j = 0; j < n; ++j) {
-      for (ptrdiff_t i = 0; i < m; ++i) {
-        // FIXME: Choose a more reasonable value for the tolerance
-        constexpr double tol = 1e-9;
-        EXPECT_NEAR(gs(i,j), C(i,j), tol)
-          << "Matrices differ at index ("
-          << i << "," << j << ")\n";
-      }
-    }
-
-    // Check the overwriting version
-    triangular_matrix_left_product(A, upper_triangle, implicit_unit_diagonal, B);
-
-    for (ptrdiff_t j = 0; j < n; ++j) {
-      for (ptrdiff_t i = 0; i < m; ++i) {
-        // FIXME: Choose a more reasonable value for the tolerance
-        constexpr double tol = 1e-9;
-        EXPECT_NEAR(gs(i,j), B(i,j), tol)
-          << "Matrices differ at index ("
-          << i << "," << j << ")\n";
-      }
-    }
+    test_triangular_matrix_product<true, decltype(upper_triangle), decltype(implicit_unit_diagonal)>();
   }
 
-TEST(BLAS3_trmm, right_lower_tri_explicit_diag)
+  TEST(BLAS3_trmm, right_lower_tri_explicit_diag)
   {
-    /* C = B * A, where A is triangular mxm */
-    using extents_t = dextents<std::size_t, 2>;
-    using matrix_t = mdspan<double, extents_t, layout_left>;
-    constexpr double snan = std::numeric_limits<double>::signaling_NaN();
-
-    int m = 3, n = 2;
-    std::vector<double> A_mem(m*m, snan);
-    std::vector<double> B_mem(m*n);
-    std::vector<double> C_mem(m*n, snan);
-    std::vector<double> gs_mem(m*n);
-
-    matrix_t A(A_mem.data(), m, m);
-    matrix_t B(B_mem.data(), n, m);
-    matrix_t C(C_mem.data(), n, m);
-    matrix_t gs(gs_mem.data(), n, m);
-
-    // Fill A
-    A(0,0) = 3.5;
-    A(1,0) = -2.0;
-    A(1,1) = 1.2;
-    A(2,0) = -0.1;
-    A(2,1) = 4.5;
-    A(2,2) = -1.0;
-
-    // Fill B
-    B(0,0) = -4.4;
-    B(1,0) = 1.8;
-    B(0,1) = -1.4;
-    B(1,1) = 3.4;
-    B(0,2) = 1.8;
-    B(1,2) = 1.6;
-
-    // Fill GS
-    gs(0,0) = -12.78;
-    gs(1,0) = -0.66;
-    gs(0,1) = 6.42;
-    gs(1,1) = 11.28;
-    gs(0,2) = -1.8;
-    gs(1,2) = -1.6;
-
-    // Check the non-overwriting version
-    triangular_matrix_product(B, A, lower_triangle, explicit_diagonal, C);
-
-    for (ptrdiff_t j = 0; j < m; ++j) {
-      for (ptrdiff_t i = 0; i < n; ++i) {
-        EXPECT_DOUBLE_EQ(gs(i,j), C(i,j))
-          << "Matrices differ at index ("
-          << i << "," << j << ")\n";
-      }
-    }
-
-    // Check the overwriting version
-    triangular_matrix_right_product(A, lower_triangle, explicit_diagonal, B);
-
-    for (ptrdiff_t j = 0; j < m; ++j) {
-      for (ptrdiff_t i = 0; i < n; ++i) {
-        EXPECT_DOUBLE_EQ(gs(i,j), B(i,j))
-          << "Matrices differ at index ("
-          << i << "," << j << ")\n";
-      }
-    }
+    test_triangular_matrix_product<false, decltype(lower_triangle), decltype(explicit_diagonal)>();
   }
 
-TEST(BLAS3_trmm, right_lower_tri_implicit_diag)
+  TEST(BLAS3_trmm, right_lower_tri_implicit_diag)
   {
-    /* C = A * B, where A is triangular mxm */
-    using extents_t = dextents<std::size_t, 2>;
-    using matrix_t = mdspan<double, extents_t, layout_left>;
-    constexpr double snan = std::numeric_limits<double>::signaling_NaN();
-
-    int m = 3, n = 2;
-    std::vector<double> A_mem(m*m, snan);
-    std::vector<double> B_mem(m*n);
-    std::vector<double> C_mem(m*n, snan);
-    std::vector<double> gs_mem(m*n);
-
-    matrix_t A(A_mem.data(), m, m);
-    matrix_t B(B_mem.data(), n, m);
-    matrix_t C(C_mem.data(), n, m);
-    matrix_t gs(gs_mem.data(), n, m);
-
-    // Fill A
-    A(1,0) = -2.0;
-    A(2,0) = -0.1;
-    A(2,1) = 4.5;
-
-    // Fill B
-    B(0,0) = -4.4;
-    B(1,0) = 1.8;
-    B(0,1) = -1.4;
-    B(1,1) = 3.4;
-    B(0,2) = 1.8;
-    B(1,2) = 1.6;
-
-    triangular_matrix_product(B, A, lower_triangle, implicit_unit_diagonal, C);
-
-    // Fill GS
-    gs(0,0) = -1.78;
-    gs(1,0) = -5.16;
-    gs(0,1) = 6.7;
-    gs(1,1) = 10.6;
-    gs(0,2) = 1.8;
-    gs(1,2) = 1.6;
-
-    for (ptrdiff_t j = 0; j < m; ++j) {
-      for (ptrdiff_t i = 0; i < n; ++i) {
-        // FIXME: Choose a more reasonable value for the tolerance
-        constexpr double tol = 1e-9;
-        EXPECT_NEAR(gs(i,j), C(i,j), tol)
-          << "Matrices differ at index ("
-          << i << "," << j << ")\n";
-      }
-    }
-
-    // Check the overwriting version
-    triangular_matrix_right_product(A, lower_triangle, implicit_unit_diagonal, B);
-
-    for (ptrdiff_t j = 0; j < m; ++j) {
-      for (ptrdiff_t i = 0; i < n; ++i) {
-        // FIXME: Choose a more reasonable value for the tolerance
-        constexpr double tol = 1e-9;
-        EXPECT_NEAR(gs(i,j), B(i,j), tol)
-          << "Matrices differ at index ("
-          << i << "," << j << ")\n";
-      }
-    }
+    test_triangular_matrix_product<false, decltype(lower_triangle), decltype(implicit_unit_diagonal)>();
   }
 
-TEST(BLAS3_trmm, right_upper_tri_explicit_diag)
+  TEST(BLAS3_trmm, right_upper_tri_explicit_diag)
   {
-    /* C = B*A, where A is triangular mxm */
-    using extents_t = dextents<std::size_t, 2>;
-    using matrix_t = mdspan<double, extents_t, layout_left>;
-    constexpr double snan = std::numeric_limits<double>::signaling_NaN();
-
-    int m = 3, n = 2;
-    std::vector<double> A_mem(m*m, snan);
-    std::vector<double> B_mem(m*n);
-    std::vector<double> C_mem(m*n, snan);
-    std::vector<double> gs_mem(m*n);
-
-    matrix_t A(A_mem.data(), m, m);
-    matrix_t B(B_mem.data(), n, m);
-    matrix_t C(C_mem.data(), n, m);
-    matrix_t gs(gs_mem.data(), n, m);
-
-    // Fill A
-    A(0,0) = 3.5;
-    A(0,1) = -2.0;
-    A(1,1) = 1.2;
-    A(0,2) = -0.1;
-    A(1,2) = 4.5;
-    A(2,2) = -1.0;
-
-    // Fill B
-    B(0,0) = -4.4;
-    B(1,0) = 1.8;
-    B(0,1) = -1.4;
-    B(1,1) = 3.4;
-    B(0,2) = 1.8;
-    B(1,2) = 1.6;
-
-    // Fill GS
-    gs(0,0) = -15.4;
-    gs(1,0) = 6.3;
-    gs(0,1) = 7.12;
-    gs(1,1) = 0.48;
-    gs(0,2) = -7.66;
-    gs(1,2) = 13.52;
-
-    // Check the non-overwriting version
-    triangular_matrix_product(B, A, upper_triangle, explicit_diagonal, C);
-
-    for (ptrdiff_t j = 0; j < m; ++j) {
-      for (ptrdiff_t i = 0; i < n; ++i) {
-        EXPECT_DOUBLE_EQ(gs(i,j), C(i,j))
-          << "Matrices differ at index ("
-          << i << "," << j << ")\n";
-      }
-    }
-
-    // Check the overwriting version
-    triangular_matrix_right_product(A, upper_triangle, explicit_diagonal, B);
-
-    for (ptrdiff_t j = 0; j < m; ++j) {
-      for (ptrdiff_t i = 0; i < n; ++i) {
-        EXPECT_DOUBLE_EQ(gs(i,j), B(i,j))
-          << "Matrices differ at index ("
-          << i << "," << j << ")\n";
-      }
-    }
+    test_triangular_matrix_product<false, decltype(upper_triangle), decltype(explicit_diagonal)>();
   }
 
-TEST(BLAS3_trmm, right_upper_tri_implicit_diag)
+  TEST(BLAS3_trmm, right_upper_tri_implicit_diag)
   {
-    /* C = B * A, where A is triangular mxm */
-    using extents_t = dextents<std::size_t, 2>;
-    using matrix_t = mdspan<double, extents_t, layout_left>;
-    constexpr double snan = std::numeric_limits<double>::signaling_NaN();
-
-    int m = 3, n = 2;
-    std::vector<double> A_mem(m*m, snan);
-    std::vector<double> B_mem(m*n);
-    std::vector<double> C_mem(m*n, snan);
-    std::vector<double> gs_mem(m*n);
-
-    matrix_t A(A_mem.data(), m, m);
-    matrix_t B(B_mem.data(), n, m);
-    matrix_t C(C_mem.data(), n, m);
-    matrix_t gs(gs_mem.data(), n, m);
-
-    // Fill A
-    A(0,1) = -2.0;
-    A(0,2) = -0.1;
-    A(1,2) = 4.5;
-
-    // Fill B
-    B(0,0) = -4.4;
-    B(1,0) = 1.8;
-    B(0,1) = -1.4;
-    B(1,1) = 3.4;
-    B(0,2) = 1.8;
-    B(1,2) = 1.6;
-
-    triangular_matrix_product(B, A, upper_triangle, implicit_unit_diagonal, C);
-
-    // Fill GS
-    gs(0,0) = -4.4;
-    gs(1,0) = 1.8;
-    gs(0,1) = 7.4;
-    gs(1,1) = -0.2;
-    gs(0,2) = -4.06;
-    gs(1,2) = 16.72;
-
-    for (ptrdiff_t j = 0; j < m; ++j) {
-      for (ptrdiff_t i = 0; i < n; ++i) {
-        // FIXME: Choose a more reasonable value for the tolerance
-        constexpr double tol = 1e-9;
-        EXPECT_NEAR(gs(i,j), C(i,j), tol)
-          << "Matrices differ at index ("
-          << i << "," << j << ")\n";
-      }
-    }
-
-    // Check the overwriting version
-    triangular_matrix_right_product(A, upper_triangle, implicit_unit_diagonal, B);
-
-    for (ptrdiff_t j = 0; j < m; ++j) {
-      for (ptrdiff_t i = 0; i < n; ++i) {
-        // FIXME: Choose a more reasonable value for the tolerance
-        constexpr double tol = 1e-9;
-        EXPECT_NEAR(gs(i,j), B(i,j), tol)
-          << "Matrices differ at index ("
-          << i << "," << j << ")\n";
-      }
-    }
+    test_triangular_matrix_product<false, decltype(upper_triangle), decltype(implicit_unit_diagonal)>();
   }
 
 } // end anonymous namespace


### PR DESCRIPTION
1) added updateing versions for symmetric and hermitian matrix product
2) fixed hermitian matrix product (right version) to read only real part of diagonal
3) added tests for hermitian diagonal reading
4) added tests for updating versions

~Note: updating triangular matrix product is still missing and is not part of this PR~

5) added updating versions for triangular matrix product
6) added tests for triangular updating versions
