### PR TITLE
Disabling LINALG_HAS_EXECUTION on apple clang compiler

### DIFF
--- a/include/experimental/__p1673_bits/macros.hpp
+++ b/include/experimental/__p1673_bits/macros.hpp
@@ -49,7 +49,7 @@ static_assert(_LINALG_CPLUSPLUS >= _LINALG_CXX_STD_17, "stdBLAS requires C++17 o
 #  if defined(LINALG_ENABLE_TBB)
 #    define LINALG_HAS_EXECUTION 1
 #  endif
-#else
+#elif ! defined(__apple_build_version__)
 #  define LINALG_HAS_EXECUTION 1
 #endif
 


### PR DESCRIPTION
This could be revised later if a more modern version actually implements the feature correctly by checking the version value.