### PR TITLE
unstdify macros

### DIFF
--- a/include/experimental/__p1673_bits/blas1_givens.hpp
+++ b/include/experimental/__p1673_bits/blas1_givens.hpp
@@ -84,7 +84,7 @@ struct is_custom_apply_givens_rotation_avail<
   : std::true_type{};
 } // end anonymous namespace
 
-MDSPAN_TEMPLATE_REQUIRES( class Real, /* requires */ ( _MDSPAN_TRAIT(std::is_floating_point, Real) ) )
+MDSPAN_TEMPLATE_REQUIRES( class Real, /* requires */ ( MDSPAN_IMPL_TRAIT(std::is_floating_point, Real) ) )
 void setup_givens_rotation(const Real f,
                            const Real g,
                            Real& cs,
@@ -190,7 +190,7 @@ void setup_givens_rotation(const Real f,
 }
 
 namespace impl {
-MDSPAN_TEMPLATE_REQUIRES( class Real, /* requires */ ( _MDSPAN_TRAIT(std::is_floating_point, Real) ) )
+MDSPAN_TEMPLATE_REQUIRES( class Real, /* requires */ ( MDSPAN_IMPL_TRAIT(std::is_floating_point, Real) ) )
 Real abs1(const std::complex<Real>& ff) {
   using std::abs;
   using std::imag;
@@ -200,7 +200,7 @@ Real abs1(const std::complex<Real>& ff) {
   return max(abs(real(ff)), abs(imag(ff)));
 }
 
-MDSPAN_TEMPLATE_REQUIRES( class Real, /* requires */ ( _MDSPAN_TRAIT(std::is_floating_point, Real) ) )
+MDSPAN_TEMPLATE_REQUIRES( class Real, /* requires */ ( MDSPAN_IMPL_TRAIT(std::is_floating_point, Real) ) )
 Real abssq(const std::complex<Real>& ff) {
   using std::imag;
   using std::real;
@@ -209,7 +209,7 @@ Real abssq(const std::complex<Real>& ff) {
 }
 }
 
-MDSPAN_TEMPLATE_REQUIRES( class Real, /* requires */ ( _MDSPAN_TRAIT(std::is_floating_point, Real) ) )
+MDSPAN_TEMPLATE_REQUIRES( class Real, /* requires */ ( MDSPAN_IMPL_TRAIT(std::is_floating_point, Real) ) )
 void setup_givens_rotation(const std::complex<Real>& f,
                            const std::complex<Real>& g,
                            Real& cs,
@@ -358,7 +358,7 @@ MDSPAN_TEMPLATE_REQUIRES(
          class Layout2,
          class Accessor2,
          class Real,
-         /* requires */ (_MDSPAN_TRAIT(std::is_floating_point, Real))
+         /* requires */ (MDSPAN_IMPL_TRAIT(std::is_floating_point, Real))
 )
 void apply_givens_rotation(
   impl::inline_exec_t&& /* exec */,
@@ -393,7 +393,7 @@ MDSPAN_TEMPLATE_REQUIRES(
          class Layout2,
          class Accessor2,
          class Real,
-         /* requires */ (_MDSPAN_TRAIT(std::is_floating_point, Real))
+         /* requires */ (MDSPAN_IMPL_TRAIT(std::is_floating_point, Real))
 )
 void apply_givens_rotation(
   ExecutionPolicy&& exec,
@@ -427,7 +427,7 @@ MDSPAN_TEMPLATE_REQUIRES(
          class Layout2,
          class Accessor2,
          class Real,
-         /* requires */ (_MDSPAN_TRAIT(std::is_floating_point, Real))
+         /* requires */ (MDSPAN_IMPL_TRAIT(std::is_floating_point, Real))
 )
 void apply_givens_rotation(
   mdspan<ElementType1, extents<SizeType1, ext1>, Layout1, Accessor1> x,
@@ -453,7 +453,7 @@ MDSPAN_TEMPLATE_REQUIRES(
          class Layout2,
          class Accessor2,
          class Real,
-         /* requires */ (_MDSPAN_TRAIT(std::is_floating_point, Real))
+         /* requires */ (MDSPAN_IMPL_TRAIT(std::is_floating_point, Real))
 )
 void apply_givens_rotation(
   impl::inline_exec_t&& /* exec */,
@@ -489,7 +489,7 @@ MDSPAN_TEMPLATE_REQUIRES(
          class Layout2,
          class Accessor2,
          class Real,
-         /* requires */ (_MDSPAN_TRAIT(std::is_floating_point, Real))
+         /* requires */ (MDSPAN_IMPL_TRAIT(std::is_floating_point, Real))
 )
 void apply_givens_rotation(
   ExecutionPolicy&& exec,
@@ -522,7 +522,7 @@ MDSPAN_TEMPLATE_REQUIRES(
          class Layout2,
          class Accessor2,
          class Real,
-         /* requires */ (_MDSPAN_TRAIT(std::is_floating_point, Real))
+         /* requires */ (MDSPAN_IMPL_TRAIT(std::is_floating_point, Real))
 )
 void apply_givens_rotation(
   mdspan<ElementType1, extents<SizeType1, ext1>, Layout1, Accessor1> x,

--- a/include/experimental/__p1673_bits/layout_blas_general.hpp
+++ b/include/experimental/__p1673_bits/layout_blas_general.hpp
@@ -32,11 +32,11 @@ template <class BaseLayout, ::std::size_t StaticLDA>
 class __layout_blas_impl {
 private:
 
-  _MDSPAN_NO_UNIQUE_ADDRESS BaseLayout _base_layout;
+  MDSPAN_IMPL_NO_UNIQUE_ADDRESS BaseLayout _base_layout;
 
 public: // but not really
   using __lda_t = impl::__maybe_static_extent<StaticLDA>;
-  _MDSPAN_NO_UNIQUE_ADDRESS __lda_t __lda = { };
+  MDSPAN_IMPL_NO_UNIQUE_ADDRESS __lda_t __lda = { };
 
 private:
   using __extents_type = decltype(std::declval<BaseLayout const&>().extents());
@@ -49,8 +49,8 @@ public:
   MDSPAN_INLINE_FUNCTION_DEFAULTED constexpr __layout_blas_impl() noexcept = default;
   MDSPAN_INLINE_FUNCTION_DEFAULTED constexpr __layout_blas_impl(__layout_blas_impl const&) noexcept = default;
   MDSPAN_INLINE_FUNCTION_DEFAULTED constexpr __layout_blas_impl(__layout_blas_impl&&) noexcept = default;
-  MDSPAN_INLINE_FUNCTION_DEFAULTED _MDSPAN_CONSTEXPR_14_DEFAULTED __layout_blas_impl& operator=(__layout_blas_impl const&) noexcept = default;
-  MDSPAN_INLINE_FUNCTION_DEFAULTED _MDSPAN_CONSTEXPR_14_DEFAULTED __layout_blas_impl& operator=(__layout_blas_impl&&) noexcept = default;
+  MDSPAN_INLINE_FUNCTION_DEFAULTED MDSPAN_IMPL_CONSTEXPR_14_DEFAULTED __layout_blas_impl& operator=(__layout_blas_impl const&) noexcept = default;
+  MDSPAN_INLINE_FUNCTION_DEFAULTED MDSPAN_IMPL_CONSTEXPR_14_DEFAULTED __layout_blas_impl& operator=(__layout_blas_impl&&) noexcept = default;
   MDSPAN_INLINE_FUNCTION_DEFAULTED ~__layout_blas_impl() = default;
 
   MDSPAN_INLINE_FUNCTION
@@ -73,7 +73,7 @@ public:
   MDSPAN_TEMPLATE_REQUIRES(
     class OtherExtents, ::std::size_t OtherLDA,
     /* requires */ (
-      _MDSPAN_TRAIT(std::is_convertible, OtherExtents, __extents_type)
+      MDSPAN_IMPL_TRAIT(std::is_convertible, OtherExtents, __extents_type)
       && (
         !__layout_blas_impl<OtherExtents, OtherLDA>::__lda_t::is_static
         || !__lda_t::is_static
@@ -81,7 +81,7 @@ public:
       )
     )
   )
-  MDSPAN_INLINE_FUNCTION _MDSPAN_CONSTEXPR_14
+  MDSPAN_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14
   __layout_blas_impl(__layout_blas_impl<OtherExtents, OtherLDA> const& other) // NOLINT(google-explicit-constructor)
     : _base_layout(other.extents()),
       __lda(other.__lda)
@@ -93,7 +93,7 @@ public:
   MDSPAN_TEMPLATE_REQUIRES(
     class OtherExtents, ::std::size_t OtherLDA,
     /* requires */ (
-      _MDSPAN_TRAIT(std::is_convertible, OtherExtents, __extents_type)
+      MDSPAN_IMPL_TRAIT(std::is_convertible, OtherExtents, __extents_type)
       && (
         !__layout_blas_impl<OtherExtents, OtherLDA>::__lda_t::is_static
           || !__lda_t::is_static
@@ -101,7 +101,7 @@ public:
       )
     )
   )
-  MDSPAN_INLINE_FUNCTION _MDSPAN_CONSTEXPR_14
+  MDSPAN_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14
   __layout_blas_impl& operator=(__layout_blas_impl<OtherExtents, OtherLDA> const& other)
   {
     this->_extents = other.extents();

--- a/include/experimental/__p1673_bits/layout_tags.hpp
+++ b/include/experimental/__p1673_bits/layout_tags.hpp
@@ -28,24 +28,24 @@ namespace linalg {
 // TODO @proposal-bug make sure these can't convert from `{}`
 
 struct column_major_t { };
-_MDSPAN_INLINE_VARIABLE constexpr auto column_major = column_major_t{};
+MDSPAN_IMPL_INLINE_VARIABLE constexpr auto column_major = column_major_t{};
 struct row_major_t { };
-_MDSPAN_INLINE_VARIABLE constexpr auto row_major = row_major_t{};
+MDSPAN_IMPL_INLINE_VARIABLE constexpr auto row_major = row_major_t{};
 
 struct upper_triangle_t { };
-_MDSPAN_INLINE_VARIABLE constexpr auto upper_triangle = upper_triangle_t{};
+MDSPAN_IMPL_INLINE_VARIABLE constexpr auto upper_triangle = upper_triangle_t{};
 struct lower_triangle_t { };
-_MDSPAN_INLINE_VARIABLE constexpr auto lower_triangle = lower_triangle_t{};
+MDSPAN_IMPL_INLINE_VARIABLE constexpr auto lower_triangle = lower_triangle_t{};
 
 struct implicit_unit_diagonal_t { };
-_MDSPAN_INLINE_VARIABLE constexpr auto implicit_unit_diagonal = implicit_unit_diagonal_t{};
+MDSPAN_IMPL_INLINE_VARIABLE constexpr auto implicit_unit_diagonal = implicit_unit_diagonal_t{};
 struct explicit_diagonal_t { };
-_MDSPAN_INLINE_VARIABLE constexpr auto explicit_diagonal = explicit_diagonal_t{};
+MDSPAN_IMPL_INLINE_VARIABLE constexpr auto explicit_diagonal = explicit_diagonal_t{};
 
 struct left_side_t { };
-_MDSPAN_INLINE_VARIABLE constexpr auto left_side = left_side_t{};
+MDSPAN_IMPL_INLINE_VARIABLE constexpr auto left_side = left_side_t{};
 struct right_side_t { };
-_MDSPAN_INLINE_VARIABLE constexpr auto right_side = right_side_t{};
+MDSPAN_IMPL_INLINE_VARIABLE constexpr auto right_side = right_side_t{};
 
 } // end namespace linalg
 } // end inline namespace __p1673_version_0

--- a/include/experimental/__p1673_bits/maybe_static_size.hpp
+++ b/include/experimental/__p1673_bits/maybe_static_size.hpp
@@ -31,7 +31,7 @@ struct __maybe_static_value {
 
   MDSPAN_INLINE_FUNCTION constexpr
   __maybe_static_value(T) noexcept { }
-  MDSPAN_INLINE_FUNCTION _MDSPAN_CONSTEXPR_14
+  MDSPAN_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14
   __maybe_static_value& operator=(T) noexcept { }
 
   MDSPAN_INLINE_FUNCTION_DEFAULTED constexpr
@@ -40,9 +40,9 @@ struct __maybe_static_value {
   __maybe_static_value(__maybe_static_value const&) noexcept = default;
   MDSPAN_INLINE_FUNCTION_DEFAULTED constexpr
   __maybe_static_value(__maybe_static_value&&) noexcept = default;
-  MDSPAN_INLINE_FUNCTION_DEFAULTED _MDSPAN_CONSTEXPR_14_DEFAULTED
+  MDSPAN_INLINE_FUNCTION_DEFAULTED MDSPAN_IMPL_CONSTEXPR_14_DEFAULTED
   __maybe_static_value& operator=(__maybe_static_value const&) noexcept = default;
-  MDSPAN_INLINE_FUNCTION_DEFAULTED _MDSPAN_CONSTEXPR_14_DEFAULTED
+  MDSPAN_INLINE_FUNCTION_DEFAULTED MDSPAN_IMPL_CONSTEXPR_14_DEFAULTED
   __maybe_static_value& operator=(__maybe_static_value&&) noexcept = default;
   MDSPAN_INLINE_FUNCTION_DEFAULTED
   ~__maybe_static_value() = default;


### PR DESCRIPTION
A commit about 2 months ago to the `mdspan` repo renamed several macros from `_MDSPAN_XXXX` to `MDSPAN_IMPL_XXXX`, which causes breakage during the autodownload of that library and building the stdBLAS examples. This commit updates the stdBLAS macros to match the new names.